### PR TITLE
fix derivation of MulAssign for generic structs

### DIFF
--- a/src/mul_assign_like.rs
+++ b/src/mul_assign_like.rs
@@ -56,7 +56,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     Ok(quote!(
         impl#impl_generics #trait_path<#scalar_ident> for #input_type#ty_generics #where_clause{
             #[inline]
-            fn #method_ident(&mut self, rhs: #scalar_ident#ty_generics) {
+            fn #method_ident(&mut self, rhs: #scalar_ident) {
                 #(#exprs;
                   )*
             }

--- a/tests/mul_assign.rs
+++ b/tests/mul_assign.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+use std::marker::PhantomData;
+
 #[macro_use]
 extern crate derive_more;
 
@@ -21,4 +23,10 @@ struct Point1D {
 struct Point2D {
     x: i32,
     y: i32,
+}
+
+#[derive(MulAssign)]
+struct MyInt2<T> {
+    x: i32,
+    ph: PhantomData<T>,
 }


### PR DESCRIPTION
The code structure generated for AddAssign and MulAssign differs in what it supports: should we make AddAssign as permissive as MulAssign in that it accept a RHS as long as the underlying type’s operation will accept it?