### PR TITLE
Add Unwrap derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ try_into = ["syn/extra-traits"]
 generate-parsing-rs = ["peg"]
 testing-helpers = ["rustc_version"]
 is_variant = ["convert_case"]
-unwrap = ["convert_case"]
+unwrap = ["convert_case", "rustc_version"]
 
 default = [
     "add_assign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ try_into = ["syn/extra-traits"]
 generate-parsing-rs = ["peg"]
 testing-helpers = ["rustc_version"]
 is_variant = ["convert_case"]
+unwrap = ["convert_case"]
 
 default = [
     "add_assign",
@@ -89,6 +90,7 @@ default = [
     "sum",
     "try_into",
     "is_variant",
+    "unwrap"
 ]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ generate-parsing-rs = ["peg"]
 testing-helpers = ["rustc_version"]
 is_variant = ["convert_case"]
 unwrap = ["convert_case", "rustc_version"]
+# Feature that requires post-MSRV Rust version,
+# of 1.46. We perform rustc version detection in the
+# build script for features that require this.
+# (Currently just `unwrap`.)
+track-caller = []
 
 default = [
     "add_assign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,11 @@ path = "tests/is_variant.rs"
 required-features = ["is_variant"]
 
 [[test]]
+name = "unwrap"
+path = "tests/unwrap.rs"
+required-features = ["unwrap"]
+
+[[test]]
 name = "no_std"
 path = "tests/no_std.rs"
 required-features = [

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,20 @@ fn detect_nightly() {
     }
 }
 
+#[cfg(not(feature = "unwrap"))]
+fn detect_track_caller() {}
+/// Detect availability of the `#[track_caller]` attribute for
+/// use in derived panicking methods like `.unwrap_*()`.
+#[cfg(feature = "unwrap")]
+fn detect_track_caller() {
+    use rustc_version::version_meta;
+    if version_meta().unwrap().semver.minor > 46 {
+        println!("cargo:rustc-cfg=feature=\"track-caller\"");
+    }
+}
+
 fn main() {
     detect_nightly();
+    detect_track_caller();
     generate_peg();
 }

--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,7 @@ fn detect_track_caller() {}
 #[cfg(feature = "unwrap")]
 fn detect_track_caller() {
     use rustc_version::version_meta;
-    if version_meta().unwrap().semver.minor > 46 {
+    if version_meta().unwrap().semver.minor >= 46 {
         println!("cargo:rustc-cfg=feature=\"track-caller\"");
     }
 }

--- a/doc/unwrap.md
+++ b/doc/unwrap.md
@@ -8,7 +8,7 @@ you can put the `#[unwrap(ignore)]` attribute on that variant.
 # Example usage
 
 ```rust
-use ::derive_more::Unwrap;
+# #[macro_use] extern crate derive_more;
 
 #[derive(Unwrap)]
 enum Maybe<T> {
@@ -21,6 +21,10 @@ enum Maybe<T> {
 
 The derive in the above example code generates the following code:
 ```rust
+# enum Maybe<T> {
+#     Just(T),
+#     Nothing,
+# }
 impl<T> Maybe<T> {
     pub fn unwrap_just(self) -> (T) {
         match self {

--- a/doc/unwrap.md
+++ b/doc/unwrap.md
@@ -1,0 +1,40 @@
+% What #[derive(Unwrap)] generates
+
+When an enum is decorated with `#[derive(Unwrap)]`, for each variant `foo` in the enum,
+with fields `(a, b, c, ...)` a public instance method `unwrap_foo(self) -> (a, b, c, ...)`
+is generated. If you don't want the `unwrap_foo` method generated for a variant,
+you can put the `#[unwrap(ignore)]` attribute on that variant.
+
+# Example usage
+
+```rust
+use ::derive_more::Unwrap;
+
+#[derive(Unwrap)]
+enum Maybe<T> {
+    Just(T),
+    Nothing,
+}
+```
+
+# What is generated?
+
+The derive in the above example code generates the following code:
+```rust
+impl<T> Maybe<T> {
+    pub fn unwrap_just(self) -> (T) {
+        match self {
+            Maybe::Just(field_0) => (field_0),
+            Maybe::Nothing => panic!(concat!("called `", stringify!(Maybe), "::", stringify!(unwrap_just),
+                                     "()` on a `", stringify!(Nothing), "` value"))
+        }
+    }
+    pub fn unwrap_nothing(self) -> () {
+        match self {
+            Maybe::Nothing => (),
+            Maybe::Just(..) => panic!(concat!("called `", stringify!(Maybe), "::", stringify!(unwrap_nothing),
+                                     "()` on a `", stringify!(Just), "` value"))
+        }
+    }
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@
 //!    This is very basic if you need more customization for your constructor, check
 //!    out the [`derive-new`] crate.
 //! 2. [`IsVariant`], for each variant `foo` of an enum type, derives a `is_foo` method.
+//! 3. [`Unwrap`], for each variant `foo` of an enum type, derives an `unwrap_foo` method.
 //!
 //! ## Generated code
 //!
@@ -181,6 +182,7 @@
 //!
 //! [`Constructor`]: https://jeltef.github.io/derive_more/derive_more/constructor.html
 //! [`IsVariant`]: https://jeltef.github.io/derive_more/derive_more/is_variant.html
+//! [`Unwrap`]: https://jeltef.github.io/derive_more/derive_more/unwrap.html
 
 #![recursion_limit = "128"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,8 +232,6 @@ mod into;
 mod into_iterator;
 #[cfg(feature = "is_variant")]
 mod is_variant;
-#[cfg(feature = "unwrap")]
-mod unwrap;
 #[cfg(feature = "mul_assign")]
 mod mul_assign_like;
 #[cfg(any(feature = "mul", feature = "mul_assign"))]
@@ -250,6 +248,8 @@ mod parsing;
 mod sum_like;
 #[cfg(feature = "try_into")]
 mod try_into;
+#[cfg(feature = "unwrap")]
+mod unwrap;
 
 // This trait describes the possible return types of
 // the derives. A derive can generally be infallible and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,8 @@ mod into;
 mod into_iterator;
 #[cfg(feature = "is_variant")]
 mod is_variant;
+#[cfg(feature = "unwrap")]
+mod unwrap;
 #[cfg(feature = "mul_assign")]
 mod mul_assign_like;
 #[cfg(any(feature = "mul", feature = "mul_assign"))]
@@ -415,3 +417,5 @@ create_derive!(
     is_variant_derive,
     is_variant
 );
+
+create_derive!("unwrap", unwrap, Unwrap, unwrap_derive, unwrap);

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -38,13 +38,18 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         let (data_pattern, ret_value, ret_type) = match variant.fields {
             Fields::Named(_) => panic!("cannot unwrap anonymous records"),
             Fields::Unnamed(ref fields) => {
-                let data_pattern = (0..fields.unnamed.len()).fold(vec![], |mut a, n| {
-                    a.push(format_ident!("field_{}", n));
-                    a
-                });
+                let data_pattern =
+                    (0..fields.unnamed.len()).fold(vec![], |mut a, n| {
+                        a.push(format_ident!("field_{}", n));
+                        a
+                    });
                 let ret_type = &fields.unnamed;
-                (quote! { (#(#data_pattern),*) }, quote! { (#(#data_pattern),*) }, quote! { (#ret_type) })
-            },
+                (
+                    quote! { (#(#data_pattern),*) },
+                    quote! { (#(#data_pattern),*) },
+                    quote! { (#ret_type) },
+                )
+            }
             Fields::Unit => (quote! {}, quote! { () }, quote! { () }),
         };
 

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -82,5 +82,6 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         }
     };
 
+    println!("{}", imp);
     Ok(imp)
 }

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -1,0 +1,71 @@
+use crate::utils::{AttrParams, DeriveType, State};
+use convert_case::{Case, Casing};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Fields, Ident, Result};
+
+pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
+    let state = State::with_attr_params(
+        input,
+        trait_name,
+        quote!(),
+        String::from("unwrap_variant"),
+        AttrParams {
+            enum_: vec!["ignore"],
+            variant: vec!["ignore"],
+            struct_: vec!["ignore"],
+            field: vec!["ignore"],
+        },
+    )?;
+    if state.derive_type != DeriveType::Enum {
+        panic!("Unwrap can only be derived for enums");
+    }
+
+    let enum_name = &input.ident;
+    let (imp_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut funcs = vec![];
+    for variant_state in state.enabled_variant_data().variant_states {
+        let variant = variant_state.variant.unwrap();
+        let fn_name = Ident::new(
+            &format_ident!("unwrap_{}", variant.ident)
+                .to_string()
+                .to_case(Case::Snake),
+            variant.ident.span(),
+        );
+        let variant_ident = &variant.ident;
+
+        let (data_pattern, ret_value, ret_type) = match variant.fields {
+            Fields::Named(_) => panic!("cannot unwrap anonymous records"),
+            Fields::Unnamed(ref fields) => {
+                let data_pattern = (0..fields.unnamed.len()).fold(vec![], |mut a, n| {
+                    a.push(format_ident!("field_{}", n));
+                    a
+                });
+                let ret_type = &fields.unnamed;
+                (quote! { (#(#data_pattern),*) }, quote! { (#(#data_pattern),*) }, quote! { #ret_type })
+            },
+            Fields::Unit => (quote! {}, quote! { () }, quote! { () }),
+        };
+
+        let func = quote! {
+            #[track_caller]
+            pub fn #fn_name(self) -> #ret_type {
+                match self {
+                    #enum_name ::#variant_ident #data_pattern => #ret_value,
+                    _ => panic!(concat!("called `", stringify!(#enum_name), "::", stringify!(#fn_name),
+                                        "()` on an invalid value")),
+                }
+            }
+        };
+        funcs.push(func);
+    }
+
+    let imp = quote! {
+        impl #imp_generics #enum_name #type_generics #where_clause{
+            #(#funcs)*
+        }
+    };
+
+    Ok(imp)
+}

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -69,8 +69,17 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                                      "()` on a `", stringify!(#variant_ident), "` value"))
             }
         });
+
+        // The `track-caller` feature is set by our build script based
+        // on rustc version detection, as `#[track_caller]` was
+        // stabilized in a later version (1.46) of Rust than our MSRV (1.36).
+        let track_caller = if cfg!(feature = "track-caller") {
+            quote! { #[track_caller] }
+        } else {
+            quote! {}
+        };
         let func = quote! {
-            #[track_caller]
+            #track_caller
             pub fn #fn_name(self) -> #ret_type {
                 match self {
                     #enum_name ::#variant_ident #data_pattern => #ret_value,

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -9,7 +9,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(),
-        String::from("unwrap_variant"),
+        String::from("unwrap"),
         AttrParams {
             enum_: vec!["ignore"],
             variant: vec!["ignore"],

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -82,6 +82,5 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         }
     };
 
-    println!("{}", imp);
     Ok(imp)
 }

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -48,7 +48,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             Fields::Unit => (quote! {}, quote! { () }, quote! { () }),
         };
 
-        let other_arms = state.enabled_variant_data().variant_states.into_iter().map(|variant| {
+        let other_arms = state.variant_states.iter().map(|variant| {
             variant.variant.unwrap()
         }).filter(|variant| {
             &variant.ident != variant_ident

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -43,7 +43,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                     a
                 });
                 let ret_type = &fields.unnamed;
-                (quote! { (#(#data_pattern),*) }, quote! { (#(#data_pattern),*) }, quote! { #ret_type })
+                (quote! { (#(#data_pattern),*) }, quote! { (#(#data_pattern),*) }, quote! { (#ret_type) })
             },
             Fields::Unit => (quote! {}, quote! { () }, quote! { () }),
         };

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -1,0 +1,62 @@
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate derive_more;
+
+#[derive(Unwrap)]
+enum Either<TLeft, TRight> {
+    Left(TLeft),
+    Right(TRight),
+}
+
+#[derive(Unwrap)]
+enum Maybe<T> {
+    Nothing,
+    Just(T),
+}
+
+#[derive(Unwrap)]
+enum Color {
+    RGB(u8, u8, u8),
+    CMYK(u8, u8, u8, u8),
+}
+
+#[derive(Unwrap)]
+enum Nonsense<'a, T> {
+    Ref(&'a T),
+    NoRef,
+    #[unwrap(ignore)]
+    NoRefIgnored,
+}
+
+#[derive(Unwrap)]
+enum WithConstraints<T>
+where
+    T: Copy,
+{
+    One(T),
+    Two,
+}
+#[derive(Unwrap)]
+enum KitchenSink<'a, 'b, T1: Copy, T2: Clone>
+where
+    T2: Into<T1> + 'b,
+{
+    Left(&'a T1),
+    Right(&'b T2),
+    OwnBoth(T1, T2),
+    Empty,
+    NeverMind(),
+    NothingToSeeHere(),
+}
+
+#[test]
+pub fn test_unwrap() {
+    assert_eq!(Maybe::<()>::Nothing.unwrap_nothing(), ());
+}
+
+#[test]
+#[should_panic]
+pub fn test_unwrap_panic() {
+    Maybe::<()>::Nothing.unwrap_just()
+}


### PR DESCRIPTION
```rust
#[derive(::derive_more::Unwrap)]
enum Lol {
    Haha(i32),
    Hm,
}

fn main() {
    let a = Lol::Haha(10);
    println!("Results: {:?}", a.unwrap_haha())
}
```
prints `Results: 10`, and switching to `a.unwrap_hm()` prints this message:
> thread 'main' panicked at 'called `Lol::unwrap_hm()` on a `Haha` value', src/main.rs:18:33
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
