### PR TITLE
Replace `fn backtrace()` with `Provider` API in `Error` derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use a deterministic `HashSet` in all derives, this is needed for rust analyzer
   to work correctly.
-- Use `Provider` API for backtraces in `Error` derive
+- Use `Provider` API for backtraces in `Error` derive.
 
 ## 0.99.10 - 2020-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use a deterministic `HashSet` in all derives, this is needed for rust analyzer
   to work correctly.
+- Use `Provider` API for backtraces in `Error` derive
 
 ## 0.99.10 - 2020-09-11
 

--- a/doc/error.md
+++ b/doc/error.md
@@ -24,8 +24,8 @@ often [`From`] as well.
 2. It's a tuple struct/variant and there's exactly one field that is not used as
    the `backtrace`. So either a tuple struct with one field, or one with two where one
    is the `backtrace`. Then it returns this field as the `source`.
-3. One of the fields is annotated with `#[error(backtrace)]`. Then it would
-   return that field as the `backtrace`.
+3. One of the fields is annotated with `#[error(source)]`. Then it would
+   return that field as the `source`.
 
 ## When and how does it derive `provide()`?
 

--- a/doc/error.md
+++ b/doc/error.md
@@ -95,6 +95,7 @@ enum CompoundError {
         #[error(backtrace)]
         source: Simple,
     },
+    #[display(fmt = "{source}")]
     WithDifferentBacktrace {
         source: Simple,
         backtrace: Backtrace,

--- a/doc/error.md
+++ b/doc/error.md
@@ -2,8 +2,8 @@
 
 # Using #[derive(Error)]
 Deriving `Error` will generate an `Error` implementation, that contains
-(depending on the type) a `source()` and a `backtrace()` method. Please note,
-at the time of writing `backtrace` is only supported on nightly rust. So you
+(depending on the type) a `source()` and a `provide()` method. Please note,
+at the time of writing `provide()` is only supported on nightly rust. So you
 have to use that to make use of it.
 
 For a struct, these methods always do the same. For an `enum` they have separate
@@ -17,15 +17,6 @@ often [`From`] as well.
 [`Display`]: display.html
 [`From`]: from.html
 
-## When and how does it derive `backtrace()`?
-
-1. It's a struct/variant with named fields and one of the fields is
-   called `backtrace`. Then it would return that field as the `backtrace`.
-2. It's a tuple struct/variant and the type of exactly one of the fields is
-   called `Backtrace`. Then it would return that field as the `backtrace`.
-3. One of the fields is annotated with `#[error(backtrace)]`. Then it would
-   return that field as the `backtrace`.
-
 ## When and how does it derive `source()`?
 
 1. It's a struct/variant with named fields and one is the fields is
@@ -33,6 +24,15 @@ often [`From`] as well.
 2. It's a tuple struct/variant and there's exactly one field that is not used as
    the `backtrace`. So either a tuple struct with one field, or one with two where one
    is the `backtrace`. Then it returns this field as the `source`.
+3. One of the fields is annotated with `#[error(backtrace)]`. Then it would
+   return that field as the `backtrace`.
+
+## When and how does it derive `provide()`?
+
+1. It's a struct/variant with named fields and one of the fields is
+   called `backtrace`. Then it would return that field as the `backtrace`.
+2. It's a tuple struct/variant and the type of exactly one of the fields is
+   called `Backtrace`. Then it would return that field as the `backtrace`.
 3. One of the fields is annotated with `#[error(backtrace)]`. Then it would
    return that field as the `backtrace`.
 

--- a/doc/error.md
+++ b/doc/error.md
@@ -47,7 +47,7 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 # Example usage
 
 ```rust
-#![feature(backtrace)]
+#![feature(error_generic_member_access, provide_any)]
 # #[macro_use] extern crate derive_more;
 # use std::error::Error as _;
 use std::backtrace::Backtrace;

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ pub fn expand(
         })
         .collect();
 
-    let (bounds, source, backtrace) = match state.derive_type {
+    let (bounds, source, provide) = match state.derive_type {
         DeriveType::Named | DeriveType::Unnamed => render_struct(&type_params, &state)?,
         DeriveType::Enum => render_enum(&type_params, &state)?,
     };
@@ -45,11 +45,11 @@ pub fn expand(
         }
     });
 
-    let backtrace = backtrace.map(|backtrace| {
+    let provide = provide.map(|provide| {
         quote! {
-            fn backtrace(&self) -> Option<&::std::backtrace::Backtrace> {
-                #backtrace
-            }
+            fn provide<'_demand>(&'_demand self, demand: &mut ::std::any::Demand<'_demand>) {
+                 #provide
+             }
         }
     });
 
@@ -82,7 +82,7 @@ pub fn expand(
     let render = quote! {
         impl#impl_generics ::std::error::Error for #ident#ty_generics #where_clause {
             #source
-            #backtrace
+            #provide
         }
     };
 
@@ -96,9 +96,9 @@ fn render_struct(
     let parsed_fields = parse_fields(type_params, state)?;
 
     let source = parsed_fields.render_source_as_struct();
-    let backtrace = parsed_fields.render_backtrace_as_struct();
+    let provide = parsed_fields.render_provide_as_struct();
 
-    Ok((parsed_fields.bounds, source, backtrace))
+    Ok((parsed_fields.bounds, source, provide))
 }
 
 fn render_enum(
@@ -107,7 +107,7 @@ fn render_enum(
 ) -> Result<(HashSet<syn::Type>, Option<TokenStream>, Option<TokenStream>)> {
     let mut bounds = HashSet::default();
     let mut source_match_arms = Vec::new();
-    let mut backtrace_match_arms = Vec::new();
+    let mut provide_match_arms = Vec::new();
 
     for variant in state.enabled_variant_data().variants {
         let default_info = FullMetaInfo {
@@ -131,16 +131,16 @@ fn render_enum(
             source_match_arms.push(expr);
         }
 
-        if let Some(expr) = parsed_fields.render_backtrace_as_enum_variant_match_arm() {
-            backtrace_match_arms.push(expr);
+        if let Some(expr) = parsed_fields.render_provide_as_enum_variant_match_arm() {
+            provide_match_arms.push(expr);
         }
 
         bounds.extend(parsed_fields.bounds.into_iter());
     }
 
-    let render = |match_arms: &mut Vec<TokenStream>| {
+    let render = |match_arms: &mut Vec<TokenStream>, unmatched| {
         if !match_arms.is_empty() && match_arms.len() < state.variants.len() {
-            match_arms.push(quote!(_ => None));
+            match_arms.push(quote!(_ => #unmatched));
         }
 
         if !match_arms.is_empty() {
@@ -156,10 +156,10 @@ fn render_enum(
         }
     };
 
-    let source = render(&mut source_match_arms);
-    let backtrace = render(&mut backtrace_match_arms);
+    let source = render(&mut source_match_arms, quote!(None));
+    let provide = render(&mut provide_match_arms, quote!(()));
 
-    Ok((bounds, source, backtrace))
+    Ok((bounds, source, provide))
 }
 
 fn allowed_attr_params() -> AttrParams {
@@ -203,16 +203,68 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
         Some(quote!(#pattern => #expr))
     }
 
-    fn render_backtrace_as_struct(&self) -> Option<TokenStream> {
+    fn render_provide_as_struct(&self) -> Option<TokenStream> {
         let backtrace = self.backtrace?;
-        let backtrace_expr = &self.data.members[backtrace];
-        Some(quote!(Some(&#backtrace_expr)))
+
+        let source_provider = self.source.map(|source| {
+            let source_expr = &self.data.members[source];
+            quote! {
+                ::std::error::Error::provide(&#source_expr, demand);
+            }
+        });
+        let backtrace_provider =
+            if self.source.filter(|source| *source == backtrace).is_some() {
+                None
+            } else {
+                let backtrace_expr = &self.data.members[backtrace];
+                Some(quote! {
+                    demand.provide_ref::<std::backtrace::Backtrace>(&#backtrace_expr);
+                })
+            };
+
+        if source_provider.is_some() || backtrace_provider.is_some() {
+            Some(quote! {
+                #backtrace_provider
+                #source_provider
+            })
+        } else {
+            None
+        }
     }
 
-    fn render_backtrace_as_enum_variant_match_arm(&self) -> Option<TokenStream> {
+    fn render_provide_as_enum_variant_match_arm(&self) -> Option<TokenStream> {
         let backtrace = self.backtrace?;
-        let pattern = self.data.matcher(&[backtrace], &[quote!(backtrace)]);
-        Some(quote!(#pattern => Some(backtrace)))
+
+        match self.source {
+            Some(source) if source == backtrace => {
+                let pattern = self.data.matcher(&[source], &[quote!(source)]);
+                Some(quote!(
+                    #pattern => {
+                        ::std::error::Error::provide(source, demand);
+                    }
+                ))
+            }
+            Some(source) => {
+                let pattern = self.data.matcher(
+                    &[source, backtrace],
+                    &[quote!(source), quote!(backtrace)],
+                );
+                Some(quote!(
+                    #pattern => {
+                        demand.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                        ::std::error::Error::provide(source, demand);
+                    }
+                ))
+            }
+            None => {
+                let pattern = self.data.matcher(&[backtrace], &[quote!(backtrace)]);
+                Some(quote!(
+                    #pattern => {
+                        demand.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                    }
+                ))
+            }
+        }
     }
 }
 

--- a/tests/error/nightly/derives_for_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_enums_with_backtrace.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+
+use std::any;
+
 use super::*;
 
 derive_display!(TestErr);
@@ -53,6 +56,29 @@ enum TestErr {
         backtrace: Backtrace,
         field: i32,
     },
+    NamedImplicitNoBacktraceFromSource {
+        #[error(source)]
+        err: BacktraceErr,
+    },
+    NamedExplicitNoBacktraceFromSource {
+        #[error(source, not(backtrace))]
+        err: BacktraceErr,
+    },
+    NamedExplicitBacktraceFromSource {
+        #[error(backtrace, source)]
+        err: BacktraceErr,
+    },
+    NamedImplicitDifferentSourceAndBacktrace {
+        #[error(source)]
+        err: BacktraceErr,
+        backtrace: Backtrace,
+    },
+    NamedExplicitDifferentSourceAndBacktrace {
+        #[error(source)]
+        err: BacktraceErr,
+        #[error(backtrace)]
+        backtrace: Backtrace,
+    },
     UnnamedImplicitNoBacktrace(i32, i32),
     UnnamedImplicitBacktrace(Backtrace, i32, i32),
     UnnamedExplicitNoBacktrace(#[error(not(backtrace))] Backtrace, i32),
@@ -63,30 +89,50 @@ enum TestErr {
     ),
     UnnamedExplicitBacktraceRedundant(#[error(backtrace)] Backtrace, i32, i32),
     UnnamedExplicitSupressesImplicit(#[error(backtrace)] MyBacktrace, Backtrace, i32),
+    UnnamedImplicitNoBacktraceFromSource(BacktraceErr),
+    UnnamedExplicitNoBacktraceFromSource(#[error(not(backtrace))] BacktraceErr),
+    UnnamedExplicitBacktraceFromSource(#[error(backtrace)] BacktraceErr),
+    UnnamedImplicitDifferentSourceAndBacktrace(
+        #[error(source)] BacktraceErr,
+        Backtrace,
+    ),
+    UnnamedExplicitDifferentSourceAndBacktrace(
+        #[error(source)] BacktraceErr,
+        #[error(backtrace)] Backtrace,
+    ),
 }
 
 impl TestErr {
     fn get_stored_backtrace(&self) -> &Backtrace {
         match self {
-            Self::NamedImplicitBacktraceByFieldName { backtrace, .. } => backtrace,
-            Self::NamedImplicitBacktraceByFieldType {
-                implicit_backtrace, ..
-            } => implicit_backtrace,
-            Self::NamedExplicitBacktrace {
-                explicit_backtrace, ..
-            } => explicit_backtrace,
-            Self::NamedExplicitBacktraceByFieldNameRedundant { backtrace, .. } => {
+            Self::NamedImplicitBacktraceByFieldName { backtrace, .. }
+            | Self::NamedImplicitBacktraceByFieldType {
+                implicit_backtrace: backtrace,
+                ..
+            }
+            | Self::NamedExplicitBacktrace {
+                explicit_backtrace: backtrace,
+                ..
+            }
+            | Self::NamedExplicitBacktraceByFieldNameRedundant { backtrace, .. }
+            | Self::NamedExplicitBacktraceByFieldTypeRedundant {
+                implicit_backtrace: backtrace,
+                ..
+            }
+            | Self::NamedExplicitSupressesImplicit {
+                not_backtrace: backtrace,
+                ..
+            }
+            | Self::NamedImplicitDifferentSourceAndBacktrace { backtrace, .. }
+            | Self::NamedExplicitDifferentSourceAndBacktrace { backtrace, .. }
+            | Self::UnnamedImplicitBacktrace(backtrace, _, _)
+            | Self::UnnamedExplicitBacktrace(backtrace, _, _)
+            | Self::UnnamedExplicitBacktraceRedundant(backtrace, _, _)
+            | Self::UnnamedExplicitSupressesImplicit(backtrace, _, _)
+            | Self::UnnamedImplicitDifferentSourceAndBacktrace(_, backtrace)
+            | Self::UnnamedExplicitDifferentSourceAndBacktrace(_, backtrace) => {
                 backtrace
             }
-            Self::NamedExplicitBacktraceByFieldTypeRedundant {
-                implicit_backtrace,
-                ..
-            } => implicit_backtrace,
-            Self::NamedExplicitSupressesImplicit { not_backtrace, .. } => not_backtrace,
-            Self::UnnamedImplicitBacktrace(backtrace, _, _) => backtrace,
-            Self::UnnamedExplicitBacktrace(backtrace, _, _) => backtrace,
-            Self::UnnamedExplicitBacktraceRedundant(backtrace, _, _) => backtrace,
-            Self::UnnamedExplicitSupressesImplicit(backtrace, _, _) => backtrace,
             _ => panic!("ERROR IN TEST IMPLEMENTATION"),
         }
     }
@@ -98,20 +144,33 @@ impl TestErr {
             _ => panic!("ERROR IN TEST IMPLEMENTATION"),
         }
     }
+
+    fn get_source_backtrace(&self) -> &Backtrace {
+        any::request_ref(match self {
+            Self::NamedExplicitBacktraceFromSource { err }
+            | Self::NamedExplicitDifferentSourceAndBacktrace { err, .. }
+            | Self::NamedImplicitDifferentSourceAndBacktrace { err, .. }
+            | Self::UnnamedExplicitBacktraceFromSource(err)
+            | Self::UnnamedExplicitDifferentSourceAndBacktrace(err, ..)
+            | Self::UnnamedImplicitDifferentSourceAndBacktrace(err, ..) => err,
+            _ => panic!("ERROR IN TEST IMPLEMENTATION"),
+        })
+        .unwrap()
+    }
 }
 
 type MyBacktrace = Backtrace;
 
 #[test]
 fn unit() {
-    assert!(TestErr::Unit.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&TestErr::Unit).is_none());
 }
 
 #[test]
 fn named_implicit_no_backtrace() {
     let err = TestErr::NamedImplicitNoBacktrace { field: 0 };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -121,7 +180,7 @@ fn named_implicit_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -132,7 +191,7 @@ fn named_implicit_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -143,7 +202,7 @@ fn named_explicit_no_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -153,7 +212,7 @@ fn named_explicit_no_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -163,7 +222,7 @@ fn named_explicit_backtrace() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -174,7 +233,7 @@ fn named_explicit_no_backtrace_redundant() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -184,7 +243,7 @@ fn named_explicit_backtrace_by_field_name_redundant() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -195,7 +254,7 @@ fn named_explicit_backtrace_by_field_type_redundant() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -207,23 +266,95 @@ fn named_explicit_supresses_implicit() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
+}
+
+#[test]
+fn named_implicit_no_backtrace_from_source() {
+    let err = TestErr::NamedImplicitNoBacktraceFromSource {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn named_explicit_no_backtrace_from_source() {
+    let err = TestErr::NamedExplicitNoBacktraceFromSource {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn named_explicit_backtrace_from_source() {
+    let err = TestErr::NamedExplicitBacktraceFromSource {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_source_backtrace);
+}
+
+#[test]
+fn named_implicit_different_source_and_backtrace() {
+    let err = TestErr::NamedImplicitDifferentSourceAndBacktrace {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        backtrace: (|| Backtrace::force_capture())(), // ensure backtraces are different
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
+}
+
+#[test]
+fn named_explicit_different_source_and_backtrace() {
+    let err = TestErr::NamedExplicitDifferentSourceAndBacktrace {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        backtrace: (|| Backtrace::force_capture())(), // ensure backtraces are different
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
 }
 
 #[test]
 fn unnamed_implicit_no_backtrace() {
     let err = TestErr::UnnamedImplicitNoBacktrace(0, 0);
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_implicit_backtrace() {
     let err = TestErr::UnnamedImplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -231,14 +362,14 @@ fn unnamed_implicit_backtrace() {
 fn unnamed_explicit_no_backtrace() {
     let err = TestErr::UnnamedExplicitNoBacktrace(Backtrace::force_capture(), 0);
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_explicit_backtrace() {
     let err = TestErr::UnnamedExplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -247,7 +378,7 @@ fn unnamed_explicit_no_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitNoBacktraceRedundant(Backtrace::force_capture(), 0);
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -255,7 +386,7 @@ fn unnamed_explicit_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitBacktraceRedundant(Backtrace::force_capture(), 0, 0);
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -267,7 +398,73 @@ fn unnamed_explicit_supresses_implicit() {
         0,
     );
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
+}
+
+#[test]
+fn unnamed_implicit_no_backtrace_from_source() {
+    let err = TestErr::UnnamedImplicitNoBacktraceFromSource(BacktraceErr {
+        backtrace: Backtrace::force_capture(),
+    });
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn unnamed_explicit_no_backtrace_from_source() {
+    let err = TestErr::UnnamedExplicitNoBacktraceFromSource(BacktraceErr {
+        backtrace: Backtrace::force_capture(),
+    });
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn unnamed_explicit_backtrace_from_source() {
+    let err = TestErr::UnnamedExplicitBacktraceFromSource(BacktraceErr {
+        backtrace: Backtrace::force_capture(),
+    });
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_source_backtrace);
+}
+
+#[test]
+fn unnamed_implicit_different_source_and_backtrace() {
+    let err = TestErr::UnnamedImplicitDifferentSourceAndBacktrace(
+        BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        (|| Backtrace::force_capture())(), // ensure backtraces are different
+    );
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
+}
+
+#[test]
+fn unnamed_explicit_different_source_and_backtrace() {
+    let err = TestErr::UnnamedExplicitDifferentSourceAndBacktrace(
+        BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        (|| Backtrace::force_capture())(), // ensure backtraces are different
+    );
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
 }

--- a/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+
+use std::any;
+
 use super::*;
 
 derive_display!(TestErr, T);
@@ -104,14 +107,14 @@ type MyBacktrace = Backtrace;
 
 #[test]
 fn unit() {
-    assert!(TestErr::<i32>::Unit.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&TestErr::<i32>::Unit).is_none());
 }
 
 #[test]
 fn named_implicit_no_backtrace() {
     let err = TestErr::NamedImplicitNoBacktrace { field: 0 };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -121,7 +124,7 @@ fn named_implicit_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -132,7 +135,7 @@ fn named_implicit_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -143,7 +146,7 @@ fn named_explicit_no_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -153,7 +156,7 @@ fn named_explicit_no_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -163,7 +166,7 @@ fn named_explicit_backtrace() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -174,7 +177,7 @@ fn named_explicit_no_backtrace_redundant() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -184,7 +187,7 @@ fn named_explicit_backtrace_by_field_name_redundant() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -195,7 +198,7 @@ fn named_explicit_backtrace_by_field_type_redundant() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -207,7 +210,7 @@ fn named_explicit_supresses_implicit() {
         field: 0,
     };
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
 }
@@ -216,14 +219,14 @@ fn named_explicit_supresses_implicit() {
 fn unnamed_implicit_no_backtrace() {
     let err = TestErr::UnnamedImplicitNoBacktrace(0, 0);
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_implicit_backtrace() {
     let err = TestErr::UnnamedImplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -231,14 +234,14 @@ fn unnamed_implicit_backtrace() {
 fn unnamed_explicit_no_backtrace() {
     let err = TestErr::UnnamedExplicitNoBacktrace(Backtrace::force_capture(), 0);
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_explicit_backtrace() {
     let err = TestErr::UnnamedExplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -247,7 +250,7 @@ fn unnamed_explicit_no_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitNoBacktraceRedundant(Backtrace::force_capture(), 0);
 
-    assert!(err.backtrace().is_none());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -255,7 +258,7 @@ fn unnamed_explicit_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitBacktraceRedundant(Backtrace::force_capture(), 0, 0);
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -267,7 +270,208 @@ fn unnamed_explicit_supresses_implicit() {
         0,
     );
 
-    assert!(err.backtrace().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
+}
+
+derive_display!(BoundedTestErr, T);
+#[derive(Debug, Error)]
+enum BoundedTestErr<T> {
+    NamedImplicitNoBacktraceFromSource {
+        #[error(source)]
+        err: T,
+    },
+    NamedExplicitNoBacktraceFromSource {
+        #[error(source, not(backtrace))]
+        err: T,
+    },
+    NamedExplicitBacktraceFromSource {
+        #[error(backtrace, source)]
+        err: T,
+    },
+    NamedImplicitDifferentSourceAndBacktrace {
+        #[error(source)]
+        err: T,
+        backtrace: Backtrace,
+    },
+    NamedExplicitDifferentSourceAndBacktrace {
+        #[error(source)]
+        err: T,
+        #[error(backtrace)]
+        backtrace: Backtrace,
+    },
+    UnnamedImplicitNoBacktraceFromSource(T),
+    UnnamedExplicitNoBacktraceFromSource(#[error(not(backtrace))] T),
+    UnnamedExplicitBacktraceFromSource(#[error(backtrace)] T),
+    UnnamedImplicitDifferentSourceAndBacktrace(#[error(source)] T, Backtrace),
+    UnnamedExplicitDifferentSourceAndBacktrace(
+        #[error(source)] T,
+        #[error(backtrace)] Backtrace,
+    ),
+}
+
+impl<T: Error> BoundedTestErr<T> {
+    fn get_stored_backtrace(&self) -> &Backtrace {
+        match self {
+            Self::NamedImplicitDifferentSourceAndBacktrace { backtrace, .. }
+            | Self::NamedExplicitDifferentSourceAndBacktrace { backtrace, .. }
+            | Self::UnnamedImplicitDifferentSourceAndBacktrace(_, backtrace)
+            | Self::UnnamedExplicitDifferentSourceAndBacktrace(_, backtrace) => {
+                backtrace
+            }
+            _ => panic!("ERROR IN TEST IMPLEMENTATION"),
+        }
+    }
+
+    fn get_source_backtrace(&self) -> &Backtrace {
+        any::request_ref(match self {
+            Self::NamedExplicitBacktraceFromSource { err }
+            | Self::NamedExplicitDifferentSourceAndBacktrace { err, .. }
+            | Self::NamedImplicitDifferentSourceAndBacktrace { err, .. }
+            | Self::UnnamedExplicitBacktraceFromSource(err)
+            | Self::UnnamedExplicitDifferentSourceAndBacktrace(err, ..)
+            | Self::UnnamedImplicitDifferentSourceAndBacktrace(err, ..) => err,
+            _ => panic!("ERROR IN TEST IMPLEMENTATION"),
+        })
+        .unwrap()
+    }
+}
+
+#[test]
+fn named_implicit_no_backtrace_from_source() {
+    let err = BoundedTestErr::NamedImplicitNoBacktraceFromSource {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn named_explicit_no_backtrace_from_source() {
+    let err = BoundedTestErr::NamedExplicitNoBacktraceFromSource {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn named_explicit_backtrace_from_source() {
+    let err = BoundedTestErr::NamedExplicitBacktraceFromSource {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_source_backtrace);
+}
+
+#[test]
+fn named_implicit_different_source_and_backtrace() {
+    let err = BoundedTestErr::NamedImplicitDifferentSourceAndBacktrace {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        backtrace: (|| Backtrace::force_capture())(), // ensure backtraces are different
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
+}
+
+#[test]
+fn named_explicit_different_source_and_backtrace() {
+    let err = BoundedTestErr::NamedExplicitDifferentSourceAndBacktrace {
+        err: BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        backtrace: (|| Backtrace::force_capture())(), // ensure backtraces are different
+    };
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
+}
+
+#[test]
+fn unnamed_implicit_no_backtrace_from_source() {
+    let err = BoundedTestErr::UnnamedImplicitNoBacktraceFromSource(BacktraceErr {
+        backtrace: Backtrace::force_capture(),
+    });
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn unnamed_explicit_no_backtrace_from_source() {
+    let err = BoundedTestErr::UnnamedExplicitNoBacktraceFromSource(BacktraceErr {
+        backtrace: Backtrace::force_capture(),
+    });
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(any::request_value::<i32>(&err).is_none());
+}
+
+#[test]
+fn unnamed_explicit_backtrace_from_source() {
+    let err = BoundedTestErr::UnnamedExplicitBacktraceFromSource(BacktraceErr {
+        backtrace: Backtrace::force_capture(),
+    });
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_source_backtrace);
+}
+
+#[test]
+fn unnamed_implicit_different_source_and_backtrace() {
+    let err = BoundedTestErr::UnnamedImplicitDifferentSourceAndBacktrace(
+        BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        (|| Backtrace::force_capture())(), // ensure backtraces are different
+    );
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
+}
+
+#[test]
+fn unnamed_explicit_different_source_and_backtrace() {
+    let err = BoundedTestErr::UnnamedExplicitDifferentSourceAndBacktrace(
+        BacktraceErr {
+            backtrace: Backtrace::force_capture(),
+        },
+        (|| Backtrace::force_capture())(), // ensure backtraces are different
+    );
+
+    assert!(err.source().is_some());
+    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, .get_stored_backtrace);
+    assert_bt!(!=, err, .get_source_backtrace);
 }

--- a/tests/error/nightly/mod.rs
+++ b/tests/error/nightly/mod.rs
@@ -86,6 +86,8 @@ impl Default for BacktraceErr {
 
 impl Error for BacktraceErr {
     fn provide<'a>(&'a self, demand: &mut std::any::Demand<'a>) {
-        demand.provide_ref(&self.backtrace).provide_value(|| 42);
+        demand
+            .provide_ref::<Backtrace>(&self.backtrace)
+            .provide_value::<i32>(42);
     }
 }

--- a/tests/error/nightly/mod.rs
+++ b/tests/error/nightly/mod.rs
@@ -40,13 +40,19 @@ use super::*;
 /// ```
 macro_rules! assert_bt {
     (@impl $macro:ident, $error:expr, $backtrace:expr) => {
-        $macro!($error.backtrace().unwrap().to_string(), $backtrace.to_string());
+        $macro!(std::any::request_ref::<Backtrace>(&$error).unwrap().to_string(), $backtrace.to_string());
     };
     (@expand $macro:ident, $error:expr, .$backtrace:ident) => {
         assert_bt!(@impl $macro, $error, $error.$backtrace())
     };
-    (@expand $macro:ident, $error:expr, $backtrace:tt) => {
+    (@expand $macro:ident, $error:expr, .$backtrace:tt) => {
         assert_bt!(@impl $macro, $error, $error.$backtrace)
+    };
+    (@expand $macro:ident, $error:expr, $backtrace:ident) => {
+        assert_bt!(@impl $macro, $error, $error.$backtrace)
+    };
+    (@expand $macro:ident, $error:expr, $backtrace:expr) => {
+        assert_bt!(@impl $macro, $error, $backtrace)
     };
     (@expand $macro:ident, $error:expr) => {
         assert_bt!(@expand $macro, $error, backtrace)
@@ -79,7 +85,7 @@ impl Default for BacktraceErr {
 }
 
 impl Error for BacktraceErr {
-    fn backtrace(&self) -> Option<&Backtrace> {
-        Some(&self.backtrace)
+    fn provide<'a>(&'a self, demand: &mut std::any::Demand<'a>) {
+        demand.provide_ref(&self.backtrace).provide_value(|| 42);
     }
 }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(backtrace))]
+#![cfg_attr(feature = "nightly", feature(error_generic_member_access, provide_any))]
 
 #[macro_use]
 extern crate derive_more;


### PR DESCRIPTION
Fixes #195 similar to https://github.com/dtolnay/thiserror/pull/182