### PR TITLE
`Display`: test that we can use `self` at the top level

### DIFF
--- a/tests/display.rs
+++ b/tests/display.rs
@@ -100,6 +100,10 @@ enum Affix {
     },
 }
 
+#[derive(Debug, Display)]
+#[display(fmt = "{:?}", self)]
+struct DebugStructAsDisplay;
+
 #[test]
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
@@ -134,6 +138,7 @@ fn check_display() {
         .to_string(),
         "Here's a prefix for things -- false and a suffix"
     );
+    assert_eq!(DebugStructAsDisplay.to_string(), "DebugStructAsDisplay");
 }
 
 mod generic {


### PR DESCRIPTION
Currently, [documentation for `Display`-like derives](https://jeltef.github.io/derive_more/derive_more/display.html) states:

> The variables available in the arguments is `self` and each member of the variant, with members of tuple structs being named with a leading underscore and their index, i.e. `_0`, `_1`, `_2`, etc.

...but this isn't tested anywhere. This PR adds this coverage.

---

Checklist:

* [x] Merge soft dep (base) on #140.