### PR TITLE
Impl display enum

### DIFF
--- a/tests/display.rs
+++ b/tests/display.rs
@@ -10,3 +10,9 @@ struct MyInt(i32);
 struct Point1D {
     x: i32,
 }
+
+#[derive(Display)]
+enum MyEnum {
+    Foo,
+    Bar
+}


### PR DESCRIPTION
Hi,

my attempt to provide a implementation to derive `Display` for enums, shamelessly ripped off of https://github.com/ihrwein/enum-display-derive (Apache2, MIT - so no problem I guess).

Does not work, though, the test fails with:

```
error[E0405]: cannot find trait `Display` in this scope
  --> tests/display.rs:14:10
   |
14 | #[derive(Display)]
   |          ^^^^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope

```

Maybe you have an idea?