### PR TITLE
Avoid branch in `Display` `match` statement for empty enums

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -68,9 +68,8 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> Result<TokenStream>
             fn fmt(&self, _derive_more_display_formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 #helper_struct
 
-                match self {
+                match *self {
                     #arms
-                    _ => Ok(()) // This is needed for empty enums
                 }
             }
         }
@@ -200,7 +199,7 @@ impl<'a, 'b> State<'a, 'b> {
                 let fields: TokenStream = (0..fields.unnamed.len())
                     .map(|n| {
                         let i = Ident::new(&format!("_{}", n), Span::call_site());
-                        quote!(#i,)
+                        quote!(ref #i,)
                     })
                     .collect();
                 quote!((#fields))
@@ -211,7 +210,7 @@ impl<'a, 'b> State<'a, 'b> {
                     .iter()
                     .map(|f| {
                         let i = f.ident.as_ref().unwrap();
-                        quote!(#i,)
+                        quote!(ref #i,)
                     })
                     .collect();
                 quote!({#fields})

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -160,6 +160,13 @@ fn check_display() {
     assert_eq!(DebugStructAsDisplay.to_string(), "DebugStructAsDisplay");
 }
 
+#[test]
+fn empty_enum_impls_display() {
+    trait S: std::fmt::Display {}
+
+    impl S for EmptyEnum {}
+}
+
 mod generic {
     #[derive(Display)]
     #[display(fmt = "Generic {}", field)]


### PR DESCRIPTION
This removes a match arm that will never be triggered for non empty enums.
So now only if their are no arms in the enum will the code for empty enums be generated.

This changes no functionally and is a bug fix.
