### PR TITLE
Implement display-bound attribute for derive-Display macro (#93)

### DIFF
--- a/doc/display.md
+++ b/doc/display.md
@@ -33,13 +33,12 @@ i.e. `_0`, `_1`, `_2`, etc.
 The syntax does not change, but the name of the attribute is the snake case version of the trait.
 E.g. `Octal` -> `octal`, `Pointer` -> `pointer`, `UpperHex` -> `upper_hex`.
 
-# Deriving `Display` for generic data types
+# Generic data types
 
 When deriving `Display` (or other formatting trait) for a generic struct/enum, all generic type 
 arguments used during formatting are bound by respective formatting trait.
 
-E.g., for a structure Foo defined like this:
-
+E.g., for a structure `Foo` defined like this:
 ```rust
 #[macro_use] extern crate derive_more;
 
@@ -57,22 +56,21 @@ struct Foo<'a, T1, T2: Trait, T3> {
 }
 ```
 
-Following where clauses would be generated:
-
+The following where clauses would be generated:
 * `T1: Display + Pointer`
 * `<T2 as Trait>::Type: Debug`
 * `Bar<T3>: Display`
 
-## Specifying additional trait bounds
+## Custom trait bounds
 
 Sometimes you may want to specify additional trait bounds on your generic type parameters, so that they
 could be used during formatting. This can be done with a `#[display(bound = "...")]` attribute.
 
-`#[display(bound = "...")]` accepts single string argument in a format similar to a format 
+`#[display(bound = "...")]` accepts a single string argument in a format similar to the format 
 used in angle bracket list: `T: MyTrait, U: Trait1 + Trait2`.
 
 Only type parameters defined on a struct allowed to appear in bound-string and they can only be bound
-by traits, i.e., no lifetime parameters or lifetime bounds allowed in bound-string.
+by traits, i.e. no lifetime parameters or lifetime bounds allowed in bound-string.
 
 ```rust
 #[macro_use] extern crate derive_more;

--- a/doc/display.md
+++ b/doc/display.md
@@ -41,12 +41,18 @@ arguments used during formatting are bound by respective formatting trait.
 E.g., for a structure Foo defined like this:
 
 ```rust
+#[macro_use] extern crate derive_more;
+
+trait Trait {
+    type Type;
+}
+
 #[derive(Display)]
-#[display(fmt = "{} {:?} {} {:p}", a, b, c, d)]
+#[display(fmt = "{} {} {:?} {:p}", a, b, c, d)]
 struct Foo<'a, T1, T2: Trait, T3> {
     a: T1,
     b: <T2 as Trait>::Type,
-    c: Bar<T3>,
+    c: Vec<T3>,
     d: &'a T1,
 }
 ```
@@ -62,16 +68,22 @@ Following where clauses would be generated:
 Sometimes you may want to specify additional trait bounds on your generic type parameters, so that they
 could be used during formatting. This can be done with a `#[display(bound = "...")]` attribute.
 
-`#[display(bound = "...")]` accepts single string argument in a format generally similar to a format 
+`#[display(bound = "...")]` accepts single string argument in a format similar to a format 
 used in angle bracket list: `T: MyTrait, U: Trait1 + Trait2`.
 
 Only type parameters defined on a struct allowed to appear in bound-string and they can only be bound
 by traits, i.e., no lifetime parameters or lifetime bounds allowed in bound-string.
 
 ```rust
+#[macro_use] extern crate derive_more;
+
+trait MyTrait {
+    fn my_function(&self) -> i32;
+}
+
 #[derive(Display)]
 #[display(bound = "T: MyTrait, U: ::std::fmt::Display")]
-#[display(fmt = "{} {}", "a.my_function()", "transform(b.to_string())")]
+#[display(fmt = "{} {}", "a.my_function()", "b.to_string()")]
 struct MyStruct<T, U> {
     a: T,
     b: U,
@@ -81,7 +93,7 @@ struct MyStruct<T, U> {
 # Example usage
 
 ```rust
-# #[macro_use] extern crate derive_more;
+#[macro_use] extern crate derive_more;
 
 use std::path::PathBuf;
 

--- a/doc/display.md
+++ b/doc/display.md
@@ -82,6 +82,7 @@ write `c` without double-quotes.
 
 ```rust
 # #[macro_use] extern crate derive_more;
+# use std::fmt::Display;
 # trait MyTrait { fn my_function(&self) -> i32; }
 
 #[derive(Display)]

--- a/doc/display.md
+++ b/doc/display.md
@@ -40,11 +40,8 @@ arguments used during formatting are bound by respective formatting trait.
 
 E.g., for a structure `Foo` defined like this:
 ```rust
-#[macro_use] extern crate derive_more;
-
-trait Trait {
-    type Type;
-}
+# #[macro_use] extern crate derive_more;
+# trait Trait { type Type; }
 
 #[derive(Display)]
 #[display(fmt = "{} {} {:?} {:p}", a, b, c, d)]
@@ -72,26 +69,35 @@ used in angle bracket list: `T: MyTrait, U: Trait1 + Trait2`.
 Only type parameters defined on a struct allowed to appear in bound-string and they can only be bound
 by traits, i.e. no lifetime parameters or lifetime bounds allowed in bound-string.
 
-```rust
-#[macro_use] extern crate derive_more;
+As double-quote `fmt` arguments are parsed as an arbitrary Rust expression and passed to generated
+`write!` as-is, it's impossible to meaningfully infer any kind of trait bounds for generic type parameters
+used this way. That means that you'll **have to** explicitly specify all trait bound used. Either in the
+struct/enum definition, or via `#[display(bound = "...")]` attribute.
 
-trait MyTrait {
-    fn my_function(&self) -> i32;
-}
+Note how we have to bound `U` and `V` by `Display` in the following example, as no bound is inferred.
+Not even `Display`. 
+
+Also note, that `"c"` case is just a curious example. Bound inference works as expected if you simply 
+write `c` without double-quotes.
+
+```rust
+# #[macro_use] extern crate derive_more;
+# trait MyTrait { fn my_function(&self) -> i32; }
 
 #[derive(Display)]
-#[display(bound = "T: MyTrait, U: ::std::fmt::Display")]
-#[display(fmt = "{} {}", "a.my_function()", "b.to_string()")]
-struct MyStruct<T, U> {
+#[display(bound = "T: MyTrait, U: Display, V: Display")]
+#[display(fmt = "{} {} {}", "a.my_function()", "b.to_string().len()", "c")] 
+struct MyStruct<T, U, V> {
     a: T,
     b: U,
+    c: V,
 }
 ```
 
 # Example usage
 
 ```rust
-#[macro_use] extern crate derive_more;
+# #[macro_use] extern crate derive_more;
 
 use std::path::PathBuf;
 

--- a/doc/display.md
+++ b/doc/display.md
@@ -63,17 +63,14 @@ Sometimes you may want to specify additional trait bounds on your generic type p
 could be used during formatting. This can be done with a `#[display(bound = "...")]` attribute.
 
 `#[display(bound = "...")]` accepts single string argument in a format generally similar to a format 
-used in angle bracket list: `T, U: MyTrait, V: Trait1 + Trait2`.
-
-Specifying type argument without explicitly specifying trait bounds is a shortcut to bind by formatting 
-type.
+used in angle bracket list: `T: MyTrait, U: Trait1 + Trait2`.
 
 Only type parameters defined on a struct allowed to appear in bound-string and they can only be bound
 by traits, i.e., no lifetime parameters or lifetime bounds allowed in bound-string.
 
 ```rust
 #[derive(Display)]
-#[display(bound = "T: MyTrait, U")]
+#[display(bound = "T: MyTrait, U: ::std::fmt::Display")]
 #[display(fmt = "{} {}", "a.my_function()", "transform(b.to_string())")]
 struct MyStruct<T, U> {
     a: T,

--- a/doc/display.md
+++ b/doc/display.md
@@ -33,6 +33,54 @@ i.e. `_0`, `_1`, `_2`, etc.
 The syntax does not change, but the name of the attribute is the snake case version of the trait.
 E.g. `Octal` -> `octal`, `Pointer` -> `pointer`, `UpperHex` -> `upper_hex`.
 
+# Deriving `Display` for generic data types
+
+When deriving `Display` (or other formatting trait) for a generic struct/enum, all generic type 
+arguments used during formatting are bound by respective formatting trait.
+
+E.g., for a structure Foo defined like this:
+
+```rust
+#[derive(Display)]
+#[display(fmt = "{} {:?} {} {:p}", a, b, c, d)]
+struct Foo<'a, T1, T2: Trait, T3> {
+    a: T1,
+    b: <T2 as Trait>::Type,
+    c: Bar<T3>,
+    d: &'a T1,
+}
+```
+
+Following where clauses would be generated:
+
+* `T1: Display + Pointer`
+* `<T2 as Trait>::Type: Debug`
+* `Bar<T3>: Display`
+
+## Specifying additional trait bounds
+
+Sometimes you may want to specify additional trait bounds on your generic type parameters, so that they
+could be used during formatting. This can be done with a `#[display(bound = "...")]` attribute.
+
+`#[display(bound = "...")]` accepts single string argument in a format generally similar to a format 
+used in angle bracket list: `T, U: MyTrait, V: Trait1 + Trait2`.
+
+Specifying type argument without explicitly specifying trait bounds is a shortcut to bind by formatting 
+type.
+
+Only type parameters defined on a struct allowed to appear in bound-string and they can only be bound
+by traits, i.e., no lifetime parameters or lifetime bounds allowed in bound-string.
+
+```rust
+#[derive(Display)]
+#[display(bound = "T: MyTrait, U")]
+#[display(fmt = "{} {}", "a.my_function()", "transform(b.to_string())")]
+struct MyStruct<T, U> {
+    a: T,
+    b: U,
+}
+```
+
 # Example usage
 
 ```rust

--- a/src/display.rs
+++ b/src/display.rs
@@ -495,9 +495,13 @@ impl<'a, 'b> State<'a, 'b> {
         let span = meta.span();
 
         let meta = match meta {
-            syn::Meta::List(meta) if meta.nested.len() == 1 => meta.nested,
+            syn::Meta::List(meta) => meta.nested,
             _ => return Err(Error::new(span, self.get_proper_bound_syntax())),
         };
+
+        if meta.nested.len() != 1 {
+            return Err(Error::new(span, self.get_proper_bound_syntax()));
+        }
 
         let meta = match &meta[0] {
             syn::NestedMeta::Meta(syn::Meta::NameValue(meta)) => meta,

--- a/src/display.rs
+++ b/src/display.rs
@@ -499,7 +499,7 @@ impl<'a, 'b> State<'a, 'b> {
             _ => return Err(Error::new(span, self.get_proper_bound_syntax())),
         };
 
-        if meta.nested.len() != 1 {
+        if meta.len() != 1 {
             return Err(Error::new(span, self.get_proper_bound_syntax()));
         }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -268,6 +268,8 @@ impl<'a, 'b> State<'a, 'b> {
                         } else if type_param.eq_token.is_some() || type_param.default.is_some() {
                             Err(Error::new(span.clone(), "Default type parameters aren't allowed"))
                         } else {
+                            let ident = type_param.ident.to_string();
+
                             let ty = Type::Path(TypePath { qself: None, path: type_param.ident.into() });
                             let bounds = accumulator.entry(ty).or_insert_with(|| HashSet::new());
 
@@ -285,11 +287,11 @@ impl<'a, 'b> State<'a, 'b> {
                                 }
                             })?;
 
-                            if bounds.is_empty() {
-                                bounds.insert(trait_name_to_trait_bound(attribute_name_to_trait_name(self.trait_attr)));
+                            if !bounds.is_empty() {
+                                Ok(accumulator)
+                            } else {
+                                Err(Error::new(span.clone(), format!("No bounds specified for type parameter {}", ident)))
                             }
-
-                            Ok(accumulator)
                         }
                     } else {
                         Err(Error::new(span.clone(), "Unknown generic type argument specified"))

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -339,4 +339,50 @@ mod generic {
             assert_eq!(s.to_string(), "10");
         }
     }
+
+    mod bound {
+        use super::*;
+
+        #[test]
+        fn bound_simple() {
+            #[derive(Display)]
+            #[display(bound = "T1, T2")]
+            #[display(fmt = "{} {}", _0, _1)]
+            struct Struct<T1, T2>(T1, T2);
+
+            let s = Struct(10, 20);
+            assert_eq!(s.to_string(), "10 20");
+        }
+
+        #[test]
+        fn bound_complex() {
+            trait Trait1 {
+                fn function1(&self) -> &'static str;
+            }
+
+            trait Trait2 {
+                fn function2(&self) -> &'static str;
+            }
+
+            impl Trait1 for i32 {
+                fn function1(&self) -> &'static str {
+                    "WHAT"
+                }
+            }
+
+            impl Trait2 for i32 {
+                fn function2(&self) -> &'static str {
+                    "EVER"
+                }
+            }
+
+            #[derive(Display)]
+            #[display(bound = "T1: Trait1 + Trait2, T2: Trait1 + Trait2")]
+            #[display(fmt = "{} {} {} {}", "_0.function1()", _0, "_1.function2()", _1)]
+            struct Struct<T1, T2>(T1, T2);
+
+            let s = Struct(10, 20);
+            assert_eq!(s.to_string(), "WHAT 10 EVER 20");
+        }
+    }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -346,7 +346,17 @@ mod generic {
         #[test]
         fn bound_simple() {
             #[derive(Display)]
-            #[display(bound = "T1, T2")]
+            #[display(fmt = "{} {}", _0, _1)]
+            struct Struct<T1, T2>(T1, T2);
+
+            let s = Struct(10, 20);
+            assert_eq!(s.to_string(), "10 20");
+        }
+
+        #[test]
+        fn bound_redundant() {
+            #[derive(Display)]
+            #[display(bound = "T1: ::std::fmt::Display, T2: ::std::fmt::Display")]
             #[display(fmt = "{} {}", _0, _1)]
             struct Struct<T1, T2>(T1, T2);
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -344,7 +344,7 @@ mod generic {
         use super::*;
 
         #[test]
-        fn bound_simple() {
+        fn simple() {
             #[derive(Display)]
             #[display(fmt = "{} {}", _0, _1)]
             struct Struct<T1, T2>(T1, T2);
@@ -354,7 +354,7 @@ mod generic {
         }
 
         #[test]
-        fn bound_redundant() {
+        fn redundant() {
             #[derive(Display)]
             #[display(bound = "T1: ::std::fmt::Display, T2: ::std::fmt::Display")]
             #[display(fmt = "{} {}", _0, _1)]
@@ -365,7 +365,7 @@ mod generic {
         }
 
         #[test]
-        fn bound_complex() {
+        fn complex() {
             trait Trait1 {
                 fn function1(&self) -> &'static str;
             }


### PR DESCRIPTION
Second half of #93. This PR is based on top of #95.

Implemented `[display(bound = "...")]` attribute for `Display` macro as proposed by @tyranron in #93.
