### PR TITLE
Fixing typos

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -441,7 +441,7 @@ impl<'a, 'b> State<'a, 'b> {
         } else if fields.len() > 1 {
             return Err(Error::new(
                 fields.span(),
-                "Can not automatically infer format for types with more than 1 field",
+                "Cannot automatically infer format for types with more than 1 field",
             ));
         }
 
@@ -552,7 +552,7 @@ impl<'a, 'b> State<'a, 'b> {
                     self.find_meta(&self.input.attrs, "fmt")?.ok_or_else(|| {
                         Error::new(
                             self.input.span(),
-                            "Can not automatically infer format for unions",
+                            "Cannot automatically infer format for unions",
                         )
                     })?;
                 let fmt = self.parse_meta_fmt(&meta, false)?.0;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -409,7 +409,7 @@ impl<'input> State<'input> {
                 data_enum.variants.iter().collect(),
             ),
             Data::Union(_) => {
-                panic!(format!("can not derive({}) for union", trait_name))
+                panic!(format!("cannot derive({}) for union", trait_name))
             }
         };
         let attrs: Vec<_> = if derive_type == DeriveType::Enum {
@@ -613,7 +613,7 @@ impl<'input> State<'input> {
 
     pub fn enabled_fields_data<'state>(&'state self) -> MultiFieldData<'input, 'state> {
         if self.derive_type == DeriveType::Enum {
-            panic!(format!("can not derive({}) for enum", self.trait_name))
+            panic!(format!("cannot derive({}) for enum", self.trait_name))
         }
         let fields = self.enabled_fields();
         let field_idents = self.enabled_fields_idents();


### PR DESCRIPTION
"can not" -> "cannot" where appropriate