### PR TITLE
[WIP] Implement proof-of-concept of an enum "affix"

### DIFF
--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -21,7 +21,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
         _ => panic!("Only structs can derive a constructor"),
     };
     let original_types = &get_field_types(&fields);
-    quote!{
+    quote! {
         #[allow(missing_docs)]
         impl#impl_generics #input_type#ty_generics #where_clause {
             #[inline]

--- a/src/deref.rs
+++ b/src/deref.rs
@@ -28,7 +28,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     // let generics = add_extra_ty_param_bound(&input.generics, trait_path);
     let casted_trait = &quote!(<#field_type as #trait_path>);
-    quote!{
+    quote! {
         impl#impl_generics #trait_path for #input_type#ty_generics #where_clause
         {
             type Target = #casted_trait::Target;

--- a/src/deref_mut.rs
+++ b/src/deref_mut.rs
@@ -28,7 +28,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     // let generics = add_extra_ty_param_bound(&input.generics, trait_path);
     let casted_trait = &quote!(<#field_type as #trait_path>);
-    quote!{
+    quote! {
         impl#impl_generics #trait_path for #input_type#ty_generics #where_clause
         {
             #[inline]

--- a/src/display.rs
+++ b/src/display.rs
@@ -168,20 +168,12 @@ impl<'a, 'b> State<'a, 'b> {
     }
     fn infer_fmt(&self, fields: &Fields, name: &Ident) -> Result<TokenStream> {
         let fields = match fields {
-            Fields::Unit => {
-                return Ok(quote!(write!(
-                    _derive_more_Display_formatter,
-                    stringify!(#name)
-                )));
-            }
+            Fields::Unit => return Ok(quote!(stringify!(#name))),
             Fields::Named(fields) => &fields.named,
             Fields::Unnamed(fields) => &fields.unnamed,
         };
         if fields.is_empty() {
-            return Ok(quote!(write!(
-                _derive_more_Display_formatter,
-                stringify!(#name)
-            )));
+            return Ok(quote!(stringify!(#name)));
         } else if fields.len() > 1 {
             return Err(Error::new(
                 fields.span(),

--- a/src/index_mut.rs
+++ b/src/index_mut.rs
@@ -25,7 +25,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
         _ => panic_one_field(trait_name),
     };
     let field_type = &field_vec[0].ty;
-    let type_where_clauses = quote!{
+    let type_where_clauses = quote! {
         where #field_type: #trait_path
     };
 
@@ -40,7 +40,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let (_, ty_generics, _) = input.generics.split_for_impl();
     // let generics = add_extra_ty_param_bound(&input.generics, trait_path);
     let casted_trait = &quote!(<#field_type as #trait_path>);
-    quote!{
+    quote! {
         impl#impl_generics #trait_path for #input_type#ty_generics #where_clause
         {
             #[inline]

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -70,7 +70,7 @@ fn enum_try_into(input: &DeriveInput, data_enum: &DataEnum) -> TokenStream {
             .join(", ");
         let message = format!("Only {} can be converted to {}", variants, output_type);
 
-        let try_from = quote!{
+        let try_from = quote! {
             impl#impl_generics ::std::convert::TryFrom<#input_type#ty_generics> for
                 (#(#original_types),*) #where_clause {
                 type Error = &'static str;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -80,6 +80,17 @@ enum EmptyEnum {}
 #[display(fmt = "Generic")]
 struct Generic<T>(T);
 
+#[derive(Display)]
+#[display(affix = "Here's a prefix for {} and a suffix")]
+enum Affix {
+    A(u32),
+    #[display(fmt = "{} -- {}", wat, stuff)]
+    B {
+        wat: String,
+        stuff: bool,
+    },
+}
+
 #[test]
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
@@ -99,6 +110,18 @@ fn check_display() {
     assert_eq!(Unit.to_string(), "Unit");
     assert_eq!(UnitStruct {}.to_string(), "UnitStruct");
     assert_eq!(Generic(()).to_string(), "Generic");
+    assert_eq!(
+        Affix::A(2).to_string(),
+        "Here's a prefix for 2 and a suffix"
+    );
+    assert_eq!(
+        Affix::B {
+            wat: "things".to_owned(),
+            stuff: false,
+        }
+        .to_string(),
+        "Here's a prefix for things -- false and a suffix"
+    );
 }
 
 mod generic {

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -3,5 +3,18 @@
 #[macro_use]
 extern crate derive_more;
 
-#[derive(AddAssign, MulAssign, Add, Mul, Not, Index, Display, FromStr, Into, From, IndexMut, Constructor)]
+#[derive(
+    AddAssign,
+    MulAssign,
+    Add,
+    Mul,
+    Not,
+    Index,
+    Display,
+    FromStr,
+    Into,
+    From,
+    IndexMut,
+    Constructor
+)]
 struct MyInts(u64);


### PR DESCRIPTION
It'd be really nice to be able to derive `Display` and use an affix (prefix and/or suffix) that comes before each inner implementation of `Display`. This allows one to write a `derive`d implementation of `Display` like so:

```rust
    // Expects a single Display item corresponding to where an inner 
    // variant's Display will be written (`{}`), otherwise errors
    #[derive(Debug, Display)]
    #[display(affix = "unable to read from /proc/stat: {}")]
    pub(crate) enum SnapshotReadError {
        Io(IoError),
        #[display(fmt = "expected CPU stat line for {}, got {:#?}", expected_cpu, line)]
        UnableToParseLine {
            expected_cpu: CpuComponent,
            line: String,
        }
    }

    #[derive(Debug, Display)]
    pub(crate) enum CpuComponent {
        #[display(fmt = "entire CPU")]
        EntireCpu,
        #[display(fmt = "CPU core {}", _0)]
        Core(usize),
    }
```

This can be particularly handy for error handling, but I'm sure there are other places this could be applied as well. :)

---

Things to do before this should be merged:

- [ ] Design feedback: Mostly, is this interesting?
- [ ] This commit probably shouldn't make things as hard to follow as it does -- how could this improve?
- [ ] I specifically chose a terrible but concise word for this which I fully expect to be bikeshedded. Alternatives might include:
    * `outer_fmt` (I like this one the best.)
    * `prefix` (but it's not just a prefix!)
    * `surround`
