### PR TITLE
Refactor derive(Display) to properly propagate the alternate flag

### DIFF
--- a/src/deref.rs
+++ b/src/deref.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse::Result, DeriveInput};
 
-/// Provides the hook to expand `#[derive(Index)]` into an implementation of `From`
+/// Provides the hook to expand `#[derive(Deref)]` into an implementation of `Deref`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let state = State::with_field_ignore_and_forward(
         input,

--- a/src/deref_mut.rs
+++ b/src/deref_mut.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse::Result, DeriveInput};
 
-/// Provides the hook to expand `#[derive(Index)]` into an implementation of `From`
+/// Provides the hook to expand `#[derive(DerefMut)]` into an implementation of `DerefMut`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let state = State::with_field_ignore_and_forward(
         input,

--- a/src/display.rs
+++ b/src/display.rs
@@ -60,19 +60,16 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> Result<TokenStream>
             #[allow(unused_variables)]
             #[inline]
             fn fmt(&self, _derive_more_Display_formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                use core::fmt::{Display, Formatter, Result};
                 struct _derive_more_DisplayAs<F>(F)
                 where
-                    F: Fn(&mut Formatter) -> Result;
+                    F: ::core::ops::Fn(&mut ::core::fmt::Formatter) -> ::core::fmt::Result;
 
                 const _derive_more_DisplayAs_impl: () = {
-                    use core::fmt::{Display, Formatter, Result};
-
-                    impl <F> Display for _derive_more_DisplayAs<F>
+                    impl<F> ::core::fmt::Display for _derive_more_DisplayAs<F>
                     where
-                        F: Fn(&mut Formatter) -> Result
+                        F: ::core::ops::Fn(&mut ::core::fmt::Formatter) -> ::core::fmt::Result
                     {
-                        fn fmt(&self, f: &mut Formatter) -> Result {
+                        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                             (self.0)(f)
                         }
                     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -59,7 +59,7 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> Result<TokenStream>
         {
             #[allow(unused_variables)]
             #[inline]
-            fn fmt(&self, _derive_more_Display_formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn fmt(&self, _derive_more_display_formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 struct _derive_more_DisplayAs<F>(F)
                 where
                     F: ::core::ops::Fn(&mut ::core::fmt::Formatter) -> ::core::fmt::Result;
@@ -428,7 +428,7 @@ impl<'a, 'b> State<'a, 'b> {
                         })?;
 
                         Ok((
-                            quote_spanned!(self.input.span()=> _ => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
+                            quote_spanned!(self.input.span()=> _ => ::core::fmt::Display::fmt(&#fmt, _derive_more_display_formatter),),
                             HashMap::new(),
                         ))
                     }
@@ -443,7 +443,7 @@ impl<'a, 'b> State<'a, 'b> {
                             };
                             let name = &self.input.ident;
                             let v_name = &v.ident;
-                            Ok(quote_spanned!(fmt.span()=> #arms #name::#v_name #matcher => write!(_derive_more_Display_formatter, #outer_fmt, #fmt),))
+                            Ok(quote_spanned!(fmt.span()=> #arms #name::#v_name #matcher => write!(_derive_more_display_formatter, #outer_fmt, #fmt),))
                         });
                         let fmt = fmt?;
                         Ok((
@@ -473,7 +473,7 @@ impl<'a, 'b> State<'a, 'b> {
                             });
 
                         Ok((
-                            quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
+                            quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => ::core::fmt::Display::fmt(&#fmt, _derive_more_display_formatter),),
                             all_bounds,
                         ))
                     }),
@@ -494,7 +494,7 @@ impl<'a, 'b> State<'a, 'b> {
                 }
 
                 Ok((
-                    quote_spanned!(self.input.span()=> #name #matcher => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
+                    quote_spanned!(self.input.span()=> #name #matcher => ::core::fmt::Display::fmt(&#fmt, _derive_more_display_formatter),),
                     bounds,
                 ))
             }
@@ -509,7 +509,7 @@ impl<'a, 'b> State<'a, 'b> {
                 let fmt = self.parse_meta_fmt(&meta, false)?.0;
 
                 Ok((
-                    quote_spanned!(self.input.span()=> _ => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
+                    quote_spanned!(self.input.span()=> _ => ::core::fmt::Display::fmt(&#fmt, _derive_more_display_formatter),),
                     HashMap::new(),
                 ))
             }

--- a/src/display.rs
+++ b/src/display.rs
@@ -549,7 +549,7 @@ impl<'a, 'b> State<'a, 'b> {
 
                 Ok(ParseResult {
                     arms: quote_spanned!(self.input.span()=> #name #matcher => #fmt,),
-                    bounds: bounds,
+                    bounds,
                     requires_helper: false,
                 })
             }

--- a/src/display.rs
+++ b/src/display.rs
@@ -524,11 +524,9 @@ impl<'a, 'b> State<'a, 'b> {
                             fmt = self.infer_fmt(&v.fields, v_name)?;
                             these_bounds = self.infer_type_params_bounds(&v.fields);
                         };
-                        bounds = these_bounds.into_iter()
-                            .fold(bounds, |mut bounds, (ty, trait_names)| {
-                                bounds.entry(ty).or_insert_with(HashSet::new).extend(trait_names);
-                                bounds
-                            });
+                        these_bounds.into_iter().for_each(|(ty, trait_names)| {
+                            bounds.entry(ty).or_default().extend(trait_names)
+                        });
                         let arms = quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => #fmt,);
 
                         Ok(ParseResult{ arms, bounds, requires_helper })
@@ -603,13 +601,9 @@ impl<'a, 'b> State<'a, 'b> {
 
         let extra_bounds = self.parse_meta_bounds(extra_bounds)?;
 
-        for (ty, extra_bounds) in extra_bounds {
-            result
-                .bounds
-                .entry(ty)
-                .or_insert_with(HashSet::new)
-                .extend(extra_bounds);
-        }
+        extra_bounds.into_iter().for_each(|(ty, trait_names)| {
+            result.bounds.entry(ty).or_default().extend(trait_names)
+        });
 
         Ok(result)
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -414,6 +414,7 @@ impl<'a, 'b> State<'a, 'b> {
                     .find_meta(&self.input.attrs, "fmt")
                     .and_then(|m| m.map(|m| self.parse_meta_fmt(&m, true)).transpose())?
                 {
+                    // #[display(fmt = "no placeholder")] on whole enum.
                     Some((fmt, false)) => {
                         e.variants.iter().try_for_each(|v| {
                             if let Some(meta) = self.find_meta(&v.attrs, "fmt")? {
@@ -431,6 +432,7 @@ impl<'a, 'b> State<'a, 'b> {
                             HashMap::new(),
                         ))
                     }
+                    // #[display(fmt = "one placeholder: {}")] on whole enum.
                     Some((outer_fmt, true)) => {
                         let fmt: Result<TokenStream> = e.variants.iter().try_fold(TokenStream::new(), |arms, v| {
                             let matcher = self.get_matcher(&v.fields);
@@ -449,6 +451,7 @@ impl<'a, 'b> State<'a, 'b> {
                             HashMap::new(),
                         ))
                     }
+                    // No format attribute on whole enum.
                     None => e.variants.iter().try_fold((TokenStream::new(), HashMap::new()), |(arms, mut all_bounds), v| {
                         let matcher = self.get_matcher(&v.fields);
                         let name = &self.input.ident;

--- a/src/display.rs
+++ b/src/display.rs
@@ -15,7 +15,7 @@ use syn::{
     spanned::Spanned as _,
 };
 
-/// Provides the hook to expand `#[derive(Display)]` into an implementation of `From`
+/// Provides the hook to expand `#[derive(Display)]` into an implementation of `Display`
 pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> Result<TokenStream> {
     let trait_name = trait_name.trim_end_matches("Custom");
     let trait_ident = syn::Ident::new(trait_name, Span::call_site());

--- a/src/display.rs
+++ b/src/display.rs
@@ -428,7 +428,7 @@ impl<'a, 'b> State<'a, 'b> {
                         })?;
 
                         Ok((
-                            quote_spanned!(self.input.span()=> _ => write!(_derive_more_Display_formatter, "{}", #fmt),),
+                            quote_spanned!(self.input.span()=> _ => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
                             HashMap::new(),
                         ))
                     }
@@ -473,7 +473,7 @@ impl<'a, 'b> State<'a, 'b> {
                             });
 
                         Ok((
-                            quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => write!(_derive_more_Display_formatter, "{}", #fmt),),
+                            quote_spanned!(self.input.span()=> #arms #name::#v_name #matcher => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
                             all_bounds,
                         ))
                     }),
@@ -494,7 +494,7 @@ impl<'a, 'b> State<'a, 'b> {
                 }
 
                 Ok((
-                    quote_spanned!(self.input.span()=> #name #matcher => write!(_derive_more_Display_formatter, "{}", #fmt),),
+                    quote_spanned!(self.input.span()=> #name #matcher => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
                     bounds,
                 ))
             }
@@ -509,7 +509,7 @@ impl<'a, 'b> State<'a, 'b> {
                 let fmt = self.parse_meta_fmt(&meta, false)?.0;
 
                 Ok((
-                    quote_spanned!(self.input.span()=> _ => write!(_derive_more_Display_formatter, "{}", #fmt),),
+                    quote_spanned!(self.input.span()=> _ => ::core::fmt::Display::fmt(&#fmt, _derive_more_Display_formatter),),
                     HashMap::new(),
                 ))
             }

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{parse::Result, DeriveInput, Ident};
 
-/// Provides the hook to expand `#[derive(Index)]` into an implementation of `From`
+/// Provides the hook to expand `#[derive(Index)]` into an implementation of `Index`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let index_type = &Ident::new("__IdxT", Span::call_site());
     let mut state = State::with_field_ignore(

--- a/src/index_mut.rs
+++ b/src/index_mut.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{parse::Result, DeriveInput, Ident};
 
-/// Provides the hook to expand `#[derive(Index)]` into an implementation of `From`
+/// Provides the hook to expand `#[derive(IndexMut)]` into an implementation of `IndexMut`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let index_type = &Ident::new("__IdxT", Span::call_site());
     let mut state = State::with_field_ignore(

--- a/src/into_iterator.rs
+++ b/src/into_iterator.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{parse::Result, DeriveInput};
 
-/// Provides the hook to expand `#[derive(Index)]` into an implementation of `From`
+/// Provides the hook to expand `#[derive(IntoIterator)]` into an implementation of `IntoIterator`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let state = State::with_field_ignore_and_refs(
         input,

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -11,6 +11,12 @@ use std::fmt::Binary;
 #[derive(Display, Octal, Binary)]
 struct MyInt(i32);
 
+#[derive(UpperHex)]
+enum IntEnum {
+    U8(u8),
+    I8(i8),
+}
+
 #[derive(Display)]
 #[display(fmt = "({}, {})", x, y)]
 struct Point2D {
@@ -98,7 +104,10 @@ enum Affix {
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
     assert_eq!(format!("{:b}", MyInt(9)), "1001");
+    assert_eq!(format!("{:#b}", MyInt(9)), "0b1001");
     assert_eq!(format!("{:o}", MyInt(9)), "11");
+    assert_eq!(format!("{:X}", IntEnum::I8(-1)), "FF");
+    assert_eq!(format!("{:#X}", IntEnum::U8(255)), "0xFF");
     assert_eq!(Point2D { x: 3, y: 4 }.to_string(), "(3, 4)");
     assert_eq!(Error::new("Error").to_string(), "Error");
     assert_eq!(E::Uint(2).to_string(), "2");


### PR DESCRIPTION
Closes #107 

After having a look into the expanded code and wrapping my head around, I finally found the issue. the `Display` derive uses a helper struct for the case of an enum with nested format-strings like the following (taken from the tests):

```rust
#[derive(Display)]
#[display(fmt = "Here's a prefix for {} and a suffix")]
enum Affix {
    A(u32),
    #[display(fmt = "{} -- {}", wat, stuff)]
    B {
        wat: String,
        stuff: bool,
    },
}
```

The problem was that if there was no outer format string, the default `"{}"` would be used, which removes all formatting settings from properly propagating.

A quick workaround was to avoid the treacherous line `write!(f, "{}", helper_object)` and instead call `Display::fmt(&helper_object, f)` directly, so that's what I did in 2c74515. After I slowly became more familiar with the code, I actually managed to completely avoid the helper object when it isn't necessary (c9c1ada). Ultimately, I even managed to only generate the type definition for this helper object when it is really necessary (faf2e84).

Once that was done, I couldn't help myself and cleaned up a few places that I found confusing, e.g. 2b0ff54. :slightly_smiling_face: 

Thank you for providing and maintaining this library and thank you for the thorough test suite: it really sped up the process and helped me make sure that my changes didn't break anything!