### PR TITLE
Don't use collections::HashSet in derive impls

### DIFF
--- a/src/mul_assign_like.rs
+++ b/src/mul_assign_like.rs
@@ -1,9 +1,8 @@
 use crate::add_assign_like;
 use crate::mul_helpers::generics_and_exprs;
-use crate::utils::{AttrParams, MultiFieldData, RefType, State};
+use crate::utils::{AttrParams, HashSet, MultiFieldData, RefType, State};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use std::collections::HashSet;
 use std::iter;
 use syn::{DeriveInput, Ident, Result};
 

--- a/src/mul_like.rs
+++ b/src/mul_like.rs
@@ -1,9 +1,8 @@
 use crate::add_like;
 use crate::mul_helpers::generics_and_exprs;
-use crate::utils::{AttrParams, MultiFieldData, RefType, State};
+use crate::utils::{AttrParams, HashSet, MultiFieldData, RefType, State};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use std::collections::HashSet;
 use std::iter;
 use syn::{DeriveInput, Ident, Result};
 


### PR DESCRIPTION
This causes issues like we've already seen in #124.

Maybe it's possible to write some clippy lint to prevent imports of
HashSet/HashMap from std::collections. I don't know how to write one
though.

Fixes #177.