### PR TITLE
WIP: Improve derive-Display trait bounds inference (#93)

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -511,9 +511,9 @@ impl<'a, 'b> State<'a, 'b> {
                 }
 
                 ty.path.segments.iter()
-                    .find(|segment| {
+                    .any(|segment| {
                         if let PathArguments::AngleBracketed(arguments) = &segment.arguments {
-                            arguments.args.iter().find(|argument| {
+                            arguments.args.iter().any(|argument| {
                                 match argument {
                                     GenericArgument::Type(ty) => {
                                         self.has_type_param_in_impl(ty, false)
@@ -524,12 +524,10 @@ impl<'a, 'b> State<'a, 'b> {
                                     _ => false,
                                 }
                             })
-                                .is_some()
                         } else {
                             false
                         }
                     })
-                    .is_some()
             },
 
             Type::Reference(ty) => {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -301,6 +301,28 @@ mod generic {
         }
     }
 
+    mod reference {
+        use super::*;
+
+        #[test]
+        fn auto_generic_reference() {
+            #[derive(Display)]
+            struct AutoGenericReference<'a, T>(&'a T);
+
+            let s = AutoGenericReference(&10);
+            assert_eq!(s.to_string(), "10");
+        }
+
+        #[test]
+        fn auto_generic_static_reference() {
+            #[derive(Display)]
+            struct AutoGenericStaticReference<T: 'static>(&'static T);
+
+            let s = AutoGenericStaticReference(&10);
+            assert_eq!(s.to_string(), "10");
+        }
+    }
+
     mod indirect {
         use super::*;
 
@@ -310,10 +332,10 @@ mod generic {
         #[test]
         fn auto_generic_indirect() {
             #[derive(Display)]
-            struct AutoGenericIndirectRef<T: 'static>(Struct<&'static T>);
+            struct AutoGenericIndirect<T: 'static>(Struct<&'static T>);
 
             const V: i32 = 10;
-            let s = AutoGenericIndirectRef(Struct(&V));
+            let s = AutoGenericIndirect(Struct(&V));
             assert_eq!(s.to_string(), "10");
         }
     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -217,4 +217,104 @@ mod generic {
         let s = UnusedGenericStruct(());
         assert_eq!(s.to_string(), "12");
     }
+
+    mod associated_type_field_enumerator {
+        use super::*;
+
+        trait Trait {
+            type Type;
+        }
+
+        struct Struct;
+
+        impl Trait for Struct {
+            type Type = i32;
+        }
+
+        #[test]
+        fn auto_generic_named_struct_associated() {
+            #[derive(Display)]
+            struct AutoGenericNamedStructAssociated<T: Trait> {
+                field: <T as Trait>::Type,
+            }
+
+            let s = AutoGenericNamedStructAssociated::<Struct>{ field: 10 };
+            assert_eq!(s.to_string(), "10");
+        }
+
+        #[test]
+        fn auto_generic_unnamed_struct_associated() {
+            #[derive(Display)]
+            struct AutoGenericUnnamedStructAssociated<T: Trait>(<T as Trait>::Type);
+
+            let s = AutoGenericUnnamedStructAssociated::<Struct>(10);
+            assert_eq!(s.to_string(), "10");
+        }
+
+        #[test]
+        fn auto_generic_enum_associated() {
+            #[derive(Display)]
+            enum AutoGenericEnumAssociated<T: Trait> {
+                Enumerator(<T as Trait>::Type),
+            }
+
+            let e = AutoGenericEnumAssociated::<Struct>::Enumerator(10);
+            assert_eq!(e.to_string(), "10");
+        }
+    }
+
+    mod complex_type_field_enumerator {
+        use super::*;
+
+        #[derive(Display)]
+        struct Struct<T>(T);
+
+        #[test]
+        fn auto_generic_named_struct_complex() {
+            #[derive(Display)]
+            struct AutoGenericNamedStructComplex<T> {
+                field: Struct<T>,
+            }
+
+            let s = AutoGenericNamedStructComplex { field: Struct(10) };
+            assert_eq!(s.to_string(), "10");
+        }
+
+        #[test]
+        fn auto_generic_unnamed_struct_complex() {
+            #[derive(Display)]
+            struct AutoGenericUnnamedStructComplex<T>(Struct<T>);
+
+            let s = AutoGenericUnnamedStructComplex(Struct(10));
+            assert_eq!(s.to_string(), "10");
+        }
+
+        #[test]
+        fn auto_generic_enum_complex() {
+            #[derive(Display)]
+            enum AutoGenericEnumComplex<T> {
+                Enumerator(Struct<T>),
+            }
+
+            let e = AutoGenericEnumComplex::Enumerator(Struct(10));
+            assert_eq!(e.to_string(), "10")
+        }
+    }
+
+    mod indirect {
+        use super::*;
+
+        #[derive(Display)]
+        struct Struct<T>(T);
+
+        #[test]
+        fn auto_generic_indirect() {
+            #[derive(Display)]
+            struct AutoGenericIndirectRef<T: 'static>(Struct<&'static T>);
+
+            const V: i32 = 10;
+            let s = AutoGenericIndirectRef(Struct(&V));
+            assert_eq!(s.to_string(), "10");
+        }
+    }
 }


### PR DESCRIPTION
First half of #93.

Modified `Display` macro, so that for each field of the following types _or of reference to 
such types_ a where clause is generated bounding field's type by `Display` trait:

* `T`
* `T::AssociatedType` and `<T as Trait>::AssociatedType`
* `::path::SomeOtherType<T>` and `::path::SomeOtherType<&T>`

E.g., for a structure `Foo` defined like this:

```Rust
#[derive(Display)]
struct Foo<'a, T1, T2: Trait, T3> {
    field1: T1,
    field2: <T2 as Trait>::Type,
    field3: Bar<T3>,
    field4: &'a T1,
    field5: &'a <T2 as Trait>::Type,
    field6: &'a Bar<T3>,
}
```

Following where clauses would be generated (notice, that for reference types the 
_referred_ type is bound):

* `T1: Display`
* `<T2 as Trait>::Type: Display`
* `Bar<T3>: Display`

_As far as I understand,_ as we can't define `Display` for pointers, arrays, slices and tuples, adding bounds for such types (or any generic types parametrized by such types, e.g., `SomeType<[T; 10]>`) would be wrong.