### PR TITLE
Allow complex additional types for From/Into

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -110,8 +110,10 @@ fn render_enum(
     let mut backtrace_match_arms = Vec::new();
 
     for variant in state.enabled_variant_data().variants {
-        let mut default_info = FullMetaInfo::default();
-        default_info.enabled = true;
+        let default_info = FullMetaInfo {
+            enabled: true,
+            ..FullMetaInfo::default()
+        };
 
         let state = State::from_variant(
             state.input,

--- a/src/into.rs
+++ b/src/into.rs
@@ -72,7 +72,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                     (#(#into_types),*) #where_clause {
 
                     #[inline]
-                    fn from(original: #reference_with_lifetime #input_type#ty_generics) -> (#(#into_types),*) {
+                    fn from(original: #reference_with_lifetime #input_type#ty_generics) -> Self {
                         (#(#initializers),*)
                     }
                 }

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -2,6 +2,8 @@
 #[macro_use]
 extern crate derive_more;
 
+use std::borrow::Cow;
+
 #[derive(From)]
 struct EmptyTuple();
 
@@ -168,4 +170,18 @@ fn explicit_types_point_2d() {
     assert_eq!(expected, (42i32, 42i32).into());
     assert_eq!(expected, (42i8, 42i8).into());
     assert_eq!(expected, (42i16, 42i16).into());
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[derive(From)]
+#[from(types("Cow<'_, str>", "&str"))]
+struct Name(String);
+
+#[test]
+fn explicit_complex_types_name() {
+    let name = "Eärendil";
+    let expected = Name(name.to_owned());
+    assert_eq!(expected, name.to_owned().into());
+    assert_eq!(expected, name.into());
+    assert_eq!(expected, Cow::Borrowed(name).into());
 }

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -2,6 +2,8 @@
 #[macro_use]
 extern crate derive_more;
 
+use std::borrow::Cow;
+
 #[derive(Into)]
 #[into(owned, ref, ref_mut)]
 struct EmptyTuple();
@@ -123,4 +125,17 @@ fn explicit_types_point_2d() {
         <(&mut i32, &mut i32)>::from(&mut input),
         (&mut 42i32, &mut 42i32)
     );
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Into)]
+#[into(owned(types("Cow<'_, str>")))]
+struct Name(String);
+
+#[test]
+fn explicit_complex_types_name() {
+    let name = "Ñolofinwë";
+    let input = Name(name.to_owned());
+    assert_eq!(String::from(input.clone()), name.to_owned());
+    assert_eq!(Cow::from(input.clone()), Cow::Borrowed(name));
 }


### PR DESCRIPTION
This PR extends `types()` attribute in`From`/`Into` derives to support types more complex than a simple ident.

```rust
#[derive(From, Into)]
#[from(types("Cow<'_, str>", "&str"))]
#[into(owned(types("Cow<'_, str>")))]
struct Name(String);
```