### PR TITLE
WIP: Distinguish top-level enum `fmt` from `affix`

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -344,7 +344,7 @@ impl<'a, 'b> State<'a, 'b> {
                 ..
             })) => match path {
                 op if op.segments.first().expect("path shouldn't be empty").ident
-                    == "fmt" =>
+                    == "affix" =>
                 {
                     let expected_affix_usage = "outer `enum` `fmt` is an affix spec that expects no args and at most 1 placeholder for inner variant display";
                     if outer_enum {

--- a/src/display.rs
+++ b/src/display.rs
@@ -414,6 +414,11 @@ impl<'a, 'b> State<'a, 'b> {
                         false,
                     ))
                 }
+                op if op.segments.first().expect("path shouldn't be empty").ident
+                    == "fmt" =>
+                {
+                    todo!()
+                }
                 _ => Err(Error::new(
                     list.nested[0].span(),
                     self.get_proper_fmt_syntax(),

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -100,6 +100,10 @@ enum Affix {
     },
 }
 
+#[derive(Debug, Display)]
+#[display(fmt = "{:?}", self)]
+struct DebugStructAsDisplay;
+
 #[test]
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
@@ -134,6 +138,7 @@ fn check_display() {
         .to_string(),
         "Here's a prefix for things -- false and a suffix"
     );
+    assert_eq!(DebugStructAsDisplay.to_string(), "DebugStructAsDisplay");
 }
 
 mod generic {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -104,6 +104,12 @@ enum Affix {
 #[display(fmt = "{:?}", self)]
 struct DebugStructAsDisplay;
 
+#[derive(Debug, Display)]
+#[display(fmt = "{:?}", self)]
+enum DebugEnumAsDisplay {
+    Variant,
+}
+
 #[test]
 fn check_display() {
     assert_eq!(MyInt(-2).to_string(), "-2");
@@ -139,6 +145,7 @@ fn check_display() {
         "Here's a prefix for things -- false and a suffix"
     );
     assert_eq!(DebugStructAsDisplay.to_string(), "DebugStructAsDisplay");
+    assert_eq!(DebugEnumAsDisplay::Variant.to_string(), "Variant");
 }
 
 mod generic {


### PR DESCRIPTION
Fixes https://github.com/JelteF/derive_more/issues/142 by implementing the solution proposed in the OP. Once the proposal is validated, I'll fill in this PR with more details and polish it up for review.

---

Things to do before merge:

* [x] Soft dep on https://github.com/JelteF/derive_more/pull/141.