### PR TITLE
Use `#[automatically_derived]` attribute in each macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   practice.
 
 ### New features
+
 - Add support captured identifiers in `Display` derives. So now you can use:
   `#[display(fmt = "Prefix: {field}")]` instead of needing to use
   `#[display(fmt = "Prefix: {}", field)]`
@@ -26,7 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 
-- Generate doc comments for `Unwrap` and `IsVariant`
+- Generate doc comments for `Unwrap` and `IsVariant`.
+- Use `#[automatically_derived]` attribute in all macros' expansion for code
+  style linters to omit the generated code.
 
 ### Fixes
 

--- a/src/add_assign_like.rs
+++ b/src/add_assign_like.rs
@@ -30,11 +30,11 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     };
 
     quote!(
+        #[automatically_derived]
         impl #impl_generics ::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
             #[inline]
             fn #method_ident(&mut self, rhs: #input_type #ty_generics) {
-                #(#exprs;
-                  )*
+                #( #exprs; )*
             }
         }
     )

--- a/src/add_like.rs
+++ b/src/add_like.rs
@@ -39,8 +39,10 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     };
 
     quote!(
+        #[automatically_derived]
         impl #impl_generics ::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;
+
             #[inline]
             fn #method_ident(self, rhs: #input_type #ty_generics) -> #output_type {
                 #block

--- a/src/as_mut.rs
+++ b/src/as_mut.rs
@@ -71,9 +71,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let return_types = sub_items.iter().map(|i| &i.4);
 
     Ok(quote! {#(
-        impl #impl_genericses #trait_paths for #input_type #ty_generics
-        #where_clauses
-        {
+        #[automatically_derived]
+        impl #impl_genericses #trait_paths for #input_type #ty_generics #where_clauses {
             #[inline]
             fn as_mut(&mut self) -> &mut #return_types {
                 #bodies

--- a/src/as_ref.rs
+++ b/src/as_ref.rs
@@ -71,9 +71,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let return_types = sub_items.iter().map(|i| &i.4);
 
     Ok(quote! {#(
-        impl #impl_generics #trait_paths for #input_type #ty_generics
-        #where_clauses
-        {
+        #[automatically_derived]
+        impl #impl_generics #trait_paths for #input_type #ty_generics #where_clauses {
             #[inline]
             fn as_ref(&self) -> &#return_types {
                 #bodies

--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -25,7 +25,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
     };
     let original_types = &get_field_types(&fields);
     quote! {
-        #[allow(missing_docs)]
+        #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
             #[inline]
             pub fn new(#(#vars: #original_types),*) -> #input_type #ty_generics {

--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -25,6 +25,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
     };
     let original_types = &get_field_types(&fields);
     quote! {
+        #[allow(missing_docs)]
         #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
             #[inline]

--- a/src/deref.rs
+++ b/src/deref.rs
@@ -43,9 +43,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
-        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause
-        {
+        #[automatically_derived]
+        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             type Target = #target;
+
             #[inline]
             fn deref(&self) -> &Self::Target {
                 #body

--- a/src/deref_mut.rs
+++ b/src/deref_mut.rs
@@ -37,8 +37,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
-        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause
-        {
+        #[automatically_derived]
+        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]
             fn deref_mut(&mut self) -> &mut Self::Target {
                 #body

--- a/src/display.rs
+++ b/src/display.rs
@@ -64,9 +64,8 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> Result<TokenStream>
     };
 
     Ok(quote! {
-        impl #impl_generics #trait_path for #name #ty_generics #where_clause
-        {
-            #[allow(unused_variables)]
+        #[automatically_derived]
+        impl #impl_generics #trait_path for #name #ty_generics #where_clause {
             #[inline]
             fn fmt(&self, _derive_more_display_formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 #helper_struct

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,7 @@ pub fn expand(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let render = quote! {
+        #[automatically_derived]
         impl #impl_generics ::std::error::Error for #ident #ty_generics #where_clause {
             #source
             #provide

--- a/src/from_str.rs
+++ b/src/from_str.rs
@@ -43,9 +43,10 @@ pub fn struct_from(state: &State, trait_name: &'static str) -> TokenStream {
     let body = single_field_data.initializer(&initializers);
 
     quote! {
-        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause
-        {
+        #[automatically_derived]
+        impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             type Err = <#field_type as #trait_path>::Err;
+
             #[inline]
             fn from_str(src: &str) -> ::core::result::Result<Self, Self::Err> {
                 Ok(#body)

--- a/src/index.rs
+++ b/src/index.rs
@@ -38,9 +38,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = new_generics.split_for_impl();
     let (_, ty_generics, _) = input.generics.split_for_impl();
     Ok(quote! {
-        impl #impl_generics #trait_path_with_params for #input_type #ty_generics #where_clause
-        {
+        #[automatically_derived]
+        impl #impl_generics #trait_path_with_params for #input_type #ty_generics #where_clause {
             type Output = #casted_trait::Output;
+
             #[inline]
             fn index(&self, idx: #index_type) -> &Self::Output {
                 #casted_trait::index(&#member, idx)

--- a/src/index_mut.rs
+++ b/src/index_mut.rs
@@ -38,8 +38,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = new_generics.split_for_impl();
     let (_, ty_generics, _) = input.generics.split_for_impl();
     Ok(quote! {
-        impl #impl_generics #trait_path_with_params for #input_type #ty_generics #where_clause
-        {
+        #[automatically_derived]
+        impl #impl_generics #trait_path_with_params for #input_type #ty_generics #where_clause {
             #[inline]
             fn index_mut(&mut self, idx: #index_type) -> &mut Self::Output {
                 #casted_trait::index_mut(&mut #member, idx)

--- a/src/into.rs
+++ b/src/into.rs
@@ -68,9 +68,11 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
             (quote! {
                 #[automatically_derived]
-                impl #impl_generics ::core::convert::From<#reference_with_lifetime #input_type #ty_generics> for
-                    (#(#into_types),*) #where_clause {
-
+                impl #impl_generics
+                     ::core::convert::From<#reference_with_lifetime #input_type #ty_generics> for
+                     (#(#into_types),*)
+                     #where_clause
+                {
                     #[inline]
                     fn from(original: #reference_with_lifetime #input_type #ty_generics) -> Self {
                         (#(#initializers),*)

--- a/src/into_iterator.rs
+++ b/src/into_iterator.rs
@@ -43,10 +43,13 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         let casted_trait =
             &quote!(<#reference_with_lifetime #field_type as #trait_path>);
         let into_iterator = quote! {
-            impl #impl_generics #trait_path for #reference_with_lifetime #input_type #ty_generics #where_clause
+            #[automatically_derived]
+            impl #impl_generics #trait_path for #reference_with_lifetime #input_type #ty_generics
+                 #where_clause
             {
                 type Item = #casted_trait::Item;
                 type IntoIter = #casted_trait::IntoIter;
+
                 #[inline]
                 fn into_iter(self) -> Self::IntoIter {
                     #casted_trait::into_iter(#reference #member)

--- a/src/is_variant.rs
+++ b/src/is_variant.rs
@@ -57,7 +57,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
-        impl #imp_generics #enum_name #type_generics #where_clause{
+        #[automatically_derived]
+        impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*
         }
     };

--- a/src/mul_assign_like.rs
+++ b/src/mul_assign_like.rs
@@ -53,11 +53,11 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote!(
-        impl #impl_generics #trait_path<#scalar_ident> for #input_type #ty_generics #where_clause{
+        #[automatically_derived]
+        impl #impl_generics #trait_path<#scalar_ident> for #input_type #ty_generics #where_clause {
             #[inline]
             fn #method_ident(&mut self, rhs: #scalar_ident) {
-                #(#exprs;
-                  )*
+                #( #exprs; )*
             }
         }
     ))

--- a/src/mul_like.rs
+++ b/src/mul_like.rs
@@ -49,8 +49,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let body = multi_field_data.initializer(&initializers);
     let (impl_generics, _, where_clause) = generics.split_for_impl();
     Ok(quote!(
+        #[automatically_derived]
         impl #impl_generics  #trait_path_with_params for #input_type #ty_generics #where_clause {
             type Output = #input_type #ty_generics;
+
             #[inline]
             fn #method_ident(self, rhs: #scalar_ident) -> #input_type #ty_generics {
                 #body

--- a/src/not_like.rs
+++ b/src/not_like.rs
@@ -35,8 +35,10 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     };
 
     quote!(
+        #[automatically_derived]
         impl #impl_generics ::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;
+
             #[inline]
             fn #method_ident(self) -> #output_type {
                 #block

--- a/src/sum_like.rs
+++ b/src/sum_like.rs
@@ -46,6 +46,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let identity = multi_field_data.initializer(&initializers);
 
     Ok(quote!(
+        #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]
             fn #method_ident<I: ::core::iter::Iterator<Item = Self>>(iter: I) -> Self {

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -102,11 +102,14 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         };
 
         let try_from = quote! {
-            impl #impl_generics ::core::convert::TryFrom<#reference_with_lifetime #input_type #ty_generics> for
-                (#(#reference_with_lifetime #original_types),*) #where_clause {
+            #[automatically_derived]
+            impl #impl_generics
+                 ::core::convert::TryFrom<#reference_with_lifetime #input_type #ty_generics> for
+                 (#(#reference_with_lifetime #original_types),*)
+                 #where_clause
+            {
                 type Error = &'static str;
 
-                #[allow(unused_variables)]
                 #[inline]
                 fn try_from(value: #reference_with_lifetime #input_type #ty_generics) -> ::core::result::Result<Self, Self::Error> {
                     match value {

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -88,7 +88,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
-        impl #imp_generics #enum_name #type_generics #where_clause{
+        #[automatically_derived]
+        impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*
         }
     };


### PR DESCRIPTION
Revealed from https://github.com/JelteF/derive_more/pull/192#issuecomment-1152091758  


## Synopsis

The code, generated by `derive_more`, often becomes a subject of complains for strict style linters.

## Solution

Use `#[automatically_derived]` attribute on any generated code, so the code style linters will omit the generated code.