### PR TITLE
Upgrade to syn 0.15 and extend Display-like derivations to support custom formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Updated to `syn` v0.15
+- Extended Display-like derives to support custom formats
 
 ## 0.12.0 - 2018-09-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 
 [dependencies]
 quote = "0.6"
-syn = { version = "0.14", features = ['extra-traits'] }
+syn = { version = "0.15", features = ['extra-traits'] }
 proc-macro2 = "0.4"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 [dependencies]
 quote = "0.6"
 syn = { version = "0.15", features = ['extra-traits'] }
-proc-macro2 = "0.4"
+proc-macro2 = "0.4.19"
 
 [build-dependencies]
 rustc_version = "0.2.2"

--- a/doc/display.md
+++ b/doc/display.md
@@ -41,10 +41,6 @@ extern crate derive_more;
 
 use std::path::PathBuf;
 
-// Here just to make sure that this doesn't conflict with
-// the derives in some way
-use std::fmt::Binary;
-
 #[derive(Display)]
 struct MyInt(i32);
 

--- a/doc/display.md
+++ b/doc/display.md
@@ -36,8 +36,7 @@ E.g. `Octal` -> `octal`, `Pointer` -> `pointer`, `UpperHex` -> `upper_hex`.
 # Example usage
 
 ```rust
-#[macro_use]
-extern crate derive_more;
+# #[macro_use] extern crate derive_more;
 
 use std::path::PathBuf;
 
@@ -90,8 +89,7 @@ struct Unit;
 #[derive(Display)]
 struct UnitStruct {}
 
-#[test]
-fn check_display() {
+fn main() {
     assert_eq!(MyInt(-2).to_string(), "-2");
     assert_eq!(Point2D { x: 3, y: 4 }.to_string(), "(3, 4)");
     assert_eq!(E::Uint(2).to_string(), "2");

--- a/doc/display.md
+++ b/doc/display.md
@@ -1,5 +1,7 @@
 % What #[derive(Display)] generates
 
+**NB: These derives are fully backward-compatible with the ones from the display_derive crate.**
+
 Deriving `Display` will generate a `Display` implementation, with a `fmt`
 method that matches `self` and each of its variants. In the case of a struct or union,
 only a single variant is available, and it is thus equivalent to a simple `let` statement.
@@ -34,27 +36,42 @@ E.g. `Octal` -> `octal`, `Pointer` -> `pointer`, `UpperHex` -> `upper_hex`.
 # Example usage
 
 ```rust
-# #[macro_use] extern crate derive_more;
+#[macro_use]
+extern crate derive_more;
+
+use std::path::PathBuf;
+
+// Here just to make sure that this doesn't conflict with
+// the derives in some way
+use std::fmt::Binary;
+
 #[derive(Display)]
 struct MyInt(i32);
 
 #[derive(Display)]
 #[display(fmt = "({}, {})", x, y)]
-struct Point1D {
+struct Point2D {
     x: i32,
     y: i32,
 }
 
 #[derive(Display)]
 enum E {
-    A(u32),
+    Uint(u32),
     #[display(fmt = "I am B {:b}", i)]
-    B {
+    Binary {
         i: i8,
     },
-    #[cfg(feature = "nightly")] // this will be in stable releases soon
+    #[cfg(feature = "nightly")]
     #[display(fmt = "I am C {}", "_0.display()")]
-    C(PathBuf),
+    Path(PathBuf),
+}
+
+#[derive(Display)]
+#[display(fmt = "Java EE")]
+enum EE {
+    A,
+    B,
 }
 
 #[derive(Display)]
@@ -64,6 +81,33 @@ union U {
 }
 
 #[derive(Octal)]
-#[octal(fmt = "8")]
+#[octal(fmt = "7")]
 struct S;
+
+#[derive(UpperHex)]
+#[upper_hex(fmt = "UpperHex")]
+struct UH;
+
+#[derive(Display)]
+struct Unit;
+
+#[derive(Display)]
+struct UnitStruct {}
+
+#[test]
+fn check_display() {
+    assert_eq!(MyInt(-2).to_string(), "-2");
+    assert_eq!(Point2D { x: 3, y: 4 }.to_string(), "(3, 4)");
+    assert_eq!(E::Uint(2).to_string(), "2");
+    assert_eq!(E::Binary { i: -2 }.to_string(), "I am B 11111110");
+    #[cfg(feature = "nightly")]
+    assert_eq!(E::Path("abc".into()).to_string(), "I am C abc");
+    assert_eq!(EE::A.to_string(), "Java EE");
+    assert_eq!(EE::B.to_string(), "Java EE");
+    assert_eq!(U { i: 2 }.to_string(), "Hello there!");
+    assert_eq!(format!("{:o}", S), "7");
+    assert_eq!(format!("{:X}", UH), "UpperHex");
+    assert_eq!(Unit.to_string(), "Unit");
+    assert_eq!(UnitStruct {}.to_string(), "UnitStruct");
+}
 ```

--- a/doc/display.md
+++ b/doc/display.md
@@ -1,8 +1,35 @@
 % What #[derive(Display)] generates
 
-Deriving `Display` only works for structs with only a single field, e.g.
-newtypes. The result is that you will be able to call `format!()` and
-`println!()` with `"{}"` on your type.
+Deriving `Display` will generate a `Display` implementation, with a `fmt`
+method that matches `self` and each of its variants. In the case of a struct or union,
+only a single variant is available, and it is thus equivalent to a simple `let` statement.
+In the case of an enum, each of its variants is matched.
+
+For each matched variant, a `write!` expression will be generated with
+the supplied format, or an automatically inferred one.
+
+You specify the format on each variant by writing e.g. `#[display(fmt = "my val: {}", "some_val * 2")]`.
+For enums, you can either specify it on each variant, or on the enum as a whole.
+
+For variants that don't have a format specified, it will simply defer to the format of the
+inner variable. If there is no such variable, or there is more than 1, an error is generated.
+
+# The format of the format
+
+You supply a format by attaching an attribute of the syntax: `#[display(fmt = "...", args...)]`.
+The format supplied is passed verbatim to `write!`. The arguments supplied handled specially,
+due to constraints in the syntax of attributes. In the case of an argument being a simple
+identifier, it is passed verbatim. If an argument is a string, it is **parsed as an expression**,
+and then passed to `write!`.
+
+The variables available in the arguments is `self` and each member of the variant,
+with members of tuple structs being named with a leading underscore and their index,
+i.e. `_0`, `_1`, `_2`, etc.
+
+## Other formatting traits
+
+The syntax does not change, but the name of the attribute is the snake case version of the trait.
+E.g. `Octal` -> `octal`, `Pointer` -> `pointer`, `UpperHex` -> `upper_hex`.
 
 # Example usage
 
@@ -12,67 +39,31 @@ newtypes. The result is that you will be able to call `format!()` and
 struct MyInt(i32);
 
 #[derive(Display)]
-struct Point1D{
-    x: i32,
-}
-
-fn main() {
-    assert_eq!("5", format!("{}", MyInt(5)));
-    assert_eq!("100", format!("{}", Point1D{x: 100}));
-}
-```
-
-
-# Tuple structs
-
-When deriving `Display` for a tuple struct with one field:
-
-```rust
-# #[macro_use] extern crate derive_more;
-# fn main(){}
-#[derive(Display)]
-struct MyInt(i32);
-```
-
-Code like this will be generated:
-
-```rust
-# struct MyInt(i32);
-impl ::std::fmt::Display for MyInt {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        <i32 as ::std::fmt::Display>::fmt(&self.0, formatter)
-    }
-}
-```
-
-
-# Regular structs
-
-
-When deriving `Display` for a regular struct with one field:
-
-```rust
-# #[macro_use] extern crate derive_more;
-# fn main(){}
-#[derive(Display)]
+#[display(fmt = "({}, {})", x, y)]
 struct Point1D {
     x: i32,
+    y: i32,
 }
-```
 
-Code like this will be generated:
-
-```rust
-# struct Point1D {
-#     x: i32,
-# }
-impl ::std::fmt::Display for Point1D {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        <i32 as ::std::fmt::Display>::fmt(&self.x, formatter)
-    }
+#[derive(Display)]
+enum E {
+    A(u32),
+    #[display(fmt = "I am B {:b}", i)]
+    B {
+        i: i8,
+    },
+    #[cfg(feature = "nightly")] // this will be in stable releases soon
+    #[display(fmt = "I am C {}", "_0.display()")]
+    C(PathBuf),
 }
+
+#[derive(Display)]
+#[display(fmt = "Hello there!")]
+union U {
+    i: u32,
+}
+
+#[derive(Octal)]
+#[octal(fmt = "8")]
+struct S;
 ```
-
-# Enums
-
-Deriving `Display` is not supported for enums.

--- a/src/add_like.rs
+++ b/src/add_like.rs
@@ -1,9 +1,10 @@
-use quote::ToTokens;
 use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
 use std::iter;
 use syn::{Data, DataEnum, DeriveInput, Field, Fields, Ident, Index};
-use utils::{add_extra_type_param_bound_op_output, field_idents, named_to_vec, numbered_vars,
-            unnamed_to_vec};
+use utils::{
+    add_extra_type_param_bound_op_output, field_idents, named_to_vec, numbered_vars, unnamed_to_vec,
+};
 
 pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let trait_ident = Ident::new(trait_name, Span::call_site());
@@ -48,7 +49,11 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     )
 }
 
-fn tuple_content<T: ToTokens>(input_type: &T, fields: &[&Field], method_ident: &Ident) -> TokenStream {
+fn tuple_content<T: ToTokens>(
+    input_type: &T,
+    fields: &[&Field],
+    method_ident: &Ident,
+) -> TokenStream {
     let exprs = tuple_exprs(fields, method_ident);
     quote!(#input_type(#(#exprs),*))
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -39,6 +39,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
             fn fmt(&self, _derive_more_Display_formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 match self {
                     #arms
+                    _ => Ok(()) // This is needed for empty enums
                 }
             }
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,55 +1,213 @@
-use proc_macro2::{Span, TokenStream};
-use syn::{Data, DeriveInput, Field, Fields, Ident, Type};
-use utils::{add_extra_ty_param_bound, named_to_vec, unnamed_to_vec};
+use proc_macro2::{Ident, Span, TokenStream};
+use std::fmt::Display;
+use syn::{
+    parse::{Error, Result},
+    spanned::Spanned,
+    Attribute, Data, DeriveInput, Fields, Lit, Meta, MetaNameValue, NestedMeta,
+};
+use utils::add_extra_ty_param_bound;
 
 /// Provides the hook to expand `#[derive(Display)]` into an implementation of `From`
-pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
+pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
     let trait_ident = Ident::new(trait_name, Span::call_site());
     let trait_path = &quote!(::std::fmt::#trait_ident);
+    let trait_attr = match trait_name {
+        "Display" => "display",
+        "Binary" => "binary",
+        "Octal" => "octal",
+        "LowerHex" => "lower_hex",
+        "UpperHex" => "upper_hex",
+        "LowerExp" => "lower_exp",
+        "UpperExp" => "upper_exp",
+        "Pointer" => "pointer",
+        _ => unimplemented!(),
+    };
+
     let generics = add_extra_ty_param_bound(&input.generics, trait_path);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let input_type = &input.ident;
-    let (member, field_type) = match input.data {
-        Data::Struct(ref data_struct) => match data_struct.fields {
-            Fields::Unnamed(ref fields) => tuple_from_str(trait_name, &unnamed_to_vec(fields)),
-            Fields::Named(ref fields) => struct_from_str(trait_name, &named_to_vec(fields)),
-            Fields::Unit => panic_one_field(trait_name),
-        },
-        _ => panic_one_field(trait_name),
-    };
-    quote!{
-        impl#impl_generics #trait_path for #input_type#ty_generics #where_clause
+    let name = &input.ident;
+
+    let arms = State {
+        trait_path,
+        trait_attr,
+        input,
+    }.get_match_arms()?;
+
+    Ok(quote! {
+        impl #impl_generics #trait_path for #name #ty_generics #where_clause
         {
             #[inline]
-            fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                <#field_type as #trait_path>::fmt(&#member, formatter)
+            fn fmt(&self, _derive_more_Display_formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match self {
+                    #arms
+                }
+            }
+        }
+    })
+}
+
+struct State<'a, 'b> {
+    trait_path: &'b TokenStream,
+    trait_attr: &'static str,
+    input: &'a DeriveInput,
+}
+
+impl<'a, 'b> State<'a, 'b> {
+    fn get_proper_syntax(&self) -> impl Display {
+        format!(
+            r#"Proper syntax: #[{}(fmt = "My format", "arg1", "arg2")]"#,
+            self.trait_attr
+        )
+    }
+    fn get_matcher(&self, fields: &Fields) -> TokenStream {
+        match fields {
+            Fields::Unit => TokenStream::new(),
+            Fields::Unnamed(fields) => {
+                let fields: TokenStream = (0..fields.unnamed.len())
+                    .map(|n| {
+                        let i = Ident::new(&format!("_{}", n), Span::call_site());
+                        quote!(#i,)
+                    }).collect();
+                quote!((#fields))
+            }
+            Fields::Named(fields) => {
+                let fields: TokenStream = fields
+                    .named
+                    .iter()
+                    .map(|f| {
+                        let i = f.ident.as_ref().unwrap();
+                        quote!(#i,)
+                    }).collect();
+                quote!({#fields})
             }
         }
     }
-}
+    fn find_meta(&self, attrs: &[Attribute]) -> Result<Option<Meta>> {
+        let mut it = attrs
+            .iter()
+            .filter_map(|a| a.interpret_meta())
+            .filter(|m| m.name() == self.trait_attr);
 
-fn panic_one_field(trait_name: &str) -> ! {
-    panic!(format!(
-        "Only structs with one field can derive({})",
-        trait_name
-    ))
-}
+        let meta = it.next();
+        if it.next().is_some() {
+            Err(Error::new(meta.span(), "Too many formats given"))
+        } else {
+            Ok(meta)
+        }
+    }
+    fn get_meta_fmt(&self, meta: Meta) -> Result<TokenStream> {
+        let list = match &meta {
+            Meta::List(list) => list,
+            _ => return Err(Error::new(meta.span(), self.get_proper_syntax())),
+        };
 
-fn tuple_from_str<'a>(trait_name: &str, fields: &[&'a Field]) -> (TokenStream, &'a Type) {
-    if fields.len() != 1 {
-        panic_one_field(trait_name)
-    };
-    let field = &fields[0];
-    let field_type = &field.ty;
-    (quote!(self.0), field_type)
-}
+        let fmt = match &list.nested[0] {
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+                ident,
+                lit: Lit::Str(s),
+                ..
+            }))
+                if ident == "fmt" =>
+            {
+                s
+            }
+            _ => return Err(Error::new(list.nested[0].span(), self.get_proper_syntax())),
+        };
 
-fn struct_from_str<'a>(trait_name: &str, fields: &[&'a Field]) -> (TokenStream, &'a Type) {
-    if fields.len() != 1 {
-        panic_one_field(trait_name)
-    };
-    let field = &fields[0];
-    let field_ident = &field.ident;
-    let field_type = &field.ty;
-    (quote!(self.#field_ident), field_type)
+        let args = list
+            .nested
+            .iter()
+            .skip(1) // skip fmt = "..."
+            .try_fold(TokenStream::new(), |args, arg| {
+                let arg = match arg {
+                    NestedMeta::Literal(Lit::Str(s)) => s,
+                    NestedMeta::Meta(Meta::Word(i)) => {
+                        return Ok(quote_spanned!(list.span()=> #args #i,))
+                    }
+                    _ => return Err(Error::new(arg.span(), self.get_proper_syntax())),
+                };
+                let arg: TokenStream = match arg.parse() {
+                    Ok(arg) => arg,
+                    Err(e) => return Err(Error::new(arg.span(), e)),
+                };
+                Ok(quote_spanned!(list.span()=> #args #arg,))
+            })?;
+
+        Ok(quote_spanned!(meta.span()=> write!(_derive_more_Display_formatter, #fmt, #args)))
+    }
+    fn infer_fmt(&self, span: Span, fields: &Fields) -> Result<TokenStream> {
+        let fields = match fields {
+            Fields::Unit => {
+                return Err(Error::new(
+                    span,
+                    "Can not automatically infer format from unit type",
+                ))
+            }
+            Fields::Named(fields) => &fields.named,
+            Fields::Unnamed(fields) => &fields.unnamed,
+        };
+        if fields.len() != 1 {
+            return Err(Error::new(
+                fields.span(),
+                "Can not automatically infer format for types with more than 1 field",
+            ));
+        }
+
+        let trait_path = self.trait_path;
+        if let Some(ident) = &fields.iter().next().as_ref().unwrap().ident {
+            Ok(quote!(#trait_path::fmt(#ident, _derive_more_Display_formatter)))
+        } else {
+            Ok(quote!(#trait_path::fmt(_0, _derive_more_Display_formatter)))
+        }
+    }
+    fn get_match_arms(&self) -> Result<TokenStream> {
+        match &self.input.data {
+            Data::Enum(e) => {
+                if let Some(meta) = self.find_meta(&self.input.attrs)? {
+                    let fmt = self.get_meta_fmt(meta)?;
+                    e.variants.iter().try_for_each(|v| {
+                        if let Some(meta) = self.find_meta(&v.attrs)? {
+                            Err(Error::new(
+                                meta.span(),
+                                "Can not have a format on the variant when the whole enum has one",
+                            ))
+                        } else {
+                            Ok(())
+                        }
+                    })?;
+                    Ok(quote_spanned!(self.input.span()=> _ => #fmt,))
+                } else {
+                    e.variants.iter().try_fold(TokenStream::new(), |arms, v| {
+                        let matcher = self.get_matcher(&v.fields);
+                        let fmt = if let Some(meta) = self.find_meta(&v.attrs)? {
+	                        self.get_meta_fmt(meta)?
+                        } else {
+	                        self.infer_fmt(v.span(), &v.fields)?
+                        };
+                        let name = &self.input.ident;
+                        let v_name = &v.ident;
+                        Ok(quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => #fmt,))
+                    })
+                }
+            }
+            Data::Struct(s) => {
+                let matcher = self.get_matcher(&s.fields);
+                let fmt = if let Some(meta) = self.find_meta(&self.input.attrs)? {
+                    self.get_meta_fmt(meta)?
+                } else {
+                    self.infer_fmt(self.input.span(), &s.fields)?
+                };
+                let name = &self.input.ident;
+                Ok(quote_spanned!(self.input.span()=> #name #matcher => #fmt,))
+            }
+            Data::Union(_) => {
+                let meta = self.find_meta(&self.input.attrs)?.ok_or(Error::new(
+                    self.input.span(),
+                    "Can not automatically infer format for unions",
+                ))?;
+                let fmt = self.get_meta_fmt(meta)?;
+                Ok(quote_spanned!(self.input.span()=> _ => #fmt,))
+            }
+        }
+    }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,7 +5,6 @@ use syn::{
     spanned::Spanned,
     Attribute, Data, DeriveInput, Fields, Lit, Meta, MetaNameValue, NestedMeta,
 };
-use utils::add_extra_ty_param_bound;
 
 /// Provides the hook to expand `#[derive(Display)]` into an implementation of `From`
 pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
@@ -23,8 +22,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
         _ => unimplemented!(),
     };
 
-    let generics = add_extra_ty_param_bound(&input.generics, trait_path);
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let name = &input.ident;
 
     let arms = State {

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::ops::Index;
 
-use quote::ToTokens;
 use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::{Data, DataEnum, DeriveInput, Field, Fields};
 use utils::{field_idents, get_field_types, named_to_vec, number_idents, unnamed_to_vec};
 

--- a/src/into.rs
+++ b/src/into.rs
@@ -1,5 +1,5 @@
-use quote::ToTokens;
 use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::{Data, DeriveInput, Field, Fields};
 use utils::{field_idents, get_field_types, named_to_vec, number_idents, unnamed_to_vec};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,10 @@ mod mul_like;
 mod not_like;
 mod try_into;
 
+// This trait describes the possible return types of
+// the derives. A derive can generally be infallible and
+// return a TokenStream, or it can be fallible and return
+// a Result<TokenStream, syn::parse::Error>.
 trait Output {
     fn process(self) -> TokenStream;
 }

--- a/src/mul_like.rs
+++ b/src/mul_like.rs
@@ -1,10 +1,12 @@
-use quote::ToTokens;
 use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
 use std::collections::HashSet;
 use std::iter;
 use syn::{Data, DeriveInput, Field, Fields, Ident};
-use utils::{add_where_clauses_for_new_ident, field_idents, get_field_types_iter, named_to_vec,
-            number_idents, unnamed_to_vec};
+use utils::{
+    add_where_clauses_for_new_ident, field_idents, get_field_types_iter, named_to_vec,
+    number_idents, unnamed_to_vec,
+};
 
 pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let trait_ident = Ident::new(trait_name, Span::call_site());

--- a/src/not_like.rs
+++ b/src/not_like.rs
@@ -1,5 +1,5 @@
-use quote::ToTokens;
 use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
 use std::iter;
 use syn::{Data, DataEnum, DeriveInput, Field, Fields, Ident, Index};
 use utils::{add_extra_type_param_bound_op_output, named_to_vec, unnamed_to_vec};
@@ -43,7 +43,11 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     )
 }
 
-fn tuple_content<T: ToTokens>(input_type: &T, fields: &[&Field], method_ident: &Ident) -> TokenStream {
+fn tuple_content<T: ToTokens>(
+    input_type: &T,
+    fields: &[&Field],
+    method_ident: &Ident,
+) -> TokenStream {
     let mut exprs = vec![];
 
     for i in 0..fields.len() {
@@ -91,7 +95,9 @@ fn enum_output_type_and_content(
                 // The patern that is outputted should look like this:
                 // (Subtype(vars)) => Ok(TypePath(exprs))
                 let size = unnamed_to_vec(fields).len();
-                let vars: &Vec<_> = &(0..size).map(|i| Ident::new(&format!("__{}", i), Span::call_site())).collect();
+                let vars: &Vec<_> = &(0..size)
+                    .map(|i| Ident::new(&format!("__{}", i), Span::call_site()))
+                    .collect();
                 let method_iter = method_iter.by_ref();
                 let mut body = quote!(#subtype(#(#vars.#method_iter()),*));
                 if has_unit_type {
@@ -115,7 +121,9 @@ fn enum_output_type_and_content(
                     .iter()
                     .map(|f| f.ident.as_ref().unwrap())
                     .collect();
-                let vars: &Vec<_> = &(0..size).map(|i| Ident::new(&format!("__{}", i), Span::call_site())).collect();
+                let vars: &Vec<_> = &(0..size)
+                    .map(|i| Ident::new(&format!("__{}", i), Span::call_site()))
+                    .collect();
                 let method_iter = method_iter.by_ref();
                 let mut body = quote!(#subtype{#(#field_names: #vars.#method_iter()),*});
                 if has_unit_type {

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -1,5 +1,5 @@
-use quote::ToTokens;
 use proc_macro2::TokenStream;
+use quote::ToTokens;
 use std::collections::HashMap;
 use syn::{Data, DataEnum, DeriveInput, Fields};
 use utils::{field_idents, named_to_vec, numbered_vars, unnamed_to_vec};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,8 @@
 use proc_macro2::{Span, TokenStream};
-use syn::{parse_str, Field, FieldsNamed, FieldsUnnamed, GenericParam, Generics, Ident, Index,
-          Type, TypeParamBound, WhereClause};
+use syn::{
+    parse_str, Field, FieldsNamed, FieldsUnnamed, GenericParam,
+    Generics, Ident, Index, Type, TypeParamBound, WhereClause,
+};
 
 pub fn numbered_vars(count: usize, prefix: &str) -> Vec<Ident> {
     (0..count)
@@ -19,8 +21,7 @@ pub fn field_idents<'a>(fields: &'a [&'a Field]) -> Vec<&'a Ident> {
             f.ident
                 .as_ref()
                 .expect("Tried to get field names of a tuple struct")
-        })
-        .collect()
+        }).collect()
 }
 
 pub fn get_field_types_iter<'a>(fields: &'a [&'a Field]) -> Box<Iterator<Item = &'a Type> + 'a> {

--- a/tests/boats_display_derive.rs
+++ b/tests/boats_display_derive.rs
@@ -1,0 +1,57 @@
+// The following code is from https://github.com/withoutboats/display_derive/blob/232a32ee19e262aacbd2c93be5b4ce9e89a5fc30/tests/tests.rs
+// Written by without boats originally
+
+#[macro_use]
+extern crate derive_more;
+
+#[derive(Display)]
+#[display(fmt = "An error has occurred.")]
+struct UnitError;
+
+#[test]
+fn unit_struct() {
+    let s = format!("{}", UnitError);
+    assert_eq!(&s[..], "An error has occurred.");
+}
+
+#[derive(Display)]
+#[display(fmt = "Error code: {}", code)]
+struct RecordError {
+    code: u32,
+}
+
+#[test]
+fn record_struct() {
+    let s = format!("{}", RecordError { code: 0 });
+    assert_eq!(&s[..], "Error code: 0");
+}
+
+#[derive(Display)]
+#[display(fmt = "Error code: {}", _0)]
+struct TupleError(i32);
+
+#[test]
+fn tuple_struct() {
+    let s = format!("{}", TupleError(2));
+    assert_eq!(&s[..], "Error code: 2");
+}
+
+#[derive(Display)]
+enum EnumError {
+    #[display(fmt = "Error code: {}", code)]
+    StructVariant { code: i32 },
+    #[display(fmt = "Error: {}", _0)]
+    TupleVariant(&'static str),
+    #[display(fmt = "An error has occurred.")]
+    UnitVariant,
+}
+
+#[test]
+fn enum_error() {
+    let s = format!("{}", EnumError::StructVariant { code: 2 });
+    assert_eq!(&s[..], "Error code: 2");
+    let s = format!("{}", EnumError::TupleVariant("foobar"));
+    assert_eq!(&s[..], "Error: foobar");
+    let s = format!("{}", EnumError::UnitVariant);
+    assert_eq!(&s[..], "An error has occurred.");
+}

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -60,6 +60,10 @@ struct UnitStruct {}
 #[derive(Display)]
 enum EmptyEnum {}
 
+#[derive(Display)]
+#[display(fmt = "Generic")]
+struct Generic<T>(T);
+
 #[test]
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
@@ -75,4 +79,5 @@ fn check_display() {
     assert_eq!(format!("{:X}", UH), "UpperHex");
     assert_eq!(Unit.to_string(), "Unit");
     assert_eq!(UnitStruct {}.to_string(), "UnitStruct");
+    assert_eq!(Generic(()).to_string(), "Generic");
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -4,6 +4,10 @@ extern crate derive_more;
 
 use std::path::PathBuf;
 
+// Here just to make sure that this doesn't conflict with
+// the derives in some way
+use std::fmt::Binary;
+
 #[derive(Display)]
 struct MyInt(i32);
 
@@ -16,14 +20,14 @@ struct Point2D {
 
 #[derive(Display)]
 enum E {
-    A(u32),
+    Uint(u32),
     #[display(fmt = "I am B {:b}", i)]
-    B {
+    Binary {
         i: i8,
     },
     #[cfg(feature = "nightly")]
     #[display(fmt = "I am C {}", "_0.display()")]
-    C(PathBuf),
+    Path(PathBuf),
 }
 
 #[derive(Display)]
@@ -40,24 +44,35 @@ union U {
 }
 
 #[derive(Octal)]
-#[octal(fmt = "8")]
+#[octal(fmt = "7")]
 struct S;
 
 #[derive(UpperHex)]
 #[upper_hex(fmt = "UpperHex")]
 struct UH;
 
+#[derive(Display)]
+struct Unit;
+
+#[derive(Display)]
+struct UnitStruct {}
+
+#[derive(Display)]
+enum EmptyEnum {}
+
 #[test]
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
     assert_eq!(Point2D { x: 3, y: 4 }.to_string(), "(3, 4)");
-    assert_eq!(E::A(2).to_string(), "2");
-    assert_eq!(E::B { i: -2 }.to_string(), "I am B 11111110");
+    assert_eq!(E::Uint(2).to_string(), "2");
+    assert_eq!(E::Binary { i: -2 }.to_string(), "I am B 11111110");
     #[cfg(feature = "nightly")]
-    assert_eq!(E::C("abc".into()).to_string(), "I am C abc");
+    assert_eq!(E::Path("abc".into()).to_string(), "I am C abc");
     assert_eq!(EE::A.to_string(), "Java EE");
     assert_eq!(EE::B.to_string(), "Java EE");
     assert_eq!(U { i: 2 }.to_string(), "Hello there!");
-    assert_eq!(format!("{:o}", S), "8");
+    assert_eq!(format!("{:o}", S), "7");
     assert_eq!(format!("{:X}", UH), "UpperHex");
+    assert_eq!(Unit.to_string(), "Unit");
+    assert_eq!(UnitStruct {}.to_string(), "UnitStruct");
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,12 +1,63 @@
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code, unused_imports, unused_variables)]
 #[macro_use]
 extern crate derive_more;
-use std::fmt::Binary; // brought in scope to be sure that we don't get compile errors
+
+use std::path::PathBuf;
 
 #[derive(Display)]
 struct MyInt(i32);
 
 #[derive(Display)]
-struct Point1D {
+#[display(fmt = "({}, {})", x, y)]
+struct Point2D {
     x: i32,
+    y: i32,
+}
+
+#[derive(Display)]
+enum E {
+    A(u32),
+    #[display(fmt = "I am B {:b}", i)]
+    B {
+        i: i8,
+    },
+    #[cfg(feature = "nightly")]
+    #[display(fmt = "I am C {}", "_0.display()")]
+    C(PathBuf),
+}
+
+#[derive(Display)]
+#[display(fmt = "Java EE")]
+enum EE {
+    A,
+    B,
+}
+
+#[derive(Display)]
+#[display(fmt = "Hello there!")]
+union U {
+    i: u32,
+}
+
+#[derive(Octal)]
+#[octal(fmt = "8")]
+struct S;
+
+#[derive(UpperHex)]
+#[upper_hex(fmt = "UpperHex")]
+struct UH;
+
+#[test]
+fn check_display() {
+    assert_eq!(MyInt(-2).to_string(), "-2");
+    assert_eq!(Point2D { x: 3, y: 4 }.to_string(), "(3, 4)");
+    assert_eq!(E::A(2).to_string(), "2");
+    assert_eq!(E::B { i: -2 }.to_string(), "I am B 11111110");
+    #[cfg(feature = "nightly")]
+    assert_eq!(E::C("abc".into()).to_string(), "I am C abc");
+    assert_eq!(EE::A.to_string(), "Java EE");
+    assert_eq!(EE::B.to_string(), "Java EE");
+    assert_eq!(U { i: 2 }.to_string(), "Hello there!");
+    assert_eq!(format!("{:o}", S), "8");
+    assert_eq!(format!("{:X}", UH), "UpperHex");
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -2,6 +2,8 @@
 #[macro_use]
 extern crate derive_more;
 
+use std::fmt::Display;
+
 #[derive(
     From,
     FromStr,
@@ -14,7 +16,7 @@ extern crate derive_more;
     AddAssign,
     Constructor
 )]
-struct Wrapped<T: Clone>(T);
+struct Wrapped<T: Clone + Display>(T);
 
 #[derive(From, Not, Add, Mul, AddAssign, Constructor)]
 struct WrappedDouble<T: Clone, U: Clone>(T, U);
@@ -31,7 +33,7 @@ struct WrappedDouble<T: Clone, U: Clone>(T, U);
     AddAssign,
     Constructor
 )]
-struct Struct<T: Clone> {
+struct Struct<T: Clone + Display> {
     t: T,
 }
 

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -2,13 +2,35 @@
 #[macro_use]
 extern crate derive_more;
 
-#[derive(From, FromStr, Display, Index, Not, Add, Mul, IndexMut, AddAssign, Constructor)]
+#[derive(
+    From,
+    FromStr,
+    Display,
+    Index,
+    Not,
+    Add,
+    Mul,
+    IndexMut,
+    AddAssign,
+    Constructor
+)]
 struct Wrapped<T: Clone>(T);
 
 #[derive(From, Not, Add, Mul, AddAssign, Constructor)]
 struct WrappedDouble<T: Clone, U: Clone>(T, U);
 
-#[derive(From, FromStr, Display, Index, Not, Add, Mul, IndexMut, AddAssign, Constructor)]
+#[derive(
+    From,
+    FromStr,
+    Display,
+    Index,
+    Not,
+    Add,
+    Mul,
+    IndexMut,
+    AddAssign,
+    Constructor
+)]
 struct Struct<T: Clone> {
     t: T,
 }


### PR DESCRIPTION
Allows stuff like the following:
```rust
#[derive(Display)]
enum E {
    #[display(fmt = "A({:o})", "_0")]
    A(u32),
    #[display(fmt = "B {i: {:b})", "i + 29")]
    B {i: i32},
}
```

The only issue is that you have to wrap arguments in strings, even though they are expressions. This is a limitation with the rust syntax, but I find this better than what `failure` does (only allows identifiers) since it's tedious to display paths with `failure`.

There's 2 semi-hacks in my PR:
- Errors aren't always reported with proper spans, since some times rustc loses the information somehow (see [this](https://github.com/dtolnay/syn/issues/508))
- The output of each derivation function is extended to allow `Results`, by utilizing traits. Perhaps this should not be used, and each derivation function should always return a `Result` instead?