### PR TITLE
Add `Borrow` and `BorrowMut` derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ add_assign = []
 add = []
 as_mut = []
 as_ref = []
+borrow = []
+borrow_mut = []
 constructor = []
 deref = []
 deref_mut = []
@@ -69,6 +71,8 @@ default = [
     "add",
     "as_mut",
     "as_ref",
+    "borrow",
+    "borrow_mut",
     "constructor",
     "deref",
     "deref_mut",

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ extern crate derive_more;
 [`IntoIterator`]: https://jeltef.github.io/derive_more/derive_more/into_iterator.html
 [`AsRef`]: https://jeltef.github.io/derive_more/derive_more/as_ref.html
 [`AsMut`]: https://jeltef.github.io/derive_more/derive_more/as_mut.html
-[`Borrow`]: https://jeltef.github.io/derive_more/derive_more/as_ref.html
-[`BorrowMut`]: https://jeltef.github.io/derive_more/derive_more/as_mut.html
+[`Borrow`]: https://jeltef.github.io/derive_more/derive_more/borrow.html
+[`BorrowMut`]: https://jeltef.github.io/derive_more/derive_more/borrow_mut.html
 
 [`Display`-like]: https://jeltef.github.io/derive_more/derive_more/display.html
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ These are traits that are used to convert automatically between types.
 5. [`IntoIterator`]
 6. [`AsRef`]
 7. [`AsMut`]
+8. [`Borrow`]
+9. [`BorrowMut`]
 
 ### Formatting traits
 
@@ -161,6 +163,8 @@ extern crate derive_more;
 [`IntoIterator`]: https://jeltef.github.io/derive_more/derive_more/into_iterator.html
 [`AsRef`]: https://jeltef.github.io/derive_more/derive_more/as_ref.html
 [`AsMut`]: https://jeltef.github.io/derive_more/derive_more/as_mut.html
+[`Borrow`]: https://jeltef.github.io/derive_more/derive_more/as_ref.html
+[`BorrowMut`]: https://jeltef.github.io/derive_more/derive_more/as_mut.html
 
 [`Display`-like]: https://jeltef.github.io/derive_more/derive_more/display.html
 

--- a/doc/borrow.md
+++ b/doc/borrow.md
@@ -1,0 +1,124 @@
+% What #[derive(Borrow)] generates
+
+Deriving `Borrow` generates one or more implementations of `Borrow`, each
+corresponding to one of the fields of the decorated type.
+This allows types which contain some `T` to be passed anywhere that an
+`Borrow<T>` is accepted.
+
+# Newtypes and Structs with One Field
+
+When `Borrow` is derived for a newtype or struct with one field, a single
+implementation is generated to expose the underlying field.
+
+```rust
+# #[macro_use] extern crate derive_more;
+# fn main(){}
+#[derive(Borrow)]
+struct MyWrapper(String);
+```
+
+Generates:
+
+```rust
+# struct MyWrapper(String);
+impl Borrow<String> for MyWrapper {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}
+```
+
+It's also possible to use the `#[borrow(forward)]` attribute to forward
+to the `borrow` implementation of the field. So here `SigleFieldForward`
+implements all `Borrow` for all types that `Vec<i32>` implements `Borrow` for.
+
+```rust
+# #[macro_use] extern crate derive_more;
+#[derive(Borrow)]
+#[borrow(forward)]
+struct SingleFieldForward(Vec<i32>);
+
+fn main() {
+    let item = SingleFieldForward(vec![]);
+    let _: &[i32] = (&item).borrow();
+}
+
+```
+
+This generates:
+
+```rust
+# struct SingleFieldForward(Vec<i32>);
+impl<__BorrowT: ?::core::marker::Sized> ::core::convert::Borrow<__BorrowT> for SingleFieldForward
+where
+    Vec<i32>: ::core::convert::Borrow<__BorrowT>,
+{
+    #[inline]
+    fn borrow(&self) -> &__BorrowT {
+        <Vec<i32> as ::core::convert::Borrow<__BorrowT>>::borrow(&self.0)
+    }
+}
+```
+
+# Structs with Multiple Fields
+
+When `Borrow` is derived for a struct with more than one field (including tuple
+structs), you must also mark one or more fields with the `#[borrow]` attribute.
+An implementation will be generated for each indicated field.
+You can also exclude a specific field by using `#[borrow(ignore)]`.
+
+```rust
+# #[macro_use] extern crate derive_more;
+# fn main(){}
+#[derive(Borrow)]
+struct MyWrapper {
+    #[borrow]
+    name: String,
+    #[borrow]
+    num: i32,
+    valid: bool,
+}
+
+```
+
+Generates:
+
+```rust
+# struct MyWrapper {
+#     name: String,
+#     num: i32,
+#     valid: bool,
+# }
+impl Borrow<String> for MyWrapper {
+    fn borrow(&self) -> &String {
+        &self.name
+    }
+}
+
+impl Borrow<i32> for MyWrapper {
+    fn borrow(&self) -> &i32 {
+        &self.num
+    }
+}
+```
+
+Note that `Borrow<T>` may only be implemented once for any given type `T`.
+This means any attempt to mark more than one field of the same type with
+`#[borrow]` will result in a compilation error.
+
+```compile_fail
+# #[macro_use] extern crate derive_more;
+# fn main(){}
+// Error! Conflicting implementations of Borrow<String>
+#[derive(Borrow)]
+struct MyWrapper {
+    #[borrow]
+    str1: String,
+    #[borrow]
+    str2: String,
+}
+```
+
+# Enums
+
+Deriving `Borrow` for enums is not supported.

--- a/doc/borrow_mut.md
+++ b/doc/borrow_mut.md
@@ -1,0 +1,125 @@
+% What #[derive(BorrowMut)] generates
+
+Deriving `BorrowMut` generates one or more implementations of `BorrowMut`, each
+corresponding to one of the fields of the decorated type.
+This allows types which contain some `T` to be passed anywhere that an
+`BorrowMut<T>` is accepted.
+
+# Newtypes and Structs with One Field
+
+When `BorrowMut` is derived for a newtype or struct with one field, a single
+implementation is generated to expose the underlying field.
+
+```rust
+# #[macro_use] extern crate derive_more;
+# fn main(){}
+#[derive(BorrowMut)]
+struct MyWrapper(String);
+```
+
+Generates:
+
+```rust
+# struct MyWrapper(String);
+impl BorrowMut<String> for MyWrapper {
+    fn borrow_mut(&mut self) -> &mut String {
+        &mut self.0
+    }
+}
+```
+
+It's also possible to use the `#[borrow_mut(forward)]` attribute to forward
+to the `borrow_mut` implementation of the field. So here `SigleFieldForward`
+implements all `BorrowMut` for all types that `Vec<i32>` implements `BorrowMut` for.
+
+```rust
+# #[macro_use] extern crate derive_more;
+#[derive(BorrowMut)]
+#[borrow_mut(forward)]
+struct SingleFieldForward(Vec<i32>);
+
+fn main() {
+    let mut item = SingleFieldForward(vec![]);
+    let _: &mut [i32] = (&mut item).borrow_mut();
+}
+
+```
+
+This generates:
+
+```rust
+# struct SingleFieldForward(Vec<i32>);
+impl<__BorrowMutT: ?::core::marker::Sized> ::core::convert::BorrowMut<__BorrowMutT> for SingleFieldForward
+where
+    Vec<i32>: ::core::convert::BorrowMut<__BorrowMutT>,
+{
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut __BorrowMutT {
+        <Vec<i32> as ::core::convert::BorrowMut<__BorrowMutT>>::borrow_mut(&mut self.0)
+    }
+}
+```
+
+
+# Structs with Multiple Fields
+
+When `BorrowMut` is derived for a struct with more than one field (including tuple
+structs), you must also mark one or more fields with the `#[borrow_mut]` attribute.
+An implementation will be generated for each indicated field.
+You can also exclude a specific field by using `#[borrow_mut(ignore)]`.
+
+```rust
+# #[macro_use] extern crate derive_more;
+# fn main(){}
+#[derive(BorrowMut)]
+struct MyWrapper {
+    #[borrow_mut]
+    name: String,
+    #[borrow_mut]
+    num: i32,
+    valid: bool,
+}
+
+
+```
+
+Generates:
+
+```
+# struct MyWrapper {
+#     name: String,
+#     num: i32,
+#     valid: bool,
+# }
+impl BorrowMut<String> for MyWrapper {
+    fn borrow_mut(&mut self) -> &mut String {
+        &mut self.name
+    }
+}
+
+impl BorrowMut<i32> for MyWrapper {
+    fn borrow_mut(&mut self) -> &mut i32 {
+        &mut self.num
+    }
+}
+```
+
+Note that `BorrowMut<T>` may only be implemented once for any given type `T`. This means any attempt to
+mark more than one field of the same type with `#[borrow_mut]` will result in a compilation error.
+
+```compile_fail
+# #[macro_use] extern crate derive_more;
+# fn main(){}
+// Error! Conflicting implementations of BorrowMut<String>
+#[derive(BorrowMut)]
+struct MyWrapper {
+    #[borrow_mut]
+    str1: String,
+    #[borrow_mut]
+    str2: String,
+}
+```
+
+# Enums
+
+Deriving `BorrowMut` for enums is not supported.

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -1,0 +1,83 @@
+use crate::utils::{
+    add_where_clauses_for_new_ident, AttrParams, MultiFieldData, State,
+};
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{parse::Result, DeriveInput, Ident};
+
+pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
+    let borrow_type = &Ident::new("__BorrowT", Span::call_site());
+    let state = State::with_type_bound(
+        input,
+        trait_name,
+        quote!(::core::borrow),
+        String::from("borrow"),
+        AttrParams::ignore_and_forward(),
+        false,
+    )?;
+    let MultiFieldData {
+        fields,
+        input_type,
+        members,
+        infos,
+        trait_path,
+        impl_generics,
+        ty_generics,
+        where_clause,
+        ..
+    } = state.enabled_fields_data();
+    let sub_items: Vec<_> = infos
+        .iter()
+        .zip(members.iter())
+        .zip(fields)
+        .map(|((info, member), field)| {
+            let field_type = &field.ty;
+            if info.forward {
+                let trait_path = quote!(#trait_path<#borrow_type>);
+                let type_where_clauses = quote! {
+                    where #field_type: #trait_path
+                };
+                let new_generics = add_where_clauses_for_new_ident(
+                    &input.generics,
+                    &[field],
+                    borrow_type,
+                    type_where_clauses,
+                    false,
+                );
+                let (impl_generics, _, where_clause) = new_generics.split_for_impl();
+                let casted_trait = quote!(<#field_type as #trait_path>);
+                (
+                    quote!(#casted_trait::borrow(&#member)),
+                    quote!(#impl_generics),
+                    quote!(#where_clause),
+                    quote!(#trait_path),
+                    quote!(#borrow_type),
+                )
+            } else {
+                (
+                    quote!(&#member),
+                    quote!(#impl_generics),
+                    quote!(#where_clause),
+                    quote!(#trait_path<#field_type>),
+                    quote!(#field_type),
+                )
+            }
+        })
+        .collect();
+    let bodies = sub_items.iter().map(|i| &i.0);
+    let impl_generics = sub_items.iter().map(|i| &i.1);
+    let where_clauses = sub_items.iter().map(|i| &i.2);
+    let trait_paths = sub_items.iter().map(|i| &i.3);
+    let return_types = sub_items.iter().map(|i| &i.4);
+
+    Ok(quote! {#(
+        impl#impl_generics #trait_paths for #input_type#ty_generics
+        #where_clauses
+        {
+            #[inline]
+            fn borrow(&self) -> &#return_types {
+                #bodies
+            }
+        }
+    )*})
+}

--- a/src/borrow_mut.rs
+++ b/src/borrow_mut.rs
@@ -1,0 +1,83 @@
+use crate::utils::{
+    add_where_clauses_for_new_ident, AttrParams, MultiFieldData, State,
+};
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{parse::Result, DeriveInput, Ident};
+
+pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
+    let as_mut_type = &Ident::new("__BorrowMutT", Span::call_site());
+    let state = State::with_type_bound(
+        input,
+        trait_name,
+        quote!(::core::borrow),
+        String::from("borrow_mut"),
+        AttrParams::ignore_and_forward(),
+        false,
+    )?;
+    let MultiFieldData {
+        fields,
+        input_type,
+        members,
+        infos,
+        trait_path,
+        impl_generics,
+        ty_generics,
+        where_clause,
+        ..
+    } = state.enabled_fields_data();
+    let sub_items: Vec<_> = infos
+        .iter()
+        .zip(members.iter())
+        .zip(fields)
+        .map(|((info, member), field)| {
+            let field_type = &field.ty;
+            if info.forward {
+                let trait_path = quote!(#trait_path<#borrow_mut_type>);
+                let type_where_clauses = quote! {
+                    where #field_type: #trait_path
+                };
+                let new_generics = add_where_clauses_for_new_ident(
+                    &input.generics,
+                    &[field],
+                    borrow_mut_type,
+                    type_where_clauses,
+                    false,
+                );
+                let (impl_generics, _, where_clause) = new_generics.split_for_impl();
+                let casted_trait = quote!(<#field_type as #trait_path>);
+                (
+                    quote!(#casted_trait::borrow_mut(&mut #member)),
+                    quote!(#impl_generics),
+                    quote!(#where_clause),
+                    quote!(#trait_path),
+                    quote!(#borrow_mut_type),
+                )
+            } else {
+                (
+                    quote!(&mut #member),
+                    quote!(#impl_generics),
+                    quote!(#where_clause),
+                    quote!(#trait_path<#field_type>),
+                    quote!(#field_type),
+                )
+            }
+        })
+        .collect();
+    let bodies = sub_items.iter().map(|i| &i.0);
+    let impl_genericses = sub_items.iter().map(|i| &i.1);
+    let where_clauses = sub_items.iter().map(|i| &i.2);
+    let trait_paths = sub_items.iter().map(|i| &i.3);
+    let return_types = sub_items.iter().map(|i| &i.4);
+
+    Ok(quote! {#(
+        impl#impl_genericses #trait_paths for #input_type#ty_generics
+        #where_clauses
+        {
+            #[inline]
+            fn borrow_mut(&mut self) -> &mut #return_types {
+                #bodies
+            }
+        }
+    )*})
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@
 //! 5. [`IntoIterator`]
 //! 6. [`AsRef`]
 //! 7. [`AsMut`]
+//! 8. [`Borrow`]
+//! 9. [`BorrowMut`]
 //!
 //! ### Formatting traits
 //!
@@ -162,6 +164,8 @@
 //! [`IntoIterator`]: https://jeltef.github.io/derive_more/derive_more/into_iterator.html
 //! [`AsRef`]: https://jeltef.github.io/derive_more/derive_more/as_ref.html
 //! [`AsMut`]: https://jeltef.github.io/derive_more/derive_more/as_mut.html
+//! [`Borrow`]: https://jeltef.github.io/derive_more/derive_more/borrow.html
+//! [`BorrowMut`]: https://jeltef.github.io/derive_more/derive_more/borrow_mut.html
 //!
 //! [`Display`-like]: https://jeltef.github.io/derive_more/derive_more/display.html
 //!
@@ -207,6 +211,10 @@ mod add_like;
 mod as_mut;
 #[cfg(feature = "as_ref")]
 mod as_ref;
+#[cfg(feature = "borrow")]
+mod borrow;
+#[cfg(feature = "borrow_mut")]
+mod borrow_mut;
 #[cfg(feature = "constructor")]
 mod constructor;
 #[cfg(feature = "deref")]
@@ -406,3 +414,6 @@ create_derive!(
 
 create_derive!("as_ref", as_ref, AsRef, as_ref_derive, as_ref);
 create_derive!("as_mut", as_mut, AsMut, as_mut_derive, as_mut);
+
+create_derive!("borrow", borrow, Borrow, borrow_derive, borrow);
+create_derive!("borrow_mut", borrow_mut, BorrowMut, borrow_mut_derive, borrow_mut);


### PR DESCRIPTION
Had to switch from using `AsRef` to using `Borrow` in a project of mine for certain reasons and I'd really like to continue using this crate for that purpose. `Borrow` is identical in functionality to `AsRef`, but is used in different contexts and implemented for both `T` and `&T`.

This literally duplicates the functionality for `AsRef`, except the duplicated instances are replaced with `Borrow`. Same with `AsMut` and `BorrowMut`, which can be used like so:

```rust
#[derive(Borrow)]
struct MyStruct {
    #[borrow]
    data: u32
}
```

Let me know if there are any issues with this and I'll fix them. I *think* I got everything in the documentation included that is necessary, but I'm not 100% sure.