### PR TITLE
Fix unhygenic use of `Result` in `TryInto` macro

### DIFF
--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -77,7 +77,7 @@ fn enum_try_into(input: &DeriveInput, data_enum: &DataEnum) -> TokenStream {
 
                 #[allow(unused_variables)]
                 #[inline]
-                fn try_from(value: #input_type#ty_generics) -> Result<Self, Self::Error> {
+                fn try_from(value: #input_type#ty_generics) -> ::std::result::Result<Self, Self::Error> {
                     match value {
                         #(#matchers)|* => ::std::result::Result::Ok(#vars),
                         _ => ::std::result::Result::Err(#message),

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -7,6 +7,10 @@ extern crate derive_more;
 
 use std::convert::{TryFrom, TryInto};
 
+// Ensure that the TryFrom macro is hygenic and doesn't break when `Result` has
+// been redefined.
+type Result = ();
+
 #[derive(Clone, Copy, TryInto)]
 enum MixedInts {
     SmallInt(i32),


### PR DESCRIPTION
Code such as this (untested) breaks with `wrong number of type arguments: expected 1, found 2` due to the `TryInto` macro using a bare `Result`:
```
pub type Result<T> = core::result.Result<T, Error>;
#[derive(TryInto)]
pub enum Error { ... }
```
This PR fixes that problem by fully-qualifying the name.