### PR TITLE
Make TryInto::Error return the original value instead of a str

### DIFF
--- a/doc/try_into.md
+++ b/doc/try_into.md
@@ -16,13 +16,16 @@ If that's not provided the default is `#[try_into(owned)]`.
 With `#[try_into]` or `#[try_into(ignore)]` it's possible to indicate which
 variants you want to derive `TryInto` for.
 
+In case of an error, the original value is not destructed but returned.
+This enables the chaining of several `try_from` (or `try_into`) calls.
+
 # Example usage
 
 ```rust
 # #[macro_use] extern crate derive_more;
 use core::convert::TryFrom;
 use core::convert::TryInto;
-#[derive(TryInto, Clone)]
+#[derive(TryInto, Clone, Eq, PartialEq, Debug)]
 #[try_into(owned, ref, ref_mut)]
 enum MixedData {
     Int(u32),
@@ -81,47 +84,47 @@ Code like this will be generated:
 #     UnsignedTwo(u32),
 # }
 impl ::core::convert::TryFrom<MixedInts> for (i32) {
-    type Error = &'static str;
+    type Error = MixedInts;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::SmallInt(__0) => Ok(__0),
-            _ => Err("Only SmallInt can be converted to i32"),
+            _ => Err(value),
         }
     }
 }
 impl ::core::convert::TryFrom<MixedInts> for (i64) {
-    type Error = &'static str;
+    type Error = MixedInts;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::BigInt(__0) => Ok(__0),
-            _ => Err("Only BigInt can be converted to i64"),
+            _ => Err(value),
         }
     }
 }
 impl ::core::convert::TryFrom<MixedInts> for (i32, i32) {
-    type Error = &'static str;
+    type Error = MixedInts;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::TwoSmallInts(__0, __1) => Ok((__0, __1)),
-            _ => Err("Only TwoSmallInts can be converted to (i32, i32)"),
+            _ => Err(value),
         }
     }
 }
 impl ::core::convert::TryFrom<MixedInts> for (i64, i64) {
-    type Error = &'static str;
+    type Error = MixedInts;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::NamedSmallInts { x: __0, y: __1 } => Ok((__0, __1)),
-            _ => Err("Only NamedSmallInts can be converted to (i64, i64)"),
+            _  => Err(value),
         }
     }
 }
 impl ::core::convert::TryFrom<MixedInts> for (u32) {
-    type Error = &'static str;
+    type Error = MixedInts;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::UnsignedOne(__0) | MixedInts::UnsignedTwo(__0) => Ok(__0),
-            _ => Err("Only UnsignedOne, UnsignedTwo can be converted to u32"),
+            _ => Err(value),
         }
     }
 }
@@ -147,20 +150,20 @@ Code like this will be generated:
 #     Unit,
 # }
 impl ::core::convert::TryFrom<EnumWithUnit> for (i32) {
-    type Error = &'static str;
+    type Error = EnumWithUnit;
     fn try_from(value: EnumWithUnit) -> Result<Self, Self::Error> {
         match value {
             EnumWithUnit::SmallInt(__0) => Ok(__0),
-            _ => Err("Only SmallInt can be converted to i32"),
+            _ => Err(value),
         }
     }
 }
 impl ::core::convert::TryFrom<EnumWithUnit> for () {
-    type Error = &'static str;
+    type Error = EnumWithUnit;
     fn try_from(value: EnumWithUnit) -> Result<Self, Self::Error> {
         match value {
             EnumWithUnit::Unit => Ok(()),
-            _ => Err("Only Unit can be converted to ()"),
+            _ => Err(value),
         }
     }
 }

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -9,7 +9,7 @@ use std::convert::{TryFrom, TryInto};
 // been redefined.
 type Result = ();
 
-#[derive(Clone, Copy, TryInto)]
+#[derive(Clone, Copy, TryInto, Eq, PartialEq, Debug)]
 #[try_into(owned, ref, ref_mut)]
 enum MixedInts {
     SmallInt(i32),
@@ -42,158 +42,68 @@ fn test_try_into() {
     assert_eq!(Ok(42i32), i.try_into());
     assert_eq!(Ok(&42i32), (&i).try_into());
     assert_eq!(Ok(&mut 42i32), (&mut i).try_into());
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
-    assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
-    );
-    assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
-    );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(i64::try_from(i), Err(i),);
+    assert_eq!(<(i32, i32)>::try_from(i), Err(i),);
+    assert_eq!(<(i64, i64)>::try_from(i), Err(i),);
+    assert_eq!(u32::try_from(i), Err(i));
+    assert_eq!(<()>::try_from(i), Err(i));
 
     let mut i = MixedInts::NamedBigInt { int: 42 };
-    assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
-    );
+    assert_eq!(i32::try_from(i), Err(i));
     assert_eq!(Ok(42i64), i.try_into());
     assert_eq!(Ok(&42i64), (&i).try_into());
     assert_eq!(Ok(&mut 42i64), (&mut i).try_into());
-    assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
-    );
-    assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
-    );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(<(i32, i32)>::try_from(i), Err(i));
+    assert_eq!(<(i64, i64)>::try_from(i), Err(i));
+    assert_eq!(u32::try_from(i), Err(i));
+    assert_eq!(<()>::try_from(i), Err(i));
 
     let mut i = MixedInts::TwoSmallInts(42, 64);
-    assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
-    );
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
+    assert_eq!(i32::try_from(i), Err(i),);
+    assert_eq!(i64::try_from(i), Err(i));
     assert_eq!(Ok((42i32, 64i32)), i.try_into());
     assert_eq!(Ok((&42i32, &64i32)), (&i).try_into());
     assert_eq!(Ok((&mut 42i32, &mut 64i32)), (&mut i).try_into());
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
-    );
-    assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
-    );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(<(i64, i64)>::try_from(i), Err(i));
+    assert_eq!(u32::try_from(i), Err(i));
+    assert_eq!(<()>::try_from(i), Err(i));
 
     let mut i = MixedInts::NamedBigInts { x: 42, y: 64 };
-    assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
-    );
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
-    assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
+    assert_eq!(i32::try_from(i), Err(i));
+    assert_eq!(i64::try_from(i), Err(i));
+    assert_eq!(<(i32, i32)>::try_from(i), Err(i));
     assert_eq!(Ok((42i64, 64i64)), i.try_into());
     assert_eq!(Ok((&42i64, &64i64)), (&i).try_into());
     assert_eq!(Ok((&mut 42i64, &mut 64i64)), (&mut i).try_into());
-    assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
-    );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(u32::try_from(i), Err(i));
+    assert_eq!(<()>::try_from(i), Err(i));
 
     let mut i = MixedInts::Unsigned(42);
-    assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
-    );
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
-    assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
-    );
+    assert_eq!(i32::try_from(i), Err(i));
+    assert_eq!(i64::try_from(i), Err(i));
+    assert_eq!(<(i32, i32)>::try_from(i), Err(i));
+    assert_eq!(<(i64, i64)>::try_from(i), Err(i));
     assert_eq!(Ok(42u32), i.try_into());
     assert_eq!(Ok(&42u32), (&i).try_into());
     assert_eq!(Ok(&mut 42u32), (&mut i).try_into());
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(<()>::try_from(i), Err(i));
 
     let mut i = MixedInts::NamedUnsigned { x: 42 };
-    assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
-    );
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
-    assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
-    );
+    assert_eq!(i32::try_from(i), Err(i));
+    assert_eq!(i64::try_from(i), Err(i),);
+    assert_eq!(i64::try_from(i), Err(i),);
+    assert_eq!(<(i32, i32)>::try_from(i), Err(i),);
+    assert_eq!(<(i64, i64)>::try_from(i), Err(i),);
     assert_eq!(Ok(42u32), i.try_into());
     assert_eq!(Ok(&42u32), (&i).try_into());
     assert_eq!(Ok(&mut 42u32), (&mut i).try_into());
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(<()>::try_from(i), Err(i));
 
     let i = MixedInts::Unit;
-    assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
-    );
-    assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
-    );
-    assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
-    );
-    assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
-    );
+    assert_eq!(i32::try_from(i), Err(i),);
+    assert_eq!(i64::try_from(i), Err(i),);
+    assert_eq!(<(i32, i32)>::try_from(i), Err(i),);
+    assert_eq!(<(i64, i64)>::try_from(i), Err(i));
+    assert_eq!(u32::try_from(i), Err(i));
     assert_eq!(Ok(()), i.try_into());
 }


### PR DESCRIPTION
When using the derived `TryInto/TryFrom` instances, if the result is an `Error`, the original value is consumed (if it is not a reference). This prevents the valid use case of chaining several `try_from` or `try_into` together, at least not without potentially expensive clones.

Returning a string error message is descriptive if the user program actually prints it, but IMHO that is not a very common use case because reliable programs should always handle errors. An additional reason against string error is that it is not friendly for localization/translation.

I could change the `Error` type to be a tuple that contains both the string & the original value if people really must have the string back.