### PR TITLE
Use dedicated error type for TryInto errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
              | sh -s -- --git hobofan/cargo-nono
                         --tag $(curl -s https://api.github.com/repos/hobofan/cargo-nono/releases/latest
                                 | jq -r '.tag_name')
+             # TODO: Remove the latest Git tag detection above once this PR is merged:
+             #       https://github.com/japaric/trust/pull/137
 
       - run: cargo nono check --package derive_more
                    --no-default-features --features all_no_std

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Install cargo nono
         run: curl -LSfs https://japaric.github.io/trust/install.sh
              | sh -s -- --git hobofan/cargo-nono
+                        --tag $(curl -s https://api.github.com/repos/hobofan/cargo-nono/releases/latest
+                                | jq -r '.tag_name')
 
       - run: cargo nono check --package derive_more
                    --no-default-features --features all_no_std

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,21 @@ jobs:
 
       - run: cargo test --workspace --features testing-helpers
 
+  no_std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install cargo nono
+        run: curl -LSfs https://japaric.github.io/trust/install.sh
+             | sh -s -- --git hobofan/cargo-nono
+
+      - run: cargo nono check --package derive_more
+                   --no-default-features --features all_no_std
+
   test:
     strategy:
       fail-fast: false
@@ -146,6 +161,7 @@ jobs:
     needs:
       - clippy
       - msrv
+      - no_std
       - rustdoc
       - rustfmt
       - test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `From` derive doesn't derive `From<()>` for enum variants without any
   fields anymore. This feature was removed because it was considered useless in
   practice.
-- The TryFrom derive now return a dedicated error type instead of a
+- The `TryFrom` derive now returns a dedicated error type instead of a
   `&'static str` on error.
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `From` derive doesn't derive `From<()>` for enum variants without any
   fields anymore. This feature was removed because it was considered useless in
   practice.
+- The TryFrom derive now return a dedicated error type instead of a
+  `&'static str` on error.
 
 ### New features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ not = ["derive_more-impl/not"]
 sum = ["derive_more-impl/sum"]
 try_into = ["derive_more-impl/try_into"]
 is_variant = ["derive_more-impl/is_variant"]
+std = []
 unwrap = ["derive_more-impl/unwrap"]
 
 default = [
@@ -83,6 +84,7 @@ default = [
     "mul_assign",
     "mul",
     "not",
+    "std",
     "sum",
     "try_into",
     "is_variant",
@@ -228,6 +230,7 @@ required-features = [
     "index",
     "index_mut",
     "into",
+    "into_iterator",
     "mul_assign",
     "mul",
     "not",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ std = []
 unwrap = ["derive_more-impl/unwrap"]
 
 default = [
+    "all_no_std",
+    "std",
+]
+
+all_no_std = [
     "add_assign",
     "add",
     "as_mut",
@@ -80,15 +85,14 @@ default = [
     "index_mut",
     "into",
     "into_iterator",
+    "is_variant",
     "iterator",
     "mul_assign",
     "mul",
     "not",
-    "std",
     "sum",
     "try_into",
-    "is_variant",
-    "unwrap"
+    "unwrap",
 ]
 
 testing-helpers = ["derive_more-impl/testing-helpers"]

--- a/impl/doc/try_into.md
+++ b/impl/doc/try_into.md
@@ -24,20 +24,29 @@ variants you want to derive `TryInto` for.
 ```rust
 # use derive_more::TryInto;
 #
-#[derive(TryInto, Clone)]
+#[derive(TryInto, Debug, Clone)]
 #[try_into(owned, ref, ref_mut)]
 enum MixedData {
     Int(u32),
     String(String),
 }
 
-let string = MixedData::String("foo".to_string());
-let int = MixedData::Int(123);
-assert_eq!(Ok(123u32), int.clone().try_into());
-assert_eq!(Ok(&123u32), (&int.clone()).try_into());
-assert_eq!(Ok(&mut 123u32), (&mut int.clone()).try_into());
-assert_eq!("foo".to_string(), String::try_from(string.clone()).unwrap());
-assert!(u32::try_from(string).is_err());
+let mixed_string = MixedData::String("foo".to_string());
+let mixed_int1 = MixedData::Int(123);
+let mixed_int2 = mixed_int1.clone();
+let mut mixed_int3 = mixed_int1.clone();
+
+assert_eq!(123u32, mixed_int1.try_into().unwrap());
+
+let int_ref : &u32 = (&mixed_int2).try_into().unwrap();
+assert_eq!(&123u32, int_ref);
+
+let int_ref_mut : &mut u32 = (&mut mixed_int3).try_into().unwrap();
+assert_eq!(&mut 123u32, int_ref_mut);
+
+assert_eq!("foo".to_string(), String::try_from(mixed_string.clone()).unwrap());
+
+assert!(u32::try_from(mixed_string).is_err());
 ```
 
 

--- a/impl/doc/try_into.md
+++ b/impl/doc/try_into.md
@@ -24,7 +24,7 @@ variants you want to derive `TryInto` for.
 ```rust
 # use derive_more::TryInto;
 #
-#[derive(TryInto, Debug, Clone)]
+#[derive(TryInto, Clone, Debug)]
 #[try_into(owned, ref, ref_mut)]
 enum MixedData {
     Int(u32),

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -89,8 +89,6 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             })
             .collect::<Vec<_>>()
             .join(", ");
-        let message =
-            format!("Only {} can be converted to {}", variant_names, output_type);
 
         let generics_impl;
         let (_, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -108,13 +106,13 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                  (#(#reference_with_lifetime #original_types),*)
                  #where_clause
             {
-                type Error = &'static str;
+                type Error = ::derive_more::TryIntoError<#reference_with_lifetime #input_type>;
 
                 #[inline]
                 fn try_from(value: #reference_with_lifetime #input_type #ty_generics) -> ::core::result::Result<Self, Self::Error> {
                     match value {
                         #(#matchers)|* => ::core::result::Result::Ok(#vars),
-                        _ => ::core::result::Result::Err(#message),
+                        _ => ::core::result::Result::Err(::derive_more::TryIntoError::new(value, #variant_names, #output_type)),
                     }
                 }
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,13 +2,13 @@ use core::fmt;
 
 /// Error returned by the derived [`TryInto`] implementation.
 ///
-/// [`TryInto`]: crate::TryInto@macro
+/// [`TryInto`]: macro@crate::TryInto
 #[derive(Clone, Copy, Debug)]
 pub struct TryIntoError<T> {
     /// Original input value which failed to convert via the derived
     /// [`TryInto`] implementation.
     ///
-    /// [`TryInto`]: crate::TryInto@macro
+    /// [`TryInto`]: macro@crate::TryInto
     pub input: T,
     variant_names: &'static str,
     output_type: &'static str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,22 @@
 use core::fmt;
 
+/// Error returned by the derived [`TryInto`] implementation.
+///
+/// [`TryInto`]: crate::TryInto@macro
 #[derive(Clone, Copy, Debug)]
 pub struct TryIntoError<T> {
+    /// Original input value which failed to convert via the derived
+    /// [`TryInto`] implementation.
+    ///
+    /// [`TryInto`]: crate::TryInto@macro
     pub input: T,
     variant_names: &'static str,
     output_type: &'static str,
 }
 
 impl<T> TryIntoError<T> {
+    /// Creates a new [`TryIntoError`].
+    #[must_use]
     pub const fn new(
         input: T,
         variant_names: &'static str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,32 @@
+use core::fmt;
+
+#[derive(Debug)]
+pub struct TryIntoError<T> {
+    pub input: T,
+    variant_names: &'static str,
+    output_type: &'static str,
+}
+
+impl<T> TryIntoError<T> {
+    pub fn new(
+        input: T,
+        variant_names: &'static str,
+        output_type: &'static str,
+    ) -> TryIntoError<T> {
+        TryIntoError {
+            input,
+            variant_names,
+            output_type,
+        }
+    }
+}
+
+impl<T> fmt::Display for TryIntoError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Only {} can be converted to {}",
+            self.variant_names, self.output_type
+        )
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,12 +8,12 @@ pub struct TryIntoError<T> {
 }
 
 impl<T> TryIntoError<T> {
-    pub fn new(
+    pub const fn new(
         input: T,
         variant_names: &'static str,
         output_type: &'static str,
-    ) -> TryIntoError<T> {
-        TryIntoError {
+    ) -> Self {
+        Self {
             input,
             variant_names,
             output_type,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,7 @@ pub struct TryIntoError<T> {
 impl<T> TryIntoError<T> {
     /// Creates a new [`TryIntoError`].
     #[must_use]
+    #[inline]
     pub const fn new(
         input: T,
         variant_names: &'static str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,3 +40,6 @@ impl<T> fmt::Display for TryIntoError<T> {
         )
     }
 }
+
+#[cfg(feature = "std")]
+impl<T: fmt::Debug> ::std::error::Error for TryIntoError<T> {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TryIntoError<T> {
     pub input: T,
     variant_names: &'static str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,4 +42,4 @@ impl<T> fmt::Display for TryIntoError<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T: fmt::Debug> ::std::error::Error for TryIntoError<T> {}
+impl<T: fmt::Debug> std::error::Error for TryIntoError<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,5 +33,7 @@
 #[doc(inline)]
 pub use derive_more_impl::*;
 
+#[cfg(feature = "try_into")]
 mod errors;
+#[cfg(feature = "try_into")]
 pub use crate::errors::TryIntoError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,6 @@
 
 #[doc(inline)]
 pub use derive_more_impl::*;
+
+mod errors;
+pub use crate::errors::TryIntoError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 // These links overwrite the ones in `README.md`
 // to become proper intra-doc links in Rust docs.
 //! [`From`]: crate::From

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -14,7 +14,7 @@ enum MixedInts {
         int: i64,
     },
     UnsignedWithIgnoredField(#[try_into(ignore)] bool, i64),
-    NamedUnsignedWithIgnnoredField {
+    NamedUnsignedWithIgnoredField {
         #[try_into(ignore)]
         useless: bool,
         x: i64,
@@ -44,7 +44,7 @@ fn test_try_into() {
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!(i64::try_from(i).unwrap_err().input, MixedInts::SmallInt(42));
     assert_eq!(
@@ -99,7 +99,7 @@ fn test_try_into() {
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!((42i32, 64i32), i.try_into().unwrap());
     assert_eq!((&42i32, &64i32), (&i).try_into().unwrap());
@@ -124,7 +124,7 @@ fn test_try_into() {
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!(
         <(i32, i32)>::try_from(i).unwrap_err().to_string(),
@@ -149,7 +149,7 @@ fn test_try_into() {
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!(
         <(i32, i32)>::try_from(i).unwrap_err().to_string(),
@@ -177,11 +177,11 @@ fn test_try_into() {
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!(
         <(i32, i32)>::try_from(i).unwrap_err().to_string(),
@@ -209,7 +209,7 @@ fn test_try_into() {
     );
     assert_eq!(
         i64::try_from(i).unwrap_err().to_string(),
-        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnoredField can be converted to i64"
     );
     assert_eq!(
         <(i32, i32)>::try_from(i).unwrap_err().to_string(),

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -6,7 +6,7 @@ use derive_more::TryInto;
 // has been redefined.
 type Result = ();
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug, TryInto)]
+#[derive(TryInto, Clone, Copy, Debug, Eq, PartialEq)]
 #[try_into(owned, ref, ref_mut)]
 enum MixedInts {
     SmallInt(i32),

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -6,7 +6,7 @@ use derive_more::TryInto;
 // has been redefined.
 type Result = ();
 
-#[derive(Clone, Copy, TryInto)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, TryInto)]
 #[try_into(owned, ref, ref_mut)]
 enum MixedInts {
     SmallInt(i32),
@@ -36,161 +36,192 @@ enum MixedInts {
 #[test]
 fn test_try_into() {
     let mut i = MixedInts::SmallInt(42);
-    assert_eq!(Ok(42i32), i.try_into());
-    assert_eq!(Ok(&42i32), (&i).try_into());
-    assert_eq!(Ok(&mut 42i32), (&mut i).try_into());
+    assert_eq!(42i32, i.try_into().unwrap());
+    assert_eq!(&42i32, <_ as TryInto<&i32>>::try_into(&i).unwrap());
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        &mut 42i32,
+        <_ as TryInto<&mut i32>>::try_into(&mut i).unwrap()
     );
     assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
+    );
+    assert_eq!(i64::try_from(i).unwrap_err().input, MixedInts::SmallInt(42));
+    assert_eq!(
+        <(i32, i32)>::try_from(i).unwrap_err().to_string(),
+        "Only TwoSmallInts can be converted to (i32, i32)"
     );
     assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
+        <(i64, i64)>::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInts can be converted to (i64, i64)"
     );
     assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
+        u32::try_from(i).unwrap_err().to_string(),
+        "Only Unsigned, NamedUnsigned can be converted to u32"
     );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(
+        <()>::try_from(i).unwrap_err().to_string(),
+        "Only Unit can be converted to ()"
+    );
 
     let mut i = MixedInts::NamedBigInt { int: 42 };
     assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
+        i32::try_from(i).unwrap_err().to_string(),
+        "Only SmallInt can be converted to i32"
     );
-    assert_eq!(Ok(42i64), i.try_into());
-    assert_eq!(Ok(&42i64), (&i).try_into());
-    assert_eq!(Ok(&mut 42i64), (&mut i).try_into());
+    assert_eq!(42i64, i.try_into().unwrap());
+    assert_eq!(&42i64, <_ as TryInto<&i64>>::try_into(&i).unwrap());
     assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
-    );
-    assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
+        &mut 42i64,
+        <_ as TryInto<&mut i64>>::try_into(&mut i).unwrap()
     );
     assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
+        <(i32, i32)>::try_from(i).unwrap_err().to_string(),
+        "Only TwoSmallInts can be converted to (i32, i32)"
     );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(
+        <(i64, i64)>::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInts can be converted to (i64, i64)"
+    );
+    assert_eq!(
+        u32::try_from(i).unwrap_err().to_string(),
+        "Only Unsigned, NamedUnsigned can be converted to u32"
+    );
+    assert_eq!(
+        <()>::try_from(i).unwrap_err().to_string(),
+        "Only Unit can be converted to ()"
+    );
 
     let mut i = MixedInts::TwoSmallInts(42, 64);
     assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
+        i32::try_from(i).unwrap_err().to_string(),
+        "Only SmallInt can be converted to i32"
     );
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
     );
-    assert_eq!(Ok((42i32, 64i32)), i.try_into());
-    assert_eq!(Ok((&42i32, &64i32)), (&i).try_into());
-    assert_eq!(Ok((&mut 42i32, &mut 64i32)), (&mut i).try_into());
+    assert_eq!((42i32, 64i32), i.try_into().unwrap());
+    assert_eq!((&42i32, &64i32), (&i).try_into().unwrap());
+    assert_eq!((&mut 42i32, &mut 64i32), (&mut i).try_into().unwrap());
     assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
+        <(i64, i64)>::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInts can be converted to (i64, i64)"
     );
     assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
+        u32::try_from(i).unwrap_err().to_string(),
+        "Only Unsigned, NamedUnsigned can be converted to u32"
     );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(
+        <()>::try_from(i).unwrap_err().to_string(),
+        "Only Unit can be converted to ()"
+    );
 
     let mut i = MixedInts::NamedBigInts { x: 42, y: 64 };
     assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
+        i32::try_from(i).unwrap_err().to_string(),
+        "Only SmallInt can be converted to i32"
     );
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
     );
     assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
+        <(i32, i32)>::try_from(i).unwrap_err().to_string(),
+        "Only TwoSmallInts can be converted to (i32, i32)"
     );
-    assert_eq!(Ok((42i64, 64i64)), i.try_into());
-    assert_eq!(Ok((&42i64, &64i64)), (&i).try_into());
-    assert_eq!(Ok((&mut 42i64, &mut 64i64)), (&mut i).try_into());
+    assert_eq!((42i64, 64i64), i.try_into().unwrap());
+    assert_eq!((&42i64, &64i64), (&i).try_into().unwrap());
+    assert_eq!((&mut 42i64, &mut 64i64), (&mut i).try_into().unwrap());
     assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
+        u32::try_from(i).unwrap_err().to_string(),
+        "Only Unsigned, NamedUnsigned can be converted to u32"
     );
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(
+        <()>::try_from(i).unwrap_err().to_string(),
+        "Only Unit can be converted to ()"
+    );
 
     let mut i = MixedInts::Unsigned(42);
     assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
+        i32::try_from(i).unwrap_err().to_string(),
+        "Only SmallInt can be converted to i32"
     );
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
     );
     assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
+        <(i32, i32)>::try_from(i).unwrap_err().to_string(),
+        "Only TwoSmallInts can be converted to (i32, i32)"
     );
     assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
+        <(i64, i64)>::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInts can be converted to (i64, i64)"
     );
-    assert_eq!(Ok(42u32), i.try_into());
-    assert_eq!(Ok(&42u32), (&i).try_into());
-    assert_eq!(Ok(&mut 42u32), (&mut i).try_into());
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(42u32, i.try_into().unwrap());
+    assert_eq!(&42u32, <_ as TryInto<&u32>>::try_into(&i).unwrap());
+    assert_eq!(
+        &mut 42u32,
+        <_ as TryInto<&mut u32>>::try_into(&mut i).unwrap()
+    );
+    assert_eq!(
+        <()>::try_from(i).unwrap_err().to_string(),
+        "Only Unit can be converted to ()"
+    );
 
     let mut i = MixedInts::NamedUnsigned { x: 42 };
     assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
+        i32::try_from(i).unwrap_err().to_string(),
+        "Only SmallInt can be converted to i32"
     );
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
     );
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
     );
     assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
+        <(i32, i32)>::try_from(i).unwrap_err().to_string(),
+        "Only TwoSmallInts can be converted to (i32, i32)"
     );
     assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
+        <(i64, i64)>::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInts can be converted to (i64, i64)"
     );
-    assert_eq!(Ok(42u32), i.try_into());
-    assert_eq!(Ok(&42u32), (&i).try_into());
-    assert_eq!(Ok(&mut 42u32), (&mut i).try_into());
-    assert_eq!(<()>::try_from(i), Err("Only Unit can be converted to ()"));
+    assert_eq!(42u32, i.try_into().unwrap());
+    assert_eq!(&42u32, <_ as TryInto<&u32>>::try_into(&i).unwrap());
+    assert_eq!(
+        &mut 42u32,
+        <_ as TryInto<&mut u32>>::try_into(&mut i).unwrap()
+    );
+    assert_eq!(
+        <()>::try_from(i).unwrap_err().to_string(),
+        "Only Unit can be converted to ()"
+    );
 
     let i = MixedInts::Unit;
     assert_eq!(
-        i32::try_from(i),
-        Err("Only SmallInt can be converted to i32")
+        i32::try_from(i).unwrap_err().to_string(),
+        "Only SmallInt can be converted to i32"
     );
     assert_eq!(
-        i64::try_from(i),
-        Err("Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64")
+        i64::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInt, UnsignedWithIgnoredField, NamedUnsignedWithIgnnoredField can be converted to i64"
     );
     assert_eq!(
-        <(i32, i32)>::try_from(i),
-        Err("Only TwoSmallInts can be converted to (i32, i32)")
+        <(i32, i32)>::try_from(i).unwrap_err().to_string(),
+        "Only TwoSmallInts can be converted to (i32, i32)"
     );
     assert_eq!(
-        <(i64, i64)>::try_from(i),
-        Err("Only NamedBigInts can be converted to (i64, i64)")
+        <(i64, i64)>::try_from(i).unwrap_err().to_string(),
+        "Only NamedBigInts can be converted to (i64, i64)"
     );
     assert_eq!(
-        u32::try_from(i),
-        Err("Only Unsigned, NamedUnsigned can be converted to u32")
+        u32::try_from(i).unwrap_err().to_string(),
+        "Only Unsigned, NamedUnsigned can be converted to u32"
     );
-    assert_eq!(Ok(()), i.try_into());
+    assert_eq!((), i.try_into().unwrap());
 }


### PR DESCRIPTION
Instead of returning a string as the error, this returns a dedicated
error type. This has the big benefit that in case of an error it's
possible to get back the original value by using `error.input`.
Previously the original value would be dropped in case of an error.

Fixes #173
Fixes #130
