### PR TITLE
Update docs: Remove reference to MulSelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ These are traits that can be used for operator overloading.
 1. [`Index`]
 2. [`Deref`]
 3. [`Not`-like], contains `Not` and `Neg`
-4. [`Add`-like], contains `Add`, `Sub`, `BitAnd`, `BitOr`, `BitXor`, `MulSelf`,
-   `DivSelf`, `RemSelf`, `ShrSelf` and `ShlSelf`
+4. [`Add`-like], contains `Add`, `Sub`, `BitAnd`, `BitOr`, `BitXor`
 5. [`Mul`-like], contains `Mul`, `Div`, `Rem`, `Shr` and `Shl`
 3. [`Sum`-like], contains `Sum` and `Product`
 6. [`IndexMut`]

--- a/doc/mul.md
+++ b/doc/mul.md
@@ -13,7 +13,7 @@ two would be two meters, but one meter times one meter would be one square meter
 As this second case clearly requires more knowledge about the meaning of the
 type in question deriving for this is not implemented.
 
-NOTE: In case you don't want this behaviour you can add `#[mul(forward)]`.
+NOTE: In case you don't want this behaviour you can add `#[mul(forward)]` in addition to `#[derive(Mul)]`.
 This will instead generate a `Mul` implementation with the same semantics as
 `Add`.
 


### PR DESCRIPTION
If I understand correctly these have been removed in the latest version.