### PR TITLE
Const generics support for Sum-like

### DIFF
--- a/src/sum_like.rs
+++ b/src/sum_like.rs
@@ -31,13 +31,18 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         .type_params()
         .map(|t| t.ident.clone())
         .collect();
+    let const_params: Vec<_> = input
+        .generics
+        .const_params()
+        .map(|t| t.ident.clone())
+        .collect();
     let generics = if type_params.is_empty() {
         input.generics.clone()
     } else {
-        let generic_type = quote!(<#(#type_params),*>);
+        let generic_params = quote!(<#(#type_params),* #(,#const_params)*>);
         let generics = add_extra_ty_param_bound(&input.generics, trait_path);
         let operator_where_clause = quote! {
-            where #input_type#generic_type: #op_path<Output=#input_type#generic_type>
+            where #input_type#generic_params: #op_path<Output=#input_type#generic_params>
         };
         add_extra_where_clauses(&generics, operator_where_clause)
     };

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -34,6 +34,9 @@ struct WrappedDouble<T: Clone, U: Clone>(T, U);
 #[from(forward)]
 struct WrappedDouble2<T: Clone, U: Clone>(T, U);
 
+#[derive(Add, Sum)]
+struct WrappedWithConst<T, const C: u32>(T);
+
 #[derive(
     From,
     FromStr,


### PR DESCRIPTION
I wanted to derive `Sum` to my struct that has multiple generics including a const generic.
```rust
#[derive(Add, Sum)]
struct WrappedWithConst<T, const C: u32>(T);
```
but I got a compilation error like this ↓
```
error[E0107]: this struct takes 2 generic arguments but only 1 generic argument was supplied
  --> tests/generics.rs:38:8
   |
38 | struct WrappedWithConst<T, const C: u32>(T);
   |        ^^^^^^^^^^^^^^^^ - supplied 1 generic argument
   |        |
   |        expected 2 generic arguments
   |
note: struct defined here, with 2 generic parameters: `T`, `C`
  --> tests/generics.rs:38:8
   |
38 | struct WrappedWithConst<T, const C: u32>(T);
   |        ^^^^^^^^^^^^^^^^ -        -
help: add missing generic argument
   |
38 | struct WrappedWithConst<T, C, const C: u32>(T);
   |                          ^^^
   
```

Here's the cargo expand result.
```rust
struct WrappedWithConst<T, const C: u32>(T);
impl<T: ::core::ops::Add<Output = T>, const C: u32> ::core::ops::Add for WrappedWithConst<T, C> {
    type Output = WrappedWithConst<T, C>;
    #[inline]
    fn add(self, rhs: WrappedWithConst<T, C>) -> WrappedWithConst<T, C> {
        WrappedWithConst(self.0.add(rhs.0))
    }
}
impl<T: ::core::iter::Sum, const C: u32> ::core::iter::Sum for WrappedWithConst<T, C>
where
    WrappedWithConst<T>: ::core::ops::Add<Output = WrappedWithConst<T>>,
{
    #[inline]
    fn sum<I: ::core::iter::Iterator<Item = Self>>(iter: I) -> Self {
        iter.fold(
            WrappedWithConst(::core::iter::Sum::sum(::core::iter::empty::<T>())),
            ::core::ops::Add::add,
        )
    }
}
```
As you can see, the where clause for the `Sum` impl  doesn't contain the const param `C`, so I fixed this by adding const params [here](https://github.com/JelteF/derive_more/compare/master...shugo256:sum-like-with-const-generics?expand=1#diff-4000580b07f162f6cf7563932548b514b9d8dab42488091a8c9bcd13fa0de091R42).
