### PR TITLE
Don't require a specific minor version of rustc_version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ syn = { version = "0.15", features = ['extra-traits'] }
 proc-macro2 = "0.4.19"
 
 [build-dependencies]
-rustc_version = "0.2.2"
+rustc_version = "0.2"
 
 [badges]
 travis-ci = { repository = "JelteF/derive_more" }


### PR DESCRIPTION
It works fine with 0.2.0, and it avoids pulling more
dependencies in https://phabricator.services.mozilla.com/D17028.