### PR TITLE
Suppress `unused_variable` warnings

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -35,6 +35,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
     Ok(quote! {
         impl #impl_generics #trait_path for #name #ty_generics #where_clause
         {
+            #[allow(unused_variables)]
             #[inline]
             fn fmt(&self, _derive_more_Display_formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 match self {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_imports, unused_variables)]
+#![allow(dead_code, unused_imports)]
 #[macro_use]
 extern crate derive_more;
 
@@ -16,6 +16,22 @@ struct MyInt(i32);
 struct Point2D {
     x: i32,
     y: i32,
+}
+
+#[derive(Display)]
+#[display(fmt = "{}", message)]
+struct Error {
+    message: &'static str,
+    backtrace: (),
+}
+
+impl Error {
+    fn new(message: &'static str) -> Self {
+        Self {
+            message,
+            backtrace: (),
+        }
+    }
 }
 
 #[derive(Display)]
@@ -70,6 +86,7 @@ fn check_display() {
     assert_eq!(format!("{:b}", MyInt(9)), "1001");
     assert_eq!(format!("{:o}", MyInt(9)), "11");
     assert_eq!(Point2D { x: 3, y: 4 }.to_string(), "(3, 4)");
+    assert_eq!(Error::new("Error").to_string(), "Error");
     assert_eq!(E::Uint(2).to_string(), "2");
     assert_eq!(E::Binary { i: -2 }.to_string(), "I am B 11111110");
     #[cfg(feature = "nightly")]


### PR DESCRIPTION
Fixes #62.

To suppress `unused_variables` warnings, there are two ways:
- Add `#[allow(unused_variables)]` to `fn`
- Add `#[automatically_derived]` to `impl`

`automatically_derived` is a built-in attribute that suppresses "unused" warnings. [It has been "ungated" since at least Rust 1.4](https://github.com/rust-lang/rust/blame/780658a464603fa755d94b27f72a375bd81d07ea/src/libsyntax/feature_gate.rs#L792). But I could not find description about `automatically_derived` except
[a Stack Overflow answer](https://stackoverflow.com/questions/51481551/what-does-automatically-derived-mean) and it does not seem to be popular. So I just added `#[allow(unused_variables)]` to `fn fmt`.
<https://github.com/search?q=language%3Arust+automatically_derived&type=Code>
<https://github.com/search?q=language%3Arust+proc_macro_derive&type=Code>
