### PR TITLE
Provide type parameter bounds for Display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,11 @@ name = "derive_more"
 proc-macro = true
 
 [dependencies]
+lazy_static = "1.3"
+proc-macro2 = "0.4"
 quote = "0.6"
-syn = { version = "0.15", features = ['extra-traits'] }
-proc-macro2 = "0.4.19"
+regex = "1"
+syn = { version = "0.15", features = ["extra-traits"] }
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,10 @@
-use std::{collections::HashSet, fmt::Display};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+};
 
 use proc_macro2::{Ident, Span, TokenStream};
+use regex::Regex;
 use syn::{
     parse::{Error, Result},
     punctuated::Pair,
@@ -31,19 +35,31 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
         .map(|t| t.ident.clone())
         .collect();
 
-    let (arms, bound_type_params) = State {
+    let (arms, bounds) = State {
         trait_path,
         trait_attr,
         input,
         type_params,
     }
-    .get_match_arms_and_bound_type_params()?;
+    .get_match_arms_and_extra_bounds()?;
 
     let mut generics = input.generics.clone();
-    if !bound_type_params.is_empty() {
-        let trait_path = vec![trait_path; bound_type_params.len()];
-        let where_clause =
-            quote_spanned!(input.span()=> where #(#bound_type_params: #trait_path),*);
+    if !bounds.is_empty() {
+        let bounds: Vec<_> = bounds
+            .into_iter()
+            .map(|(ty, trait_names)| {
+                let bounds: Vec<_> = trait_names
+                    .into_iter()
+                    .map(|trait_name| {
+                        let import_root = get_import_root();
+                        let trait_ident = Ident::new(trait_name, Span::call_site());
+                        quote!(#import_root::fmt::#trait_ident)
+                    })
+                    .collect();
+                quote!(#ty: #(#bounds)+*)
+            })
+            .collect();
+        let where_clause = quote_spanned!(input.span()=> where #(#bounds),*);
         generics = add_extra_where_clauses(&input.generics, where_clause);
     }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -179,7 +195,9 @@ impl<'a, 'b> State<'a, 'b> {
             Ok(quote!(#trait_path::fmt(_0, _derive_more_Display_formatter)))
         }
     }
-    fn get_match_arms_and_bound_type_params(&self) -> Result<(TokenStream, HashSet<Type>)> {
+    fn get_match_arms_and_extra_bounds(
+        &self,
+    ) -> Result<(TokenStream, HashMap<Type, HashSet<&'static str>>)> {
         match &self.input.data {
             Data::Enum(e) => {
                 if let Some(meta) = self.find_meta(&self.input.attrs)? {
@@ -198,32 +216,34 @@ impl<'a, 'b> State<'a, 'b> {
 
                     Ok((
                         quote_spanned!(self.input.span()=> _ => #fmt,),
-                        HashSet::new(),
+                        HashMap::new(),
                     ))
                 } else {
                     e.variants.iter().try_fold(
-                        (TokenStream::new(), HashSet::new()),
-                        |(arms, mut all_bound_type_params), v| {
+                        (TokenStream::new(), HashMap::new()),
+                        |(arms, mut all_bounds), v| {
                             let matcher = self.get_matcher(&v.fields);
                             let name = &self.input.ident;
                             let v_name = &v.ident;
                             let fmt: TokenStream;
-                            let mut bound_type_params = HashSet::new();
+                            let mut bounds = HashMap::new();
 
                             if let Some(meta) = self.find_meta(&v.attrs)? {
                                 fmt = self.get_meta_fmt(&meta)?;
-                                if !self.type_params.is_empty() {
-                                    bound_type_params = self.find_used_type_params_in_meta(&v.fields, &meta);
-                                }
+                                bounds = self.get_used_type_params_bounds(&v.fields, &meta);
                             } else {
                                 fmt = self.infer_fmt(&v.fields, v_name)?;
-                                // TODO: bound_type_params?
+                                // TODO: bounds?
                             };
-                            all_bound_type_params.extend(bound_type_params);
+                            all_bounds = bounds.into_iter()
+                                .fold(all_bounds, |mut bounds, (ty, trait_names)| {
+                                    bounds.entry(ty).or_insert_with(HashSet::new).extend(trait_names);
+                                    bounds
+                                });
 
                             Ok((
                                 quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => #fmt,),
-                                all_bound_type_params,
+                                all_bounds,
                             ))
                         },
                     )
@@ -233,21 +253,19 @@ impl<'a, 'b> State<'a, 'b> {
                 let matcher = self.get_matcher(&s.fields);
                 let name = &self.input.ident;
                 let fmt: TokenStream;
-                let mut bound_type_params = HashSet::new();
+                let mut bounds = HashMap::new();
 
                 if let Some(meta) = self.find_meta(&self.input.attrs)? {
                     fmt = self.get_meta_fmt(&meta)?;
-                    if !self.type_params.is_empty() {
-                        bound_type_params = self.find_used_type_params_in_meta(&s.fields, &meta);
-                    }
+                    bounds = self.get_used_type_params_bounds(&s.fields, &meta);
                 } else {
                     fmt = self.infer_fmt(&s.fields, name)?;
-                    // TODO: bound_type_params?
+                    // TODO: bounds?
                 }
 
                 Ok((
                     quote_spanned!(self.input.span()=> #name #matcher => #fmt,),
-                    bound_type_params,
+                    bounds,
                 ))
             }
             Data::Union(_) => {
@@ -261,21 +279,53 @@ impl<'a, 'b> State<'a, 'b> {
 
                 Ok((
                     quote_spanned!(self.input.span()=> _ => #fmt,),
-                    HashSet::new(),
+                    HashMap::new(),
                 ))
             }
         }
     }
-    fn find_used_type_params_in_meta(&self, fields: &Fields, meta: &Meta) -> HashSet<Type> {
-        if let Fields::Unit = fields {
-            return HashSet::new();
+    fn get_used_type_params_bounds(
+        &self,
+        fields: &Fields,
+        meta: &Meta,
+    ) -> HashMap<Type, HashSet<&'static str>> {
+        if self.type_params.is_empty() {
+            return HashMap::new();
+        }
+
+        let fields_type_params: HashMap<_, _> = fields
+            .iter()
+            .enumerate()
+            .filter_map(|(i, field)| {
+                if let Type::Path(ref ty) = field.ty {
+                    if let Some(t) = match ty.path.segments.first() {
+                        // TODO: test Punctuated variant
+                        Some(Pair::Punctuated(ref t, _)) => Some(t),
+                        Some(Pair::End(ref t)) => Some(t),
+                        _ => None,
+                    } {
+                        if self.type_params.contains(&t.ident) {
+                            let ident = field.ident.clone().unwrap_or_else(|| {
+                                Ident::new(&format!("_{}", i), Span::call_site())
+                            });
+                            return Some((ident, field.ty.clone()));
+                        }
+                    }
+                }
+                None
+            })
+            .collect();
+        if fields_type_params.is_empty() {
+            return HashMap::new();
         }
 
         let list = match meta {
             Meta::List(list) => list,
-            _ => return HashSet::new(),
+            // This one has been checked already in get_meta_fmt() method.
+            _ => unreachable!(),
         };
-        let used_args: HashSet<Ident> = list
+        // TODO: correctly work with non-trivial args usages like "_0.display()"
+        let fmt_args: Vec<Ident> = list
             .nested
             .iter()
             .skip(1) // skip fmt = "..."
@@ -284,47 +334,230 @@ impl<'a, 'b> State<'a, 'b> {
                     Some(Ident::new(&s.value(), Span::call_site()))
                 }
                 NestedMeta::Meta(Meta::Word(ref i)) => Some(i.clone()),
-                _ => None,
+                // This one has been checked already in get_meta_fmt() method.
+                _ => unreachable!(),
             })
             .collect();
-        // TODO: filter used_args by real use in the fmt string (trait dependent)
-        if used_args.is_empty() {
-            return HashSet::new();
+        if fmt_args.is_empty() {
+            return HashMap::new();
         }
-
-        // TODO: correctly work with non-trivial args usages like "_0.display()"
-        let used_fields: HashSet<&syn::Field> = match fields {
-            Fields::Unnamed(fields) => (0..fields.unnamed.len())
-                .filter(|n| {
-                    let i = Ident::new(&format!("_{}", n), Span::call_site());
-                    used_args.contains(&i)
-                })
-                .map(|n| &fields.unnamed[n])
-                .collect(),
-            Fields::Named(fields) => fields
-                .named
-                .iter()
-                .filter(|f| f.ident.is_some() && used_args.contains(f.ident.as_ref().unwrap()))
-                .collect(),
+        let fmt_string = match &list.nested[0] {
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+                ident,
+                lit: Lit::Str(s),
+                ..
+            })) if ident == "fmt" => s.value(),
+            // This one has been checked already in get_meta_fmt() method.
             _ => unreachable!(),
         };
-        used_fields
-            .into_iter()
-            .filter_map(|f| {
-                if let Type::Path(ref ty) = f.ty {
-                    if let Some(t) = match ty.path.segments.first() {
-                        // TODO: test Punctuated variant
-                        Some(Pair::Punctuated(ref t, _)) => Some(t),
-                        Some(Pair::End(ref t)) => Some(t),
-                        _ => None,
-                    } {
-                        if self.type_params.contains(&t.ident) {
-                            return Some(f.ty.clone());
-                        }
-                    }
+
+        Placeholder::parse_fmt_string(&fmt_string).into_iter().fold(
+            HashMap::new(),
+            |mut bounds, pl| {
+                let arg = &fmt_args[pl.position];
+                if fields_type_params.contains_key(arg) {
+                    bounds
+                        .entry(fields_type_params[arg].clone())
+                        .or_insert_with(HashSet::new)
+                        .insert(pl.trait_name);
                 }
-                None
+                bounds
+            },
+        )
+    }
+}
+
+lazy_static! {
+    /// Regular expression for parsing formatting placeholders from a string.
+    ///
+    /// Reproduces `maybe-format` expression of [formatting syntax][1].
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+    static ref MAYBE_PLACEHOLDER: Regex = Regex::new(
+        r"(\{\{|}}|(?P<placeholder>\{[^{}]*}))",
+    ).unwrap();
+
+    /// Regular expression for parsing inner type of formatting placeholder.
+    ///
+    /// Reproduces `format` expression of [formatting syntax][1], but is simplified
+    /// in the following way (as we need to parse `type` only):
+    /// - `argument` is replaced just with `\d+` (instead of [`identifier`][2]);
+    /// - `character` is allowed to be any symbol.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+    /// [2]: https://doc.rust-lang.org/reference/identifiers.html#identifiers
+    static ref PLACEHOLDER_FORMAT: Regex = Regex::new(
+        r"^\{(?P<arg>\d+)?(:(.?[<^>])?[+-]?#?0?(\w+\$|\d+)?(\.(\w+\$|\d+|\*))?(?P<type>([oxXpbeE?]|[xX]\?)?)?)?}$",
+    ).unwrap();
+}
+
+/// Representation of formatting placeholder.
+#[derive(Debug, PartialEq)]
+struct Placeholder {
+    /// Position of formatting argument to be used for this placeholder.
+    position: usize,
+    /// Name of [`std::fmt`] trait to be used for rendering this placeholder.
+    trait_name: &'static str,
+}
+
+impl Placeholder {
+    /// Parses [`Placeholder`]s from a given formatting string.
+    fn parse_fmt_string(s: &str) -> Vec<Placeholder> {
+        let mut n = 0;
+        MAYBE_PLACEHOLDER
+            .captures_iter(s)
+            .filter_map(|cap| cap.name("placeholder"))
+            .map(|m| {
+                let captured = PLACEHOLDER_FORMAT.captures(m.as_str()).unwrap();
+                let position = captured
+                    .name("arg")
+                    .map(|s| s.as_str().parse().unwrap())
+                    .unwrap_or_else(|| {
+                        // Assign "the next argument".
+                        // https://doc.rust-lang.org/stable/std/fmt/index.html#positional-parameters
+                        n += 1;
+                        n - 1
+                    });
+                let typ = captured
+                    .name("type")
+                    .map(|s| s.as_str())
+                    .unwrap_or_default();
+                let trait_name = match typ {
+                    "" => "Display",
+                    "?" | "x?" | "X?" => "Debug",
+                    "o" => "Octal",
+                    "x" => "LowerHex",
+                    "X" => "UpperHex",
+                    "p" => "Pointer",
+                    "b" => "Binary",
+                    "e" => "LowerExp",
+                    "E" => "UpperExp",
+                    _ => unreachable!(),
+                };
+                Placeholder {
+                    position,
+                    trait_name,
+                }
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod regex_maybe_placeholder_spec {
+    use super::*;
+
+    #[test]
+    fn parses_placeholders_and_omits_escaped() {
+        let fmt_string = "{}, {:?}, {{}}, {{{1:0$}}}";
+        let placeholders: Vec<_> = MAYBE_PLACEHOLDER
+            .captures_iter(&fmt_string)
+            .filter_map(|cap| cap.name("placeholder"))
+            .map(|m| m.as_str())
+            .collect();
+        assert_eq!(placeholders, vec!["{}", "{:?}", "{1:0$}"]);
+    }
+}
+
+#[cfg(test)]
+mod regex_placeholder_format_spec {
+    use super::*;
+
+    #[test]
+    fn detects_type() {
+        for (p, expected) in vec![
+            ("{}", ""),
+            ("{:?}", "?"),
+            ("{:x?}", "x?"),
+            ("{:X?}", "X?"),
+            ("{:o}", "o"),
+            ("{:x}", "x"),
+            ("{:X}", "X"),
+            ("{:p}", "p"),
+            ("{:b}", "b"),
+            ("{:e}", "e"),
+            ("{:E}", "E"),
+            ("{:.*}", ""),
+            ("{8}", ""),
+            ("{:04}", ""),
+            ("{1:0$}", ""),
+            ("{:width$}", ""),
+            ("{9:>8.*}", ""),
+            ("{2:.1$x}", "x"),
+        ] {
+            let typ = PLACEHOLDER_FORMAT
+                .captures(p)
+                .unwrap()
+                .name("type")
+                .map(|s| s.as_str())
+                .unwrap_or_default();
+            assert_eq!(typ, expected);
+        }
+    }
+
+    #[test]
+    fn detects_arg() {
+        for (p, expected) in vec![
+            ("{}", ""),
+            ("{0:?}", "0"),
+            ("{12:x?}", "12"),
+            ("{3:X?}", "3"),
+            ("{5:o}", "5"),
+            ("{6:x}", "6"),
+            ("{:X}", ""),
+            ("{8}", "8"),
+            ("{:04}", ""),
+            ("{1:0$}", "1"),
+            ("{:width$}", ""),
+            ("{9:>8.*}", "9"),
+            ("{2:.1$x}", "2"),
+        ] {
+            let arg = PLACEHOLDER_FORMAT
+                .captures(p)
+                .unwrap()
+                .name("arg")
+                .map(|s| s.as_str())
+                .unwrap_or_default();
+            assert_eq!(arg, expected);
+        }
+    }
+}
+
+#[cfg(test)]
+mod placeholder_parse_fmt_string_spec {
+    use super::*;
+
+    #[test]
+    fn indicates_position_and_trait_name_for_each_fmt_placeholder() {
+        let fmt_string = "{},{:?},{{}},{{{1:0$}}}-{2:.1$x}{0:#?}{:width$}";
+        assert_eq!(
+            Placeholder::parse_fmt_string(&fmt_string),
+            vec![
+                Placeholder {
+                    position: 0,
+                    trait_name: "Display",
+                },
+                Placeholder {
+                    position: 1,
+                    trait_name: "Debug",
+                },
+                Placeholder {
+                    position: 1,
+                    trait_name: "Display",
+                },
+                Placeholder {
+                    position: 2,
+                    trait_name: "LowerHex",
+                },
+                Placeholder {
+                    position: 0,
+                    trait_name: "Debug",
+                },
+                Placeholder {
+                    position: 2,
+                    trait_name: "Display",
+                },
+            ],
+        )
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -43,8 +43,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
     }
     .get_match_arms_and_extra_bounds()?;
 
-    let mut generics = input.generics.clone();
-    if !bounds.is_empty() {
+    let generics = if !bounds.is_empty() {
         let bounds: Vec<_> = bounds
             .into_iter()
             .map(|(ty, trait_names)| {
@@ -60,8 +59,10 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> Result<TokenStream> {
             })
             .collect();
         let where_clause = quote_spanned!(input.span()=> where #(#bounds),*);
-        generics = add_extra_where_clauses(&input.generics, where_clause);
-    }
+        add_extra_where_clauses(&input.generics, where_clause)
+    } else {
+        input.generics.clone()
+    };
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let name = &input.ident;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,10 +188,14 @@
 //! [`ShlAssign`]: https://doc.rust-lang.org/std/ops/trait.ShlAssign.html
 
 #![recursion_limit = "128"]
+
+#[macro_use]
+extern crate lazy_static;
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
+extern crate regex;
 extern crate syn;
 
 use proc_macro::TokenStream;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -113,11 +113,27 @@ mod generic {
     }
 
     #[derive(Display)]
+    struct AutoNamedGenericStruct<T> {
+        field: T,
+    }
+    #[test]
+    fn auto_named_generic_struct() {
+        assert_eq!(AutoNamedGenericStruct { field: 1 }.to_string(), "1");
+    }
+
+    #[derive(Display)]
     #[display(fmt = "Generic {}", "_0")]
     struct UnnamedGenericStruct<T>(T);
     #[test]
     fn unnamed_generic_struct() {
         assert_eq!(UnnamedGenericStruct(2).to_string(), "Generic 2");
+    }
+
+    #[derive(Display)]
+    struct AutoUnnamedGenericStruct<T>(T);
+    #[test]
+    fn auto_unnamed_generic_struct() {
+        assert_eq!(AutoUnnamedGenericStruct(2).to_string(), "2");
     }
 
     #[derive(Display)]
@@ -131,6 +147,17 @@ mod generic {
     fn generic_enum() {
         assert_eq!(GenericEnum::A::<_, u8> { field: 1 }.to_string(), "Gen::A 1");
         assert_eq!(GenericEnum::B::<u8, _>(2).to_string(), "Gen::B 2");
+    }
+
+    #[derive(Display)]
+    enum AutoGenericEnum<A, B> {
+        A { field: A },
+        B(B),
+    }
+    #[test]
+    fn auto_generic_enum() {
+        assert_eq!(AutoGenericEnum::A::<_, u8> { field: 1 }.to_string(), "1");
+        assert_eq!(AutoGenericEnum::B::<u8, _>(2).to_string(), "2");
     }
 
     #[derive(Display)]

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -100,3 +100,36 @@ fn check_display() {
     assert_eq!(UnitStruct {}.to_string(), "UnitStruct");
     assert_eq!(Generic(()).to_string(), "Generic");
 }
+
+mod generic {
+    #[derive(Display)]
+    #[display(fmt = "Generic {}", field)]
+    struct NamedGenericStruct<T> {
+        field: T,
+    }
+    #[test]
+    fn named_generic_struct() {
+        assert_eq!(NamedGenericStruct{ field: 1 }.to_string(), "Generic 1");
+    }
+
+    #[derive(Display)]
+    #[display(fmt = "Generic {}", "_0")]
+    struct UnnamedGenericStruct<T>(T);
+    #[test]
+    fn unnamed_generic_struct() {
+        assert_eq!(UnnamedGenericStruct(2).to_string(), "Generic 2");
+    }
+
+    #[derive(Display)]
+    enum GenericEnum<A, B> {
+        #[display(fmt = "Generic::A {}", field)]
+        A { field: A },
+        #[display(fmt = "Generic::B {}", "_0")]
+        B(B),
+    }
+    #[test]
+    fn generic_enum() {
+        assert_eq!(GenericEnum::A::<_, u8> { field: 1 }.to_string(), "Generic::A 1");
+        assert_eq!(GenericEnum::B::<u8, _>(2).to_string(), "Generic::B 2");
+    }
+}

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -109,7 +109,7 @@ mod generic {
     }
     #[test]
     fn named_generic_struct() {
-        assert_eq!(NamedGenericStruct{ field: 1 }.to_string(), "Generic 1");
+        assert_eq!(NamedGenericStruct { field: 1 }.to_string(), "Generic 1");
     }
 
     #[derive(Display)]
@@ -122,14 +122,35 @@ mod generic {
 
     #[derive(Display)]
     enum GenericEnum<A, B> {
-        #[display(fmt = "Generic::A {}", field)]
+        #[display(fmt = "Gen::A {}", field)]
         A { field: A },
-        #[display(fmt = "Generic::B {}", "_0")]
+        #[display(fmt = "Gen::B {}", "_0")]
         B(B),
     }
     #[test]
     fn generic_enum() {
-        assert_eq!(GenericEnum::A::<_, u8> { field: 1 }.to_string(), "Generic::A 1");
-        assert_eq!(GenericEnum::B::<u8, _>(2).to_string(), "Generic::B 2");
+        assert_eq!(GenericEnum::A::<_, u8> { field: 1 }.to_string(), "Gen::A 1");
+        assert_eq!(GenericEnum::B::<u8, _>(2).to_string(), "Gen::B 2");
+    }
+
+    #[derive(Display)]
+    #[display(fmt = "{} {} <-> {0:o} {1:#x} <-> {0:?} {1:X?}", a, b)]
+    struct MultiTraitNamedGenericStruct<A, B> {
+        a: A,
+        b: B,
+    }
+    #[test]
+    fn multi_trait_named_generic_struct() {
+        let s = MultiTraitNamedGenericStruct { a: 8u8, b: 255 };
+        assert_eq!(s.to_string(), "8 255 <-> 10 0xff <-> 8 FF");
+    }
+
+    #[derive(Display)]
+    #[display(fmt = "{} {} {{}} {0:o} {1:#x} - {0:>4?} {1:^4X?}", "_0", "_1")]
+    struct MultiTraitUnnamedGenericStruct<A, B>(A, B);
+    #[test]
+    fn multi_trait_unnamed_generic_struct() {
+        let s = MultiTraitUnnamedGenericStruct(8u8, 255);
+        assert_eq!(s.to_string(), "8 255 {} 10 0xff -    8  FF ");
     }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -180,4 +180,13 @@ mod generic {
         let s = MultiTraitUnnamedGenericStruct(8u8, 255);
         assert_eq!(s.to_string(), "8 255 {} 10 0xff -    8  FF ");
     }
+
+    #[derive(Display)]
+    #[display(fmt = "{}", "3 * 4")]
+    struct UnusedGenericStruct<T>(T);
+    #[test]
+    fn unused_generic_struct() {
+        let s = UnusedGenericStruct(());
+        assert_eq!(s.to_string(), "12");
+    }
 }


### PR DESCRIPTION
Fixes #72

## Background

See #72 for the detailed issue description and motivation.

```rust
#[derive(Display)]
#[display(fmt = "{} {} {{0:p}} {0:o} {1:#x} - {0:>4?} {1:^4X?}", "_0", "_1")]
struct MultiTraitUnnamedGenericStruct<A, B>(A, B);
```
expands to
```rust
impl<A, B> ::std::fmt::Display for MultiTraitUnnamedGenericStruct<A, B>
where
    A: ::std::fmt::Display + ::std::fmt::Debug + ::std::fmt::Octal,
    B: ::std::fmt::Display + ::std::fmt::Debug + ::std::fmt::LowerHex,
{
    // ...
}
```

## Solution

- Apply the necessary trait bounds to type parameters __only if they are used__ in formatting expression.
- Detect the correct trait bound (`Display`, `Debug`, `Octal`, etc.) basing on [formatting placeholder format](https://doc.rust-lang.org/stable/std/fmt/index.html#syntax).
- Apply the necessary trait bounds for automatically inferred implementations (when no `#[display]` attribute is provided).

## Limitations

- `union`s are not supported (are generic `union`s really used?).
- `enum` with `#[display]` attribute on itself (not on its variant) are untouched, as current deriving implementation doesn't allow using fields for this case.
- Expressions using fields (such as `"_0.as_str()"` or `"2 * field + field"`) are not supported. It turns out that without a compile-time reflection it's impossible to detect the result type of expression correctly in all cases, so we cannot know reliably whether we should apply trait bound to the type param field used in an expression or not. To avoid false positives I decided to leave this case "as is", so it works the same way the current implementation does.

## Checklist

- [x] Code formatted
- [x] Clippy is happy
- [x] Tests are added
- Documentation is not updated (nothing is changed in usage API)
- Changelog entry is not added (seems that you manage these by yourself while releasing)