### PR TITLE
`derive(Default)` on enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ add = []
 as_mut = []
 as_ref = []
 constructor = []
+enum_default = []
 deref = []
 deref_mut = []
 display = ["syn/extra-traits", "unicode-xid"]
@@ -83,6 +84,7 @@ default = [
     "deref",
     "deref_mut",
     "display",
+    "enum_default",
     "error",
     "from",
     "from_str",

--- a/src/default.rs
+++ b/src/default.rs
@@ -1,0 +1,62 @@
+use crate::utils::{AttrParams, DeriveType, SingleVariantData, State};
+use convert_case::{Case, Casing};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, Ident, Result, Variant,
+};
+
+pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
+    let state = State::with_attr_params(
+        input,
+        "Default",
+        quote!(::core::default),
+        String::from("default"),
+        AttrParams {
+            enum_: vec![],
+            variant: vec!["ignore"],
+            struct_: vec![],
+            field: vec![],
+        },
+    )?;
+    let SingleVariantData {
+        input_type,
+        variant:
+            Variant {
+                ident: variant_ident,
+                fields,
+                ..
+            },
+        trait_path,
+        impl_generics,
+        ty_generics,
+        where_clause,
+        ..
+    } = state.assert_single_enabled_variant();
+
+    let fields = match fields {
+        Fields::Named(fields) => {
+            let fields = fields
+                .named
+                .iter()
+                .map(|Field { ident, .. }| quote!(#ident: #trait_path::default()));
+            quote!({#(#fields),*})
+        }
+        Fields::Unnamed(fields) => {
+            let fields = fields
+                .unnamed
+                .iter()
+                .map(|_| quote!(#trait_path::default()));
+            quote!((#(#fields),*))
+        }
+        Fields::Unit => quote!(),
+    };
+
+    Ok(quote! {
+        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause{
+            fn default() -> Self {
+                #input_type::#variant_ident#fields
+            }
+        }
+    })
+}

--- a/src/default.rs
+++ b/src/default.rs
@@ -1,12 +1,11 @@
-use crate::utils::{AttrParams, DeriveType, SingleVariantData, State};
-use convert_case::{Case, Casing};
+use crate::utils::{AttrParams, SingleVariantData, State};
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{
-    DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, Ident, Result, Variant,
+    DeriveInput, Field, Fields, Result, Variant,
 };
 
-pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
+pub fn expand(input: &DeriveInput, _trait_name: &'static str) -> Result<TokenStream> {
     let state = State::with_attr_params(
         input,
         "Default",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,8 @@ mod sum_like;
 mod try_into;
 #[cfg(feature = "unwrap")]
 mod unwrap;
+#[cfg(feature = "enum_default")]
+mod default;
 
 // This trait describes the possible return types of
 // the derives. A derive can generally be infallible and
@@ -418,3 +420,11 @@ create_derive!(
 );
 
 create_derive!("unwrap", unwrap, Unwrap, unwrap_derive, unwrap);
+
+create_derive!(
+    "default",
+    default,
+    EnumDefault,
+    default_derive,
+    default
+);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -720,7 +720,6 @@ impl<'input> State<'input> {
             impl_generics: data.impl_generics.clone(),
             ty_generics: data.ty_generics.clone(),
             where_clause: data.where_clause,
-            multi_variant_data: data,
         }
     }
 
@@ -877,7 +876,6 @@ pub struct SingleVariantData<'input, 'state> {
     pub impl_generics: ImplGenerics<'state>,
     pub ty_generics: TypeGenerics<'state>,
     pub where_clause: Option<&'state WhereClause>,
-    multi_variant_data: MultiVariantData<'input, 'state>,
 }
 
 impl<'input, 'state> MultiFieldData<'input, 'state> {


### PR DESCRIPTION
I know that there will be a `derive(Default)` for enums in the `std` soon, but AFAICT that only implements default for unit variants.

Due to name collisions, this has to be called `EnumDefault`. This currently has neither tests nor documentation, but I'll add those when you'd approve of this addition