### PR TITLE
Issue #48: derive `Deref` and `DerefMut` directly on any newtype structs

### DIFF
--- a/src/deref.rs
+++ b/src/deref.rs
@@ -27,14 +27,13 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let generics = add_extra_ty_param_bound(&input.generics, trait_path);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     // let generics = add_extra_ty_param_bound(&input.generics, trait_path);
-    let casted_trait = &quote!(<#field_type as #trait_path>);
     quote!{
         impl#impl_generics #trait_path for #input_type#ty_generics #where_clause
         {
-            type Target = #casted_trait::Target;
+            type Target = #field_type;
             #[inline]
             fn deref(&self) -> &Self::Target {
-                #casted_trait::deref(&#member)
+                &#member
             }
         }
     }

--- a/src/deref_mut.rs
+++ b/src/deref_mut.rs
@@ -22,18 +22,16 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
         },
         _ => panic_one_field(trait_name),
     };
-    let field_type = &field_vec[0].ty;
 
     let generics = add_extra_ty_param_bound(&input.generics, trait_path);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     // let generics = add_extra_ty_param_bound(&input.generics, trait_path);
-    let casted_trait = &quote!(<#field_type as #trait_path>);
     quote!{
         impl#impl_generics #trait_path for #input_type#ty_generics #where_clause
         {
             #[inline]
             fn deref_mut(&mut self) -> &mut Self::Target {
-                #casted_trait::deref_mut(&mut #member)
+                &mut #member
             }
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,10 +14,12 @@ extern crate derive_more;
 #[derive(Display)]
 #[derive(Octal)]
 #[derive(Binary)]
+#[derive(Deref, DerefMut)]
 struct MyInt(i32);
 
 #[derive(Eq, PartialEq, Debug)]
 #[derive(Index, IndexMut)]
+#[derive(Deref, DerefMut)]
 struct MyVec(Vec<i32>);
 
 #[derive(Eq, PartialEq, Debug)]
@@ -190,8 +192,19 @@ fn main() {
     myvec[0] = 20;
     assert_eq!(20, myvec[0]);
 
+    let mut myint = MyInt(5);
+    assert_eq!(5, *myint);
+    *myint = 7;
+    assert_eq!(MyInt(7), myint);
+
+    let mut myvec = MyVec(vec![5, 8]);
+    assert_eq!(5, myvec[0]);
+    assert_eq!(8, myvec[1]);
+    myvec.push(20);
+    assert_eq!(20, myvec[2]);
+
     let mut boxed = MyBoxedInt(Box::new(5));
-    assert_eq!(5, *boxed);
-    *boxed = 7;
+    assert_eq!(Box::new(5), *boxed);
+    **boxed = 7;
     assert_eq!(MyBoxedInt(Box::new(7)), boxed)
 }


### PR DESCRIPTION
Derive `Deref` and `DerefMut` directly on any newtype structs's single field instead of requiring inner field to implement the traits.

This is a backwards-incompatible change, though many usages will require no call-site modification.

See issue #48 for discussion.