### PR TITLE
Fix generic trait bound for AsRef, AsMut

### DIFF
--- a/src/as_mut.rs
+++ b/src/as_mut.rs
@@ -1,15 +1,19 @@
-use crate::utils::{add_where_clauses_for_new_ident, MultiFieldData, State};
+use crate::utils::{
+    add_where_clauses_for_new_ident, AttrParams, MultiFieldData, State,
+};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{parse::Result, DeriveInput, Ident};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let as_mut_type = &Ident::new("__AsMutT", Span::call_site());
-    let state = State::with_field_ignore_and_forward(
+    let state = State::with_type_bound(
         input,
         trait_name,
         quote!(::core::convert),
         String::from("as_mut"),
+        AttrParams::ignore_and_forward(),
+        false,
     )?;
     let MultiFieldData {
         fields,

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -71,3 +71,38 @@ fn multi_field_struct() {
     assert!(ptr::eq(&mut item.first, item.as_mut()));
     assert!(ptr::eq(&mut item.second, item.as_mut()));
 }
+
+#[derive(AsMut)]
+struct SingleFieldGenericStruct<T> {
+    first: T,
+}
+
+#[test]
+fn single_field_generic_struct() {
+    let mut item = SingleFieldGenericStruct {
+        first: String::from("test"),
+    };
+
+    assert!(ptr::eq(&mut item.first, item.as_mut()));
+}
+
+#[derive(AsMut)]
+struct MultiFieldGenericStruct<T> {
+    #[as_mut]
+    first: Vec<T>,
+    #[as_mut]
+    second: PathBuf,
+    third: Vec<usize>,
+}
+
+#[test]
+fn multi_field_generic_struct() {
+    let mut item = MultiFieldGenericStruct {
+        first: b"test".to_vec(),
+        second: PathBuf::new(),
+        third: vec![],
+    };
+
+    assert!(ptr::eq(&mut item.first, item.as_mut()));
+    assert!(ptr::eq(&mut item.second, item.as_mut()));
+}

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -71,3 +71,38 @@ fn multi_field_struct() {
     assert!(ptr::eq(&item.first, item.as_ref()));
     assert!(ptr::eq(&item.second, item.as_ref()));
 }
+
+#[derive(AsRef)]
+struct SingleFieldGenericStruct<T> {
+    first: T,
+}
+
+#[test]
+fn single_field_generic_struct() {
+    let item = SingleFieldGenericStruct {
+        first: String::from("test"),
+    };
+
+    assert!(ptr::eq(&item.first, item.as_ref()));
+}
+
+#[derive(AsRef)]
+struct MultiFieldGenericStruct<T, U> {
+    #[as_ref]
+    first: Vec<T>,
+    #[as_ref]
+    second: [U; 2],
+    third: Vec<usize>,
+}
+
+#[test]
+fn multi_field_generic_struct() {
+    let item = MultiFieldGenericStruct {
+        first: b"test".to_vec(),
+        second: [0i32, 1i32],
+        third: vec![],
+    };
+
+    assert!(ptr::eq(&item.first, item.as_ref()));
+    assert!(ptr::eq(&item.second, item.as_ref()));
+}


### PR DESCRIPTION
The current version adds the unnecessary (and syntactically incorrect) trait bound `impl<T: ::std::convert::AsRef>`.

I did the smallest amount of refactoring necessary to make the change, but of course there is always room for more.