### PR TITLE
Tune up code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ struct Point2D {
 
 #[derive(PartialEq, From, Add, Display)]
 enum MyEnum {
-    #[display(fmt = "int: {}", _0)]
+    #[display(fmt = "int: {_0}")]
     Int(i32),
     Uint(u32),
     #[display(fmt = "nothing")]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,21 @@
+# Project configuration for Clippy Rust code linter.
+# See full lints list at:
+# https://rust-lang.github.io/rust-clippy/master/index.html
+
 msrv = "1.65.0"
+standard-macro-braces = [
+    { name = "assert", brace = "(" },
+    { name = "assert_eq", brace = "(" },
+    { name = "assert_ne", brace = "(" },
+    { name = "format", brace = "(" },
+    { name = "format_ident", brace = "(" },
+    { name = "matches", brace = "(" },
+    { name = "panic", brace = "(" },
+    { name = "parse_quote", brace = "{" },
+    { name = "quote", brace = "{" },
+    { name = "quote_spanned", brace = "{" },
+    { name = "todo", brace = "(" },
+    { name = "unimplemented", brace = "(" },
+    { name = "unreachable", brace = "(" },
+    { name = "vec", brace = "[" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,13 +3,15 @@
 # https://rust-lang.github.io/rust-clippy/master/index.html
 
 msrv = "1.65.0"
+
+# Ensures consistent bracing for macro calls in the codebase.
+# Extends default settings:
+# https://github.com/rust-lang/rust-clippy/blob/master/clippy_lints/src/nonstandard_macro_braces.rs#L143-L184
 standard-macro-braces = [
     { name = "assert", brace = "(" },
     { name = "assert_eq", brace = "(" },
     { name = "assert_ne", brace = "(" },
-    { name = "format", brace = "(" },
     { name = "format_ident", brace = "(" },
-    { name = "matches", brace = "(" },
     { name = "panic", brace = "(" },
     { name = "parse_quote", brace = "{" },
     { name = "quote", brace = "{" },
@@ -17,5 +19,4 @@ standard-macro-braces = [
     { name = "todo", brace = "(" },
     { name = "unimplemented", brace = "(" },
     { name = "unreachable", brace = "(" },
-    { name = "vec", brace = "[" },
 ]

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -6,9 +6,7 @@ use syn::{Data, DeriveInput, Fields};
 
 pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let trait_ident = format_ident!("{trait_name}");
-    let method_name = trait_name.to_string();
-    let method_name = method_name.trim_end_matches("Assign");
-    let method_name = method_name.to_lowercase();
+    let method_name = trait_name.trim_end_matches("Assign").to_lowercase();
     let method_ident = format_ident!("{method_name}_assign");
     let input_type = &input.ident;
 

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -1,15 +1,15 @@
 use crate::add_helpers::{struct_exprs, tuple_exprs};
 use crate::utils::{add_extra_ty_param_bound_op, named_to_vec, unnamed_to_vec};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{Data, DeriveInput, Fields, Ident};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Fields};
 
 pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
-    let trait_ident = Ident::new(trait_name, Span::call_site());
+    let trait_ident = format_ident!("{trait_name}");
     let method_name = trait_name.to_string();
     let method_name = method_name.trim_end_matches("Assign");
     let method_name = method_name.to_lowercase();
-    let method_ident = Ident::new(&(method_name + "_assign"), Span::call_site());
+    let method_ident = format_ident!("{method_name}_assign");
     let input_type = &input.ident;
 
     let generics = add_extra_ty_param_bound_op(&input.generics, &trait_ident);

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -27,7 +27,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
         _ => panic!("Only structs can use derive({trait_name})"),
     };
 
-    quote!(
+    quote! {
         #[automatically_derived]
         impl #impl_generics ::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
             #[inline]
@@ -35,5 +35,5 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
                 #( #exprs; )*
             }
         }
-    )
+    }
 }

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -23,10 +23,10 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
             Fields::Named(ref fields) => {
                 struct_exprs(&named_to_vec(fields), &method_ident)
             }
-            _ => panic!("Unit structs cannot use derive({})", trait_name),
+            _ => panic!("Unit structs cannot use derive({trait_name})"),
         },
 
-        _ => panic!("Only structs can use derive({})", trait_name),
+        _ => panic!("Only structs can use derive({trait_name})"),
     };
 
     quote!(

--- a/impl/src/add_helpers.rs
+++ b/impl/src/add_helpers.rs
@@ -8,7 +8,7 @@ pub fn tuple_exprs(fields: &[&Field], method_ident: &Ident) -> Vec<TokenStream> 
     for i in 0..fields.len() {
         let i = Index::from(i);
         // generates `self.0.add(rhs.0)`
-        let expr = quote!(self.#i.#method_ident(rhs.#i));
+        let expr = quote! { self.#i.#method_ident(rhs.#i) };
         exprs.push(expr);
     }
     exprs
@@ -21,7 +21,7 @@ pub fn struct_exprs(fields: &[&Field], method_ident: &Ident) -> Vec<TokenStream>
         // It's safe to unwrap because struct fields always have an identifier
         let field_id = field.ident.as_ref().unwrap();
         // generates `x: self.x.add(rhs.x)`
-        let expr = quote!(self.#field_id.#method_ident(rhs.#field_id));
+        let expr = quote! { self.#field_id.#method_ident(rhs.#field_id) };
         exprs.push(expr)
     }
     exprs

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -3,16 +3,16 @@ use crate::utils::{
     add_extra_type_param_bound_op_output, field_idents, named_to_vec, numbered_vars,
     unnamed_to_vec,
 };
-use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
 use std::iter;
 use syn::{Data, DataEnum, DeriveInput, Field, Fields, Ident};
 
 pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     let trait_name = trait_name.trim_end_matches("Self");
-    let trait_ident = Ident::new(trait_name, Span::call_site());
+    let trait_ident = format_ident!("{trait_name}");
     let method_name = trait_name.to_lowercase();
-    let method_ident = Ident::new(&method_name, Span::call_site());
+    let method_ident = format_ident!("{method_name}");
     let input_type = &input.ident;
 
     let generics = add_extra_type_param_bound_op_output(&input.generics, &trait_ident);

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -28,14 +28,14 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
                 quote!(#input_type #ty_generics),
                 struct_content(input_type, &named_to_vec(fields), &method_ident),
             ),
-            _ => panic!("Unit structs cannot use derive({})", trait_name),
+            _ => panic!("Unit structs cannot use derive({trait_name})"),
         },
         Data::Enum(ref data_enum) => (
             quote!(::core::result::Result<#input_type #ty_generics, &'static str>),
             enum_content(input_type, data_enum, &method_ident),
         ),
 
-        _ => panic!("Only structs and enums can use derive({})", trait_name),
+        _ => panic!("Only structs and enums can use derive({trait_name})"),
     };
 
     quote!(
@@ -121,7 +121,7 @@ fn enum_content(
                 matches.push(matcher);
             }
             Fields::Unit => {
-                let message = format!("Cannot {}() unit variants", method_ident);
+                let message = format!("Cannot {method_ident}() unit variants");
                 matches.push(quote!((#subtype, #subtype) => ::core::result::Result::Err(#message)));
             }
         }
@@ -130,7 +130,7 @@ fn enum_content(
     if data_enum.variants.len() > 1 {
         // In the strange case where there's only one enum variant this is would be an unreachable
         // match.
-        let message = format!("Trying to {} mismatched enum variants", method_ident);
+        let message = format!("Trying to {method_ident} mismatched enum variants");
         matches.push(quote!(_ => ::core::result::Result::Err(#message)));
     }
     quote!(

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -87,7 +87,7 @@ fn enum_content(
 
         match variant.fields {
             Fields::Unnamed(ref fields) => {
-                // The patern that is outputted should look like this:
+                // The pattern that is outputted should look like this:
                 // (Subtype(left_vars), TypePath(right_vars)) => Ok(TypePath(exprs))
                 let size = unnamed_to_vec(fields).len();
                 let l_vars = &numbered_vars(size, "l_");

--- a/impl/src/as_mut.rs
+++ b/impl/src/as_mut.rs
@@ -11,7 +11,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(::core::convert),
-        String::from("as_mut"),
+        "as_mut".into(),
         AttrParams::ignore_and_forward(),
         false,
     )?;

--- a/impl/src/as_mut.rs
+++ b/impl/src/as_mut.rs
@@ -10,7 +10,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_type_bound(
         input,
         trait_name,
-        quote!(::core::convert),
+        quote! { ::core::convert },
         "as_mut".into(),
         AttrParams::ignore_and_forward(),
         false,
@@ -33,7 +33,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         .map(|((info, member), field)| {
             let field_type = &field.ty;
             if info.forward {
-                let trait_path = quote!(#trait_path<#as_mut_type>);
+                let trait_path = quote! { #trait_path<#as_mut_type> };
                 let type_where_clauses = quote! {
                     where #field_type: #trait_path
                 };
@@ -45,21 +45,21 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                     false,
                 );
                 let (impl_generics, _, where_clause) = new_generics.split_for_impl();
-                let casted_trait = quote!(<#field_type as #trait_path>);
+                let casted_trait = quote! { <#field_type as #trait_path> };
                 (
-                    quote!(#casted_trait::as_mut(&mut #member)),
-                    quote!(#impl_generics),
-                    quote!(#where_clause),
-                    quote!(#trait_path),
-                    quote!(#as_mut_type),
+                    quote! { #casted_trait::as_mut(&mut #member) },
+                    quote! { #impl_generics },
+                    quote! { #where_clause },
+                    quote! { #trait_path },
+                    quote! { #as_mut_type },
                 )
             } else {
                 (
-                    quote!(&mut #member),
-                    quote!(#impl_generics),
-                    quote!(#where_clause),
-                    quote!(#trait_path<#field_type>),
-                    quote!(#field_type),
+                    quote! { &mut #member },
+                    quote! { #impl_generics },
+                    quote! { #where_clause },
+                    quote! { #trait_path<#field_type> },
+                    quote! { #field_type },
                 )
             }
         })

--- a/impl/src/as_mut.rs
+++ b/impl/src/as_mut.rs
@@ -1,12 +1,12 @@
 use crate::utils::{
     add_where_clauses_for_new_ident, AttrParams, MultiFieldData, State,
 };
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{parse::Result, DeriveInput, Ident};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse::Result, DeriveInput};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
-    let as_mut_type = &Ident::new("__AsMutT", Span::call_site());
+    let as_mut_type = format_ident!("__AsMutT");
     let state = State::with_type_bound(
         input,
         trait_name,
@@ -40,7 +40,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                 let new_generics = add_where_clauses_for_new_ident(
                     &input.generics,
                     &[field],
-                    as_mut_type,
+                    &as_mut_type,
                     type_where_clauses,
                     false,
                 );

--- a/impl/src/as_ref.rs
+++ b/impl/src/as_ref.rs
@@ -11,7 +11,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(::core::convert),
-        String::from("as_ref"),
+        "as_ref".into(),
         AttrParams::ignore_and_forward(),
         false,
     )?;

--- a/impl/src/as_ref.rs
+++ b/impl/src/as_ref.rs
@@ -1,12 +1,12 @@
 use crate::utils::{
     add_where_clauses_for_new_ident, AttrParams, MultiFieldData, State,
 };
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{parse::Result, DeriveInput, Ident};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse::Result, DeriveInput};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
-    let as_ref_type = &Ident::new("__AsRefT", Span::call_site());
+    let as_ref_type = format_ident!("__AsRefT");
     let state = State::with_type_bound(
         input,
         trait_name,
@@ -40,7 +40,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                 let new_generics = add_where_clauses_for_new_ident(
                     &input.generics,
                     &[field],
-                    as_ref_type,
+                    &as_ref_type,
                     type_where_clauses,
                     false,
                 );

--- a/impl/src/as_ref.rs
+++ b/impl/src/as_ref.rs
@@ -10,7 +10,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_type_bound(
         input,
         trait_name,
-        quote!(::core::convert),
+        quote! { ::core::convert },
         "as_ref".into(),
         AttrParams::ignore_and_forward(),
         false,
@@ -33,7 +33,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         .map(|((info, member), field)| {
             let field_type = &field.ty;
             if info.forward {
-                let trait_path = quote!(#trait_path<#as_ref_type>);
+                let trait_path = quote! { #trait_path<#as_ref_type> };
                 let type_where_clauses = quote! {
                     where #field_type: #trait_path
                 };
@@ -45,21 +45,21 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                     false,
                 );
                 let (impl_generics, _, where_clause) = new_generics.split_for_impl();
-                let casted_trait = quote!(<#field_type as #trait_path>);
+                let casted_trait = quote! { <#field_type as #trait_path> };
                 (
-                    quote!(#casted_trait::as_ref(&#member)),
-                    quote!(#impl_generics),
-                    quote!(#where_clause),
-                    quote!(#trait_path),
-                    quote!(#as_ref_type),
+                    quote! { #casted_trait::as_ref(&#member) },
+                    quote! { #impl_generics },
+                    quote! { #where_clause },
+                    quote! { #trait_path },
+                    quote! { #as_ref_type },
                 )
             } else {
                 (
-                    quote!(&#member),
-                    quote!(#impl_generics),
-                    quote!(#where_clause),
-                    quote!(#trait_path<#field_type>),
-                    quote!(#field_type),
+                    quote! { &#member },
+                    quote! { #impl_generics },
+                    quote! { #where_clause },
+                    quote! { #trait_path<#field_type> },
+                    quote! { #field_type },
                 )
             }
         })

--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -38,7 +38,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
 
 fn tuple_body(return_type: &Ident, fields: &[&Field]) -> (TokenStream, Vec<Ident>) {
     let vars = &numbered_vars(fields.len(), "");
-    (quote!(#return_type(#(#vars),*)), vars.clone())
+    (quote! { #return_type(#(#vars),*) }, vars.clone())
 }
 
 fn struct_body(return_type: &Ident, fields: &[&Field]) -> (TokenStream, Vec<Ident>) {
@@ -46,5 +46,5 @@ fn struct_body(return_type: &Ident, fields: &[&Field]) -> (TokenStream, Vec<Iden
         &field_idents(fields).iter().map(|f| (**f).clone()).collect();
     let vars = field_names;
     let ret_vars = field_names.clone();
-    (quote!(#return_type{#(#field_names: #vars),*}), ret_vars)
+    (quote! { #return_type{#(#field_names: #vars),*} }, ret_vars)
 }

--- a/impl/src/deref.rs
+++ b/impl/src/deref.rs
@@ -8,7 +8,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_field_ignore_and_forward(
         input,
         trait_name,
-        quote!(::core::ops),
+        quote! { ::core::ops },
         trait_name.to_lowercase(),
     )?;
     let SingleFieldData {
@@ -24,8 +24,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let (target, body, generics) = if info.forward {
         (
-            quote!(#casted_trait::Target),
-            quote!(#casted_trait::deref(&#member)),
+            quote! { #casted_trait::Target },
+            quote! { #casted_trait::deref(&#member) },
             add_extra_where_clauses(
                 &input.generics,
                 quote! {
@@ -35,8 +35,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         )
     } else {
         (
-            quote!(#field_type),
-            quote!(&#member),
+            quote! { #field_type },
+            quote! { &#member },
             input.generics.clone(),
         )
     };

--- a/impl/src/deref_mut.rs
+++ b/impl/src/deref_mut.rs
@@ -9,7 +9,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(::core::ops),
-        String::from("deref_mut"),
+        "deref_mut".into(),
     )?;
     let SingleFieldData {
         input_type,

--- a/impl/src/deref_mut.rs
+++ b/impl/src/deref_mut.rs
@@ -8,7 +8,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_field_ignore_and_forward(
         input,
         trait_name,
-        quote!(::core::ops),
+        quote! { ::core::ops },
         "deref_mut".into(),
     )?;
     let SingleFieldData {
@@ -23,7 +23,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     } = state.assert_single_enabled_field();
     let (body, generics) = if info.forward {
         (
-            quote!(#casted_trait::deref_mut(&mut #member)),
+            quote! { #casted_trait::deref_mut(&mut #member) },
             add_extra_where_clauses(
                 &input.generics,
                 quote! {
@@ -32,7 +32,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             ),
         )
     } else {
-        (quote!(&mut #member), input.generics.clone())
+        (quote! { &mut #member }, input.generics.clone())
     };
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 

--- a/impl/src/display.rs
+++ b/impl/src/display.rs
@@ -763,7 +763,7 @@ impl<'a> From<parsing::Argument<'a>> for Parameter {
     fn from(arg: parsing::Argument<'a>) -> Self {
         match arg {
             parsing::Argument::Integer(i) => Parameter::Positional(i),
-            parsing::Argument::Identifier(i) => Parameter::Named(i.to_owned()),
+            parsing::Argument::Identifier(i) => Parameter::Named(i.into()),
         }
     }
 }
@@ -861,14 +861,14 @@ mod placeholder_parse_fmt_string_spec {
                     trait_name: "LowerHex",
                 },
                 Placeholder {
-                    arg: Parameter::Named("par".to_owned()),
+                    arg: Parameter::Named("par".into()),
                     width: None,
                     precision: None,
                     trait_name: "Debug",
                 },
                 Placeholder {
                     arg: Parameter::Positional(2),
-                    width: Some(Parameter::Named("width".to_owned())),
+                    width: Some(Parameter::Named("width".into())),
                     precision: None,
                     trait_name: "Display",
                 },

--- a/impl/src/display.rs
+++ b/impl/src/display.rs
@@ -184,13 +184,13 @@ impl<'a, 'b> State<'a, 'b> {
     fn get_proper_fmt_syntax(&self) -> impl Display {
         format!(
             r#"Proper syntax: #[{}(fmt = "My format", "arg1", "arg2")]"#,
-            self.trait_attr
+            self.trait_attr,
         )
     }
     fn get_proper_bound_syntax(&self) -> impl Display {
         format!(
             "Proper syntax: #[{}(bound = \"T, U: Trait1 + Trait2, V: Trait3\")]",
-            self.trait_attr
+            self.trait_attr,
         )
     }
 
@@ -346,7 +346,7 @@ impl<'a, 'b> State<'a, 'b> {
             if bounds.is_empty() {
                 return Err(Error::new(
                     span,
-                    format!("No bounds specified for type parameter {}", ident),
+                    format!("No bounds specified for type parameter {ident}"),
                 ));
             }
         }
@@ -644,7 +644,7 @@ impl<'a, 'b> State<'a, 'b> {
                                 .ident
                                 .clone()
                                 .unwrap_or_else(|| {
-                                    Ident::new(&format!("_{}", i), Span::call_site())
+                                    Ident::new(&format!("_{i}"), Span::call_site())
                                 })
                                 .into(),
                             ty,

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -18,7 +18,7 @@ pub fn expand(
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!(::std::error),
+        quote! { ::std::error },
         trait_name.to_lowercase(),
         allowed_attr_params(),
     )?;
@@ -141,7 +141,7 @@ fn render_enum(
 
     let render = |match_arms: &mut Vec<TokenStream>, unmatched| {
         if !match_arms.is_empty() && match_arms.len() < state.variants.len() {
-            match_arms.push(quote!(_ => #unmatched));
+            match_arms.push(quote! { _ => #unmatched });
         }
 
         (!match_arms.is_empty()).then(|| {
@@ -153,8 +153,8 @@ fn render_enum(
         })
     };
 
-    let source = render(&mut source_match_arms, quote!(None));
-    let provide = render(&mut provide_match_arms, quote!(()));
+    let source = render(&mut source_match_arms, quote! { None });
+    let provide = render(&mut provide_match_arms, quote! { () });
 
     Ok((bounds, source, provide))
 }
@@ -190,14 +190,14 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
     fn render_source_as_struct(&self) -> Option<TokenStream> {
         let source = self.source?;
         let ident = &self.data.members[source];
-        Some(render_some(quote!(&#ident)))
+        Some(render_some(quote! { &#ident }))
     }
 
     fn render_source_as_enum_variant_match_arm(&self) -> Option<TokenStream> {
         let source = self.source?;
-        let pattern = self.data.matcher(&[source], &[quote!(source)]);
-        let expr = render_some(quote!(source));
-        Some(quote!(#pattern => #expr))
+        let pattern = self.data.matcher(&[source], &[quote! { source }]);
+        let expr = render_some(quote! { source });
+        Some(quote! { #pattern => #expr })
     }
 
     fn render_provide_as_struct(&self) -> Option<TokenStream> {
@@ -233,7 +233,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
 
         match self.source {
             Some(source) if source == backtrace => {
-                let pattern = self.data.matcher(&[source], &[quote!(source)]);
+                let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
                         ::std::error::Error::provide(source, demand);
@@ -243,7 +243,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
             Some(source) => {
                 let pattern = self.data.matcher(
                     &[source, backtrace],
-                    &[quote!(source), quote!(backtrace)],
+                    &[quote! { source }, quote! { backtrace }],
                 );
                 Some(quote! {
                     #pattern => {
@@ -253,7 +253,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 })
             }
             None => {
-                let pattern = self.data.matcher(&[backtrace], &[quote!(backtrace)]);
+                let pattern = self.data.matcher(&[backtrace], &[quote! { backtrace }]);
                 Some(quote! {
                     #pattern => {
                         demand.provide_ref::<std::backtrace::Backtrace>(backtrace);
@@ -268,7 +268,7 @@ fn render_some<T>(expr: T) -> TokenStream
 where
     T: quote::ToTokens,
 {
-    quote!(Some(#expr as &(dyn ::std::error::Error + 'static)))
+    quote! { Some(#expr as &(dyn ::std::error::Error + 'static)) }
 }
 
 fn parse_fields<'input, 'state>(

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -330,19 +330,17 @@ fn parse_fields<'input, 'state>(
 /// Checks if `ty` is [`syn::Type::Path`] and ends with segment matching `tail`
 /// and doesn't contain any generic parameters.
 fn is_type_path_ends_with_segment(ty: &syn::Type, tail: &str) -> bool {
-    let ty = match ty {
-        syn::Type::Path(ty) => ty,
-        _ => return false,
+    let syn::Type::Path(ty) = ty else {
+        return false;
     };
 
     // Unwrapping is safe, cause 'syn::TypePath.path.segments'
     // have to have at least one segment
     let segment = ty.path.segments.last().unwrap();
 
-    match segment.arguments {
-        syn::PathArguments::None => (),
-        _ => return false,
-    };
+    if !matches!(segment.arguments, syn::PathArguments::None) {
+        return false;
+    }
 
     segment.ident == tail
 }
@@ -463,9 +461,8 @@ fn assert_iter_contains_zero_or_one_item<'a>(
     mut iter: impl Iterator<Item = (usize, &'a syn::Field, &'a MetaInfo)>,
     error_msg: &str,
 ) -> Result<Option<(usize, &'a syn::Field, &'a MetaInfo)>> {
-    let item = match iter.next() {
-        Some(item) => item,
-        None => return Ok(None),
+    let Some(item) = iter.next() else {
+        return Ok(None);
     };
 
     if let Some((_, field, _)) = iter.next() {

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -439,9 +439,8 @@ where
     let field = assert_iter_contains_zero_or_one_item(
         explicit_fields,
         &format!(
-            "Multiple `{}` attributes specified. \
+            "Multiple `{attr}` attributes specified. \
              Single attribute per struct/enum variant allowed.",
-            attr
         ),
     )?;
 

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -1,8 +1,8 @@
 use std::iter;
 
-use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
-use syn::{parse::Result, DeriveInput, Ident, Index};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{parse::Result, DeriveInput, Index};
 
 use crate::utils::{
     add_where_clauses_for_new_ident, AttrParams, DeriveType, HashMap, MultiFieldData,
@@ -62,7 +62,7 @@ pub fn struct_from(input: &DeriveInput, state: &State) -> TokenStream {
                 });
                 from_types.push(quote! { #type_ });
             } else if info.forward {
-                let type_param = &Ident::new(&format!("__FromT{i}"), Span::call_site());
+                let type_param = format_ident!("__FromT{i}");
                 let sub_trait_path = quote! { #trait_path<#type_param> };
                 let type_where_clauses = quote! {
                     where #field_type: #sub_trait_path
@@ -70,7 +70,7 @@ pub fn struct_from(input: &DeriveInput, state: &State) -> TokenStream {
                 new_generics = add_where_clauses_for_new_ident(
                     &new_generics,
                     &[field],
-                    type_param,
+                    &type_param,
                     type_where_clauses,
                     true,
                 );

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -62,8 +62,7 @@ pub fn struct_from(input: &DeriveInput, state: &State) -> TokenStream {
                 });
                 from_types.push(quote! { #type_ });
             } else if info.forward {
-                let type_param =
-                    &Ident::new(&format!("__FromT{}", i), Span::call_site());
+                let type_param = &Ident::new(&format!("__FromT{i}"), Span::call_site());
                 let sub_trait_path = quote! { #trait_path<#type_param> };
                 let type_where_clauses = quote! {
                     where #field_type: #sub_trait_path

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -14,7 +14,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!(::core::convert),
+        quote! { ::core::convert },
         trait_name.to_lowercase(),
         AttrParams {
             enum_: vec!["forward", "ignore"],

--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -10,7 +10,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::new(
         input,
         trait_name,
-        quote!(::core::str),
+        quote! { ::core::str },
         trait_name.to_lowercase(),
     )?;
 
@@ -39,7 +39,7 @@ pub fn struct_from(state: &State, trait_name: &'static str) -> TokenStream {
         ..
     } = single_field_data.clone();
 
-    let initializers = [quote!(#casted_trait::from_str(src)?)];
+    let initializers = [quote! { #casted_trait::from_str(src)? }];
     let body = single_field_data.initializer(&initializers);
 
     quote! {

--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -64,7 +64,7 @@ fn enum_from(
     for variant_state in state.enabled_variant_data().variant_states {
         let variant = variant_state.variant.unwrap();
         if !variant.fields.is_empty() {
-            panic!("Only enums with no fields can derive({})", trait_name)
+            panic!("Only enums with no fields can derive({trait_name})")
         }
 
         variants_caseinsensitive
@@ -76,7 +76,7 @@ fn enum_from(
     let input_type = &input.ident;
     let visibility = &input.vis;
 
-    let err_name = format_ident!("Parse{}Error", input_type);
+    let err_name = format_ident!("Parse{input_type}Error");
     let err_message =
         format!("invalid {}", input_type.to_string().to_case(Case::Lower));
 
@@ -130,5 +130,5 @@ fn enum_from(
 }
 
 fn panic_one_field(trait_name: &str) -> ! {
-    panic!("Only structs with one field can derive({})", trait_name)
+    panic!("Only structs with one field can derive({trait_name})")
 }

--- a/impl/src/index.rs
+++ b/impl/src/index.rs
@@ -1,11 +1,11 @@
 use crate::utils::{add_where_clauses_for_new_ident, SingleFieldData, State};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{parse::Result, DeriveInput, Ident};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse::Result, DeriveInput};
 
 /// Provides the hook to expand `#[derive(Index)]` into an implementation of `Index`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
-    let index_type = &Ident::new("__IdxT", Span::call_site());
+    let index_type = format_ident!("__IdxT");
     let mut state = State::with_field_ignore(
         input,
         trait_name,
@@ -30,7 +30,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let new_generics = add_where_clauses_for_new_ident(
         &input.generics,
         &[field],
-        index_type,
+        &index_type,
         type_where_clauses,
         true,
     );

--- a/impl/src/index.rs
+++ b/impl/src/index.rs
@@ -9,10 +9,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let mut state = State::with_field_ignore(
         input,
         trait_name,
-        quote!(::core::ops),
+        quote! { ::core::ops },
         trait_name.to_lowercase(),
     )?;
-    state.add_trait_path_type_param(quote!(#index_type));
+    state.add_trait_path_type_param(quote! { #index_type });
     let SingleFieldData {
         field,
         field_type,

--- a/impl/src/index_mut.rs
+++ b/impl/src/index_mut.rs
@@ -1,11 +1,11 @@
 use crate::utils::{add_where_clauses_for_new_ident, SingleFieldData, State};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{parse::Result, DeriveInput, Ident};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse::Result, DeriveInput};
 
 /// Provides the hook to expand `#[derive(IndexMut)]` into an implementation of `IndexMut`
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
-    let index_type = &Ident::new("__IdxT", Span::call_site());
+    let index_type = format_ident!("__IdxT");
     let mut state = State::with_field_ignore(
         input,
         trait_name,
@@ -30,7 +30,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let new_generics = add_where_clauses_for_new_ident(
         &input.generics,
         &[field],
-        index_type,
+        &index_type,
         type_where_clauses,
         true,
     );

--- a/impl/src/index_mut.rs
+++ b/impl/src/index_mut.rs
@@ -10,7 +10,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(::core::ops),
-        String::from("index_mut"),
+        "index_mut".into(),
     )?;
     state.add_trait_path_type_param(quote!(#index_type));
     let SingleFieldData {

--- a/impl/src/index_mut.rs
+++ b/impl/src/index_mut.rs
@@ -9,10 +9,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let mut state = State::with_field_ignore(
         input,
         trait_name,
-        quote!(::core::ops),
+        quote! { ::core::ops },
         "index_mut".into(),
     )?;
-    state.add_trait_path_type_param(quote!(#index_type));
+    state.add_trait_path_type_param(quote! { #index_type });
     let SingleFieldData {
         field,
         field_type,

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -11,7 +11,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!(::core::convert),
+        quote! { ::core::convert },
         trait_name.to_lowercase(),
         AttrParams {
             enum_: vec!["ignore", "owned", "ref", "ref_mut"],

--- a/impl/src/into_iterator.rs
+++ b/impl/src/into_iterator.rs
@@ -10,7 +10,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_field_ignore_and_refs(
         input,
         trait_name,
-        quote!(::core::iter),
+        quote! { ::core::iter },
         "into_iterator".into(),
     )?;
     let SingleFieldData {
@@ -40,8 +40,9 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             generics.split_for_impl()
         };
         // let generics = add_extra_ty_param_bound(&input.generics, trait_path);
-        let casted_trait =
-            &quote!(<#reference_with_lifetime #field_type as #trait_path>);
+        let casted_trait = &quote! {
+            <#reference_with_lifetime #field_type as #trait_path>
+        };
         let into_iterator = quote! {
             #[automatically_derived]
             impl #impl_generics #trait_path for #reference_with_lifetime #input_type #ty_generics

--- a/impl/src/into_iterator.rs
+++ b/impl/src/into_iterator.rs
@@ -11,7 +11,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(::core::iter),
-        String::from("into_iterator"),
+        "into_iterator".into(),
     )?;
     let SingleFieldData {
         input_type,

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -9,7 +9,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(),
-        String::from("is_variant"),
+        "is_variant".into(),
         AttrParams {
             enum_: vec!["ignore"],
             variant: vec!["ignore"],

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -2,7 +2,7 @@ use crate::utils::{AttrParams, DeriveType, State};
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, Ident, Result};
+use syn::{DeriveInput, Fields, Result};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let state = State::with_attr_params(
@@ -28,11 +28,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let mut funcs = vec![];
     for variant_state in state.enabled_variant_data().variant_states {
         let variant = variant_state.variant.unwrap();
-        let fn_name = Ident::new(
-            &format_ident!("is_{}", variant.ident)
-                .to_string()
-                .to_case(Case::Snake),
-            variant.ident.span(),
+        let fn_name = format_ident!(
+            "is_{}",
+            variant.ident.to_string().to_case(Case::Snake),
+            span = variant.ident.span(),
         );
         let variant_ident = &variant.ident;
 

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -8,7 +8,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!(),
+        quote! {},
         "is_variant".into(),
         AttrParams {
             enum_: vec!["ignore"],
@@ -19,7 +19,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     )?;
     assert!(
         state.derive_type == DeriveType::Enum,
-        "IsVariant can only be derived for enums"
+        "IsVariant can only be derived for enums",
     );
 
     let enum_name = &input.ident;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -3,6 +3,7 @@
 #![recursion_limit = "128"]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![forbid(non_ascii_idents, unsafe_code)]
+#![warn(clippy::nonstandard_macro_braces)]
 
 use proc_macro::TokenStream;
 use syn::parse::Error as ParseError;

--- a/impl/src/mul_assign_like.rs
+++ b/impl/src/mul_assign_like.rs
@@ -1,10 +1,10 @@
 use crate::add_assign_like;
 use crate::mul_helpers::generics_and_exprs;
 use crate::utils::{AttrParams, HashSet, MultiFieldData, RefType, State};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 use std::iter;
-use syn::{DeriveInput, Ident, Result};
+use syn::{DeriveInput, Result};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let method_name = trait_name
@@ -23,7 +23,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     if state.default_info.forward {
         return Ok(add_assign_like::expand(input, trait_name));
     }
-    let scalar_ident = &Ident::new("__RhsT", Span::call_site());
+    let scalar_ident = format_ident!("__RhsT");
     state.add_trait_path_type_param(quote!(#scalar_ident));
     let multi_field_data = state.enabled_fields_data();
     let MultiFieldData {
@@ -46,7 +46,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let (generics, exprs) = generics_and_exprs(
         multi_field_data.clone(),
-        scalar_ident,
+        &scalar_ident,
         type_where_clauses,
         RefType::Mut,
     );

--- a/impl/src/mul_assign_like.rs
+++ b/impl/src/mul_assign_like.rs
@@ -16,7 +16,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let mut state = State::with_attr_params(
         input,
         trait_name,
-        quote!(::core::ops),
+        quote! { ::core::ops },
         method_name,
         AttrParams::struct_(vec!["forward"]),
     )?;
@@ -24,7 +24,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         return Ok(add_assign_like::expand(input, trait_name));
     }
     let scalar_ident = format_ident!("__RhsT");
-    state.add_trait_path_type_param(quote!(#scalar_ident));
+    state.add_trait_path_type_param(quote! { #scalar_ident });
     let multi_field_data = state.enabled_fields_data();
     let MultiFieldData {
         input_type,
@@ -52,7 +52,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     );
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
-    Ok(quote!(
+    Ok(quote! {
         #[automatically_derived]
         impl #impl_generics #trait_path<#scalar_ident> for #input_type #ty_generics #where_clause {
             #[inline]
@@ -60,5 +60,5 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                 #( #exprs; )*
             }
         }
-    ))
+    })
 }

--- a/impl/src/mul_helpers.rs
+++ b/impl/src/mul_helpers.rs
@@ -20,9 +20,9 @@ pub fn generics_and_exprs(
     let exprs: Vec<_> = casted_traits
         .iter()
         .zip(members)
-        .map(
-            |(casted_trait, member)| quote!(#casted_trait::#method_ident(#reference #member, rhs)),
-        )
+        .map(|(casted_trait, member)| {
+            quote! { #casted_trait::#method_ident(#reference #member, rhs) }
+        })
         .collect();
 
     let new_generics = add_where_clauses_for_new_ident(

--- a/impl/src/mul_like.rs
+++ b/impl/src/mul_like.rs
@@ -10,7 +10,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let mut state = State::with_attr_params(
         input,
         trait_name,
-        quote!(::core::ops),
+        quote! { ::core::ops },
         trait_name.to_lowercase(),
         AttrParams::struct_(vec!["forward"]),
     )?;
@@ -19,7 +19,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let scalar_ident = format_ident!("__RhsT");
-    state.add_trait_path_type_param(quote!(#scalar_ident));
+    state.add_trait_path_type_param(quote! { #scalar_ident });
     let multi_field_data = state.enabled_fields_data();
     let MultiFieldData {
         input_type,
@@ -48,7 +48,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     );
     let body = multi_field_data.initializer(&initializers);
     let (impl_generics, _, where_clause) = generics.split_for_impl();
-    Ok(quote!(
+    Ok(quote! {
         #[automatically_derived]
         impl #impl_generics  #trait_path_with_params for #input_type #ty_generics #where_clause {
             type Output = #input_type #ty_generics;
@@ -58,6 +58,5 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                 #body
             }
         }
-
-    ))
+    })
 }

--- a/impl/src/mul_like.rs
+++ b/impl/src/mul_like.rs
@@ -1,10 +1,10 @@
 use crate::add_like;
 use crate::mul_helpers::generics_and_exprs;
 use crate::utils::{AttrParams, HashSet, MultiFieldData, RefType, State};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 use std::iter;
-use syn::{DeriveInput, Ident, Result};
+use syn::{DeriveInput, Result};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let mut state = State::with_attr_params(
@@ -18,7 +18,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         return Ok(add_like::expand(input, trait_name));
     }
 
-    let scalar_ident = &Ident::new("__RhsT", Span::call_site());
+    let scalar_ident = format_ident!("__RhsT");
     state.add_trait_path_type_param(quote!(#scalar_ident));
     let multi_field_data = state.enabled_fields_data();
     let MultiFieldData {
@@ -33,7 +33,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let tys = field_types.iter().collect::<HashSet<_>>();
     let tys = tys.iter();
-    let scalar_iter = iter::repeat(scalar_ident);
+    let scalar_iter = iter::repeat(&scalar_ident);
     let trait_path_iter = iter::repeat(trait_path);
 
     let type_where_clauses = quote! {
@@ -42,7 +42,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let (generics, initializers) = generics_and_exprs(
         multi_field_data.clone(),
-        scalar_ident,
+        &scalar_ident,
         type_where_clauses,
         RefType::No,
     );

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -25,13 +25,13 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
                 quote!(#input_type #ty_generics),
                 struct_content(input_type, &named_to_vec(fields), method_ident),
             ),
-            _ => panic!("Unit structs cannot use derive({})", trait_name),
+            _ => panic!("Unit structs cannot use derive({trait_name})"),
         },
         Data::Enum(ref data_enum) => {
             enum_output_type_and_content(input, data_enum, method_ident)
         }
 
-        _ => panic!("Only structs and enums can use derive({})", trait_name),
+        _ => panic!("Only structs and enums can use derive({trait_name})"),
     };
 
     quote!(
@@ -104,7 +104,7 @@ fn enum_output_type_and_content(
                 // (Subtype(vars)) => Ok(TypePath(exprs))
                 let size = unnamed_to_vec(fields).len();
                 let vars: &Vec<_> = &(0..size)
-                    .map(|i| Ident::new(&format!("__{}", i), Span::call_site()))
+                    .map(|i| Ident::new(&format!("__{i}"), Span::call_site()))
                     .collect();
                 let method_iter = method_iter.by_ref();
                 let mut body = quote!(#subtype(#(#vars.#method_iter()),*));
@@ -130,7 +130,7 @@ fn enum_output_type_and_content(
                     .map(|f| f.ident.as_ref().unwrap())
                     .collect();
                 let vars: &Vec<_> = &(0..size)
-                    .map(|i| Ident::new(&format!("__{}", i), Span::call_site()))
+                    .map(|i| Ident::new(&format!("__{i}"), Span::call_site()))
                     .collect();
                 let method_iter = method_iter.by_ref();
                 let mut body =
@@ -146,7 +146,7 @@ fn enum_output_type_and_content(
                 matches.push(matcher);
             }
             Fields::Unit => {
-                let message = format!("Cannot {}() unit variants", method_ident);
+                let message = format!("Cannot {method_ident}() unit variants");
                 matches.push(quote!(#subtype => ::core::result::Result::Err(#message)));
             }
         }

--- a/impl/src/sum_like.rs
+++ b/impl/src/sum_like.rs
@@ -1,9 +1,9 @@
 use crate::utils::{
     add_extra_ty_param_bound, add_extra_where_clauses, MultiFieldData, State,
 };
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{DeriveInput, Ident, Result};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Result};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let state = State::new(
@@ -22,10 +22,9 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     } = multi_field_data.clone();
 
     let op_trait_name = if trait_name == "Sum" { "Add" } else { "Mul" };
-    let op_trait_ident = Ident::new(op_trait_name, Span::call_site());
+    let op_trait_ident = format_ident!("{op_trait_name}");
     let op_path = quote!(::core::ops::#op_trait_ident);
-    let op_method_ident =
-        Ident::new(&(op_trait_name.to_lowercase()), Span::call_site());
+    let op_method_ident = format_ident!("{}", op_trait_name.to_lowercase());
     let has_type_params = input.generics.type_params().next().is_none();
     let generics = if has_type_params {
         input.generics.clone()

--- a/impl/src/sum_like.rs
+++ b/impl/src/sum_like.rs
@@ -9,7 +9,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::new(
         input,
         trait_name,
-        quote!(::core::iter),
+        quote! { ::core::iter },
         trait_name.to_lowercase(),
     )?;
     let multi_field_data = state.enabled_fields_data();
@@ -23,7 +23,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let op_trait_name = if trait_name == "Sum" { "Add" } else { "Mul" };
     let op_trait_ident = format_ident!("{op_trait_name}");
-    let op_path = quote!(::core::ops::#op_trait_ident);
+    let op_path = quote! { ::core::ops::#op_trait_ident };
     let op_method_ident = format_ident!("{}", op_trait_name.to_lowercase());
     let has_type_params = input.generics.type_params().next().is_none();
     let generics = if has_type_params {
@@ -40,11 +40,13 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let initializers: Vec<_> = field_types
         .iter()
-        .map(|field_type| quote!(#trait_path::#method_ident(::core::iter::empty::<#field_type>())))
+        .map(|field_type| {
+            quote! { #trait_path::#method_ident(::core::iter::empty::<#field_type>()) }
+        })
         .collect();
     let identity = multi_field_data.initializer(&initializers);
 
-    Ok(quote!(
+    Ok(quote! {
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]
@@ -52,5 +54,5 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
                 iter.fold(#identity, #op_path::#op_method_ident)
             }
         }
-    ))
+    })
 }

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -71,21 +71,20 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         };
 
         let output_type = if original_types.len() == 1 {
-            format!("{}", quote!(#(#original_types)*))
+            quote!(#(#original_types)*).to_string()
         } else {
             let types = original_types
                 .iter()
-                .map(|t| format!("{}", quote!(#t)))
+                .map(|t| quote!(#t).to_string())
                 .collect::<Vec<_>>();
             format!("({})", types.join(", "))
         };
         let variant_names = multi_field_datas
             .iter()
             .map(|d| {
-                format!(
-                    "{}",
-                    d.variant_name.expect("Somehow there was no variant name")
-                )
+                d.variant_name
+                    .expect("Somehow there was no variant name")
+                    .to_string()
             })
             .collect::<Vec<_>>()
             .join(", ");

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -57,8 +57,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         let mut matchers = vec![];
         let vars = &numbered_vars(original_types.len(), "");
         for multi_field_data in multi_field_datas {
-            let patterns: Vec<_> =
-                vars.iter().map(|var| quote! { #pattern_ref #var }).collect();
+            let patterns: Vec<_> = vars
+                .iter()
+                .map(|var| quote! { #pattern_ref #var })
+                .collect();
             matchers.push(
                 multi_field_data.matcher(&multi_field_data.field_indexes, &patterns),
             );

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -14,7 +14,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!(::core::convert),
+        quote! { ::core::convert },
         "try_into".into(),
         AttrParams {
             enum_: vec!["ignore", "owned", "ref", "ref_mut"],
@@ -58,24 +58,24 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         let vars = &numbered_vars(original_types.len(), "");
         for multi_field_data in multi_field_datas {
             let patterns: Vec<_> =
-                vars.iter().map(|var| quote!(#pattern_ref #var)).collect();
+                vars.iter().map(|var| quote! { #pattern_ref #var }).collect();
             matchers.push(
                 multi_field_data.matcher(&multi_field_data.field_indexes, &patterns),
             );
         }
 
         let vars = if vars.len() == 1 {
-            quote!(#(#vars)*)
+            quote! { #(#vars)* }
         } else {
-            quote!((#(#vars),*))
+            quote! { (#(#vars),*) }
         };
 
         let output_type = if original_types.len() == 1 {
-            quote!(#(#original_types)*).to_string()
+            quote! { #(#original_types)* }.to_string()
         } else {
             let types = original_types
                 .iter()
-                .map(|t| quote!(#t).to_string())
+                .map(|t| quote! { #t }.to_string())
                 .collect::<Vec<_>>();
             format!("({})", types.join(", "))
         };

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -15,7 +15,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(::core::convert),
-        String::from("try_into"),
+        "try_into".into(),
         AttrParams {
             enum_: vec!["ignore", "owned", "ref", "ref_mut"],
             variant: vec!["ignore", "owned", "ref", "ref_mut"],

--- a/impl/src/unwrap.rs
+++ b/impl/src/unwrap.rs
@@ -2,7 +2,7 @@ use crate::utils::{AttrParams, DeriveType, State};
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, Ident, Result};
+use syn::{DeriveInput, Fields, Result};
 
 pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStream> {
     let state = State::with_attr_params(
@@ -28,11 +28,10 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let mut funcs = vec![];
     for variant_state in state.enabled_variant_data().variant_states {
         let variant = variant_state.variant.unwrap();
-        let fn_name = Ident::new(
-            &format_ident!("unwrap_{}", variant.ident)
-                .to_string()
-                .to_case(Case::Snake),
-            variant.ident.span(),
+        let fn_name = format_ident!(
+            "unwrap_{}",
+            variant.ident.to_string().to_case(Case::Snake),
+            span = variant.ident.span(),
         );
         let variant_ident = &variant.ident;
 
@@ -41,7 +40,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             Fields::Unnamed(ref fields) => {
                 let data_pattern =
                     (0..fields.unnamed.len()).fold(vec![], |mut a, n| {
-                        a.push(format_ident!("field_{}", n));
+                        a.push(format_ident!("field_{n}"));
                         a
                     });
                 let ret_type = &fields.unnamed;

--- a/impl/src/unwrap.rs
+++ b/impl/src/unwrap.rs
@@ -8,7 +8,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!(),
+        quote! {},
         "unwrap".into(),
         AttrParams {
             enum_: vec!["ignore"],
@@ -19,7 +19,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     )?;
     assert!(
         state.derive_type == DeriveType::Enum,
-        "Unwrap can only be derived for enums"
+        "Unwrap can only be derived for enums",
     );
 
     let enum_name = &input.ident;

--- a/impl/src/unwrap.rs
+++ b/impl/src/unwrap.rs
@@ -9,7 +9,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         input,
         trait_name,
         quote!(),
-        String::from("unwrap"),
+        "unwrap".into(),
         AttrParams {
             enum_: vec!["ignore"],
             variant: vec!["ignore"],

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -83,14 +83,14 @@ impl RefType {
             "owned" => RefType::No,
             "ref" => RefType::Ref,
             "ref_mut" => RefType::Mut,
-            _ => panic!("'{}' is not a RefType", name),
+            _ => panic!("'{name}' is not a RefType"),
         }
     }
 }
 
 pub fn numbered_vars(count: usize, prefix: &str) -> Vec<Ident> {
     (0..count)
-        .map(|i| Ident::new(&format!("__{}{}", prefix, i), Span::call_site()))
+        .map(|i| Ident::new(&format!("__{prefix}{i}"), Span::call_site()))
         .collect()
 }
 
@@ -247,8 +247,8 @@ pub fn named_to_vec(fields: &FieldsNamed) -> Vec<&Field> {
 
 fn panic_one_field(trait_name: &str, trait_attr: &str) -> ! {
     panic!(
-        "derive({}) only works when forwarding to a single field. Try putting #[{}] or #[{}(ignore)] on the fields in the struct",
-        trait_name, trait_attr, trait_attr,
+        "derive({trait_name}) only works when forwarding to a single field. \
+         Try putting #[{trait_attr}] or #[{trait_attr}(ignore)] on the fields in the struct",
     )
 }
 
@@ -438,7 +438,7 @@ impl<'input> State<'input> {
                 data_enum.variants.iter().collect(),
             ),
             Data::Union(_) => {
-                panic!("cannot derive({}) for union", trait_name)
+                panic!("cannot derive({trait_name}) for union")
             }
         };
         let attrs: Vec<_> = if derive_type == DeriveType::Enum {

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -4,8 +4,8 @@
     allow(unused_mut)
 )]
 
-use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
 use syn::{
     parse_quote, punctuated::Punctuated, spanned::Spanned, Attribute, Data,
     DeriveInput, Error, Field, Fields, FieldsNamed, FieldsUnnamed, GenericParam,
@@ -89,9 +89,7 @@ impl RefType {
 }
 
 pub fn numbered_vars(count: usize, prefix: &str) -> Vec<Ident> {
-    (0..count)
-        .map(|i| Ident::new(&format!("__{prefix}{i}"), Span::call_site()))
-        .collect()
+    (0..count).map(|i| format_ident!("__{prefix}{i}")).collect()
 }
 
 pub fn field_idents<'a>(fields: &'a [&'a Field]) -> Vec<&'a Ident> {
@@ -418,8 +416,8 @@ impl<'input> State<'input> {
         add_type_bound: bool,
     ) -> Result<State<'arg_input>> {
         let trait_name = trait_name.trim_end_matches("ToInner");
-        let trait_ident = Ident::new(trait_name, Span::call_site());
-        let method_ident = Ident::new(&trait_attr, Span::call_site());
+        let trait_ident = format_ident!("{trait_name}");
+        let method_ident = format_ident!("{trait_attr}");
         let trait_path = quote!(#trait_module::#trait_ident);
         let (derive_type, fields, variants): (_, Vec<_>, Vec<_>) = match input.data {
             Data::Struct(ref data_struct) => match data_struct.fields {
@@ -564,8 +562,8 @@ impl<'input> State<'input> {
         default_info: FullMetaInfo,
     ) -> Result<State<'arg_input>> {
         let trait_name = trait_name.trim_end_matches("ToInner");
-        let trait_ident = Ident::new(trait_name, Span::call_site());
-        let method_ident = Ident::new(&trait_attr, Span::call_site());
+        let trait_ident = format_ident!("{trait_name}");
+        let method_ident = format_ident!("{trait_attr}");
         let trait_path = quote!(#trait_module::#trait_ident);
         let (derive_type, fields): (_, Vec<_>) = match variant.fields {
             Fields::Unnamed(ref fields) => {

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -897,9 +897,7 @@ fn get_meta_info(
 
     let mut info = MetaInfo::default();
 
-    let meta = if let Some(meta) = it.next() {
-        meta
-    } else {
+    let Some(meta) = it.next() else {
         return Ok(info);
     };
 
@@ -1008,9 +1006,7 @@ fn parse_punctuated_nested_meta(
                         for meta in &list.nested {
                             let typ: syn::Type = match meta {
                                 NestedMeta::Meta(meta) => {
-                                    let path = if let Meta::Path(p) = meta {
-                                        p
-                                    } else {
+                                    let Meta::Path(path) = meta else {
                                         return Err(Error::new(
                                             meta.span(),
                                             format!(
@@ -1187,16 +1183,10 @@ pub fn get_if_type_parameter_used_in_type(
     type_parameters: &HashSet<syn::Ident>,
     ty: &syn::Type,
 ) -> Option<syn::Type> {
-    if is_type_parameter_used_in_type(type_parameters, ty) {
-        match ty {
-            syn::Type::Reference(syn::TypeReference { elem: ty, .. }) => {
-                Some((**ty).clone())
-            }
-            ty => Some(ty.clone()),
-        }
-    } else {
-        None
-    }
+    is_type_parameter_used_in_type(type_parameters, ty).then(|| match ty {
+        syn::Type::Reference(syn::TypeReference { elem: ty, .. }) => (**ty).clone(),
+        ty => ty.clone(),
+    })
 }
 
 pub fn is_type_parameter_used_in_type(

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -37,41 +37,41 @@ pub enum RefType {
 impl RefType {
     pub fn lifetime(self) -> TokenStream {
         match self {
-            RefType::No => quote!(),
-            _ => quote!('__deriveMoreLifetime),
+            RefType::No => quote! {},
+            _ => quote! { '__deriveMoreLifetime },
         }
     }
 
     pub fn reference(self) -> TokenStream {
         match self {
-            RefType::No => quote!(),
-            RefType::Ref => quote!(&),
-            RefType::Mut => quote!(&mut),
+            RefType::No => quote! {},
+            RefType::Ref => quote! { & },
+            RefType::Mut => quote! { &mut },
         }
     }
 
     pub fn mutability(self) -> TokenStream {
         match self {
-            RefType::Mut => quote!(mut),
-            _ => quote!(),
+            RefType::Mut => quote! { mut },
+            _ => quote! {},
         }
     }
 
     pub fn pattern_ref(self) -> TokenStream {
         match self {
-            RefType::Ref => quote!(ref),
-            RefType::Mut => quote!(ref mut),
-            RefType::No => quote!(),
+            RefType::Ref => quote! { ref },
+            RefType::Mut => quote! { ref mut },
+            RefType::No => quote! {},
         }
     }
 
     pub fn reference_with_lifetime(self) -> TokenStream {
         if !self.is_ref() {
-            return quote!();
+            return quote! {};
         }
         let lifetime = self.lifetime();
         let mutability = self.mutability();
-        quote!(&#lifetime #mutability)
+        quote! { &#lifetime #mutability }
     }
 
     pub fn is_ref(self) -> bool {
@@ -83,7 +83,7 @@ impl RefType {
             "owned" => RefType::No,
             "ref" => RefType::Ref,
             "ref_mut" => RefType::Mut,
-            _ => panic!("'{name}' is not a RefType"),
+            _ => panic!("`{name}` is not a `RefType`"),
         }
     }
 }
@@ -133,7 +133,7 @@ pub fn add_extra_ty_param_bound_op<'a>(
     generics: &'a Generics,
     trait_ident: &'a Ident,
 ) -> Generics {
-    add_extra_ty_param_bound(generics, &quote!(::core::ops::#trait_ident))
+    add_extra_ty_param_bound(generics, &quote! { ::core::ops::#trait_ident })
 }
 
 pub fn add_extra_ty_param_bound<'a>(
@@ -162,9 +162,9 @@ pub fn add_extra_ty_param_bound_ref<'a>(
             let ref_with_lifetime = ref_type.reference_with_lifetime();
             add_extra_where_clauses(
                 &generics,
-                quote!(
+                quote! {
                     where #(#ref_with_lifetime #idents: #bound),*
-                ),
+                },
             )
         }
     }
@@ -224,11 +224,11 @@ pub fn add_where_clauses_for_new_ident<'a>(
     sized: bool,
 ) -> Generics {
     let generic_param = if fields.len() > 1 {
-        quote!(#type_ident: ::core::marker::Copy)
+        quote! { #type_ident: ::core::marker::Copy }
     } else if sized {
-        quote!(#type_ident)
+        quote! { #type_ident }
     } else {
-        quote!(#type_ident: ?::core::marker::Sized)
+        quote! { #type_ident: ?::core::marker::Sized }
     };
 
     let generics = add_extra_where_clauses(generics, type_where_clauses);
@@ -418,7 +418,7 @@ impl<'input> State<'input> {
         let trait_name = trait_name.trim_end_matches("ToInner");
         let trait_ident = format_ident!("{trait_name}");
         let method_ident = format_ident!("{trait_attr}");
-        let trait_path = quote!(#trait_module::#trait_ident);
+        let trait_path = quote! { #trait_module::#trait_ident };
         let (derive_type, fields, variants): (_, Vec<_>, Vec<_>) = match input.data {
             Data::Struct(ref data_struct) => match data_struct.fields {
                 Fields::Unnamed(ref fields) => {
@@ -564,7 +564,7 @@ impl<'input> State<'input> {
         let trait_name = trait_name.trim_end_matches("ToInner");
         let trait_ident = format_ident!("{trait_name}");
         let method_ident = format_ident!("{trait_attr}");
-        let trait_path = quote!(#trait_module::#trait_ident);
+        let trait_path = quote! { #trait_module::#trait_ident };
         let (derive_type, fields): (_, Vec<_>) = match variant.fields {
             Fields::Unnamed(ref fields) => {
                 (DeriveType::Unnamed, unnamed_to_vec(fields))
@@ -648,27 +648,27 @@ impl<'input> State<'input> {
         let field_types: Vec<_> = fields.iter().map(|f| &f.ty).collect();
         let members: Vec<_> = field_idents
             .iter()
-            .map(|ident| quote!(self.#ident))
+            .map(|ident| quote! { self.#ident })
             .collect();
         let trait_path = &self.trait_path;
         let trait_path_with_params = if !self.trait_path_params.is_empty() {
             let params = self.trait_path_params.iter();
-            quote!(#trait_path<#(#params),*>)
+            quote! { #trait_path<#(#params),*> }
         } else {
             self.trait_path.clone()
         };
 
         let casted_traits: Vec<_> = field_types
             .iter()
-            .map(|field_type| quote!(<#field_type as #trait_path_with_params>))
+            .map(|field_type| quote! { <#field_type as #trait_path_with_params> })
             .collect();
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
         let input_type = &self.input.ident;
         let (variant_name, variant_type) = self.variant.map_or_else(
-            || (None, quote!(#input_type)),
+            || (None, quote! { #input_type }),
             |v| {
                 let variant_name = &v.ident;
-                (Some(variant_name), quote!(#input_type::#variant_name))
+                (Some(variant_name), quote! { #input_type::#variant_name })
             },
         );
         MultiFieldData {
@@ -845,9 +845,9 @@ impl<'input, 'state> MultiFieldData<'input, 'state> {
             ..
         } = self;
         if self.state.derive_type == DeriveType::Named {
-            quote!(#variant_type{#(#field_idents: #initializers),*})
+            quote! { #variant_type{#(#field_idents: #initializers),*} }
         } else {
-            quote!(#variant_type(#(#initializers),*))
+            quote! { #variant_type(#(#initializers),*) }
         }
     }
     pub fn matcher<T: ToTokens>(
@@ -858,15 +858,15 @@ impl<'input, 'state> MultiFieldData<'input, 'state> {
         let MultiFieldData { variant_type, .. } = self;
         let full_bindings = (0..self.state.fields.len()).map(|i| {
             indexes.iter().position(|index| i == *index).map_or_else(
-                || quote!(_),
+                || quote! { _ },
                 |found_index| bindings[found_index].to_token_stream(),
             )
         });
         if self.state.derive_type == DeriveType::Named {
             let field_idents = self.state.field_idents();
-            quote!(#variant_type{#(#field_idents: #full_bindings),*})
+            quote! { #variant_type{#(#field_idents: #full_bindings),*} }
         } else {
-            quote!(#variant_type(#(#full_bindings),*))
+            quote! { #variant_type(#(#full_bindings),*) }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,7 +36,7 @@ impl<T> fmt::Display for TryIntoError<T> {
         write!(
             f,
             "Only {} can be converted to {}",
-            self.variant_names, self.output_type
+            self.variant_names, self.output_type,
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![forbid(non_ascii_idents, unsafe_code)]
+#![warn(clippy::nonstandard_macro_braces)]
 
 #[doc(inline)]
 pub use derive_more_impl::*;

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -78,9 +78,7 @@ struct SingleFieldGenericStruct<T> {
 
 #[test]
 fn single_field_generic_struct() {
-    let mut item = SingleFieldGenericStruct {
-        first: "test".into(),
-    };
+    let mut item = SingleFieldGenericStruct { first: "test" };
 
     assert!(ptr::eq(&mut item.first, item.as_mut()));
 }

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -10,7 +10,7 @@ struct SingleFieldTuple(String);
 
 #[test]
 fn single_field_tuple() {
-    let mut item = SingleFieldTuple(String::from("test"));
+    let mut item = SingleFieldTuple("test".into());
 
     assert!(ptr::eq(&mut item.0, item.as_mut()));
 }
@@ -33,7 +33,7 @@ struct SingleFieldStruct {
 #[test]
 fn single_field_struct() {
     let mut item = SingleFieldStruct {
-        first: String::from("test"),
+        first: "test".into(),
     };
 
     assert!(ptr::eq(&mut item.first, item.as_mut()));
@@ -44,7 +44,7 @@ struct MultiFieldTuple(#[as_mut] String, #[as_mut] PathBuf, Vec<usize>);
 
 #[test]
 fn multi_field_tuple() {
-    let mut item = MultiFieldTuple(String::from("test"), PathBuf::new(), vec![]);
+    let mut item = MultiFieldTuple("test".into(), PathBuf::new(), vec![]);
 
     assert!(ptr::eq(&mut item.0, item.as_mut()));
     assert!(ptr::eq(&mut item.1, item.as_mut()));
@@ -62,7 +62,7 @@ struct MultiFieldStruct {
 #[test]
 fn multi_field_struct() {
     let mut item = MultiFieldStruct {
-        first: String::from("test"),
+        first: "test".into(),
         second: PathBuf::new(),
         third: vec![],
     };
@@ -79,7 +79,7 @@ struct SingleFieldGenericStruct<T> {
 #[test]
 fn single_field_generic_struct() {
     let mut item = SingleFieldGenericStruct {
-        first: String::from("test"),
+        first: "test".into(),
     };
 
     assert!(ptr::eq(&mut item.first, item.as_mut()));

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -10,7 +10,7 @@ struct SingleFieldTuple(String);
 
 #[test]
 fn single_field_tuple() {
-    let item = SingleFieldTuple(String::from("test"));
+    let item = SingleFieldTuple("test".into());
 
     assert!(ptr::eq(&item.0, item.as_ref()));
 }
@@ -33,7 +33,7 @@ struct SingleFieldStruct {
 #[test]
 fn single_field_struct() {
     let item = SingleFieldStruct {
-        first: String::from("test"),
+        first: "test".into(),
     };
 
     assert!(ptr::eq(&item.first, item.as_ref()));
@@ -44,7 +44,7 @@ struct MultiFieldTuple(#[as_ref] String, #[as_ref] PathBuf, Vec<usize>);
 
 #[test]
 fn multi_field_tuple() {
-    let item = MultiFieldTuple(String::from("test"), PathBuf::new(), vec![]);
+    let item = MultiFieldTuple("test".into(), PathBuf::new(), vec![]);
 
     assert!(ptr::eq(&item.0, item.as_ref()));
     assert!(ptr::eq(&item.1, item.as_ref()));
@@ -62,7 +62,7 @@ struct MultiFieldStruct {
 #[test]
 fn multi_field_struct() {
     let item = MultiFieldStruct {
-        first: String::from("test"),
+        first: "test".into(),
         second: PathBuf::new(),
         third: vec![],
     };
@@ -79,7 +79,7 @@ struct SingleFieldGenericStruct<T> {
 #[test]
 fn single_field_generic_struct() {
     let item = SingleFieldGenericStruct {
-        first: String::from("test"),
+        first: "test".into(),
     };
 
     assert!(ptr::eq(&item.first, item.as_ref()));

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -78,9 +78,7 @@ struct SingleFieldGenericStruct<T> {
 
 #[test]
 fn single_field_generic_struct() {
-    let item = SingleFieldGenericStruct {
-        first: "test".into(),
-    };
+    let item = SingleFieldGenericStruct { first: "test" };
 
     assert!(ptr::eq(&item.first, item.as_ref()));
 }

--- a/tests/boats_display_derive.rs
+++ b/tests/boats_display_derive.rs
@@ -9,8 +9,8 @@ struct UnitError;
 
 #[test]
 fn unit_struct() {
-    let s = format!("{}", UnitError);
-    assert_eq!(&s[..], "An error has occurred.");
+    let s = UnitError.to_string();
+    assert_eq!(s, "An error has occurred.");
 }
 
 #[derive(Display)]
@@ -21,8 +21,8 @@ struct RecordError {
 
 #[test]
 fn record_struct() {
-    let s = format!("{}", RecordError { code: 0 });
-    assert_eq!(&s[..], "Error code: 0");
+    let s = RecordError { code: 0 }.to_string();
+    assert_eq!(s, "Error code: 0");
 }
 
 #[derive(Display)]
@@ -31,8 +31,8 @@ struct TupleError(i32);
 
 #[test]
 fn tuple_struct() {
-    let s = format!("{}", TupleError(2));
-    assert_eq!(&s[..], "Error code: 2");
+    let s = TupleError(2).to_string();
+    assert_eq!(s, "Error code: 2");
 }
 
 #[derive(Display)]
@@ -47,10 +47,10 @@ enum EnumError {
 
 #[test]
 fn enum_error() {
-    let s = format!("{}", EnumError::StructVariant { code: 2 });
-    assert_eq!(&s[..], "Error code: 2");
-    let s = format!("{}", EnumError::TupleVariant("foobar"));
-    assert_eq!(&s[..], "Error: foobar");
-    let s = format!("{}", EnumError::UnitVariant);
-    assert_eq!(&s[..], "An error has occurred.");
+    let s = EnumError::StructVariant { code: 2 }.to_string();
+    assert_eq!(s, "Error code: 2");
+    let s = EnumError::TupleVariant("foobar").to_string();
+    assert_eq!(s, "Error: foobar");
+    let s = EnumError::UnitVariant.to_string();
+    assert_eq!(s, "An error has occurred.");
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -139,9 +139,9 @@ fn check_display() {
     assert_eq!(EE::A.to_string(), "Java EE");
     assert_eq!(EE::B.to_string(), "Java EE");
     assert_eq!(U { i: 2 }.to_string(), "Hello there!");
-    assert_eq!(format!("{:o}", S), "7");
-    assert_eq!(format!("{:X}", UH), "UpperHex");
-    assert_eq!(format!("{:?}", D), "MyDebug");
+    assert_eq!(format!("{S:o}"), "7");
+    assert_eq!(format!("{UH:X}"), "UpperHex");
+    assert_eq!(format!("{D:?}"), "MyDebug");
     assert_eq!(Unit.to_string(), "Unit");
     assert_eq!(UnitStruct {}.to_string(), "UnitStruct");
     assert_eq!(Generic(()).to_string(), "Generic");

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -151,7 +151,7 @@ fn check_display() {
     );
     assert_eq!(
         Affix::B {
-            wat: "things".to_owned(),
+            wat: "things".into(),
             stuff: false,
         }
         .to_string(),

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -180,7 +180,7 @@ struct Name(String);
 #[test]
 fn explicit_complex_types_name() {
     let name = "Eärendil";
-    let expected = Name(name.to_owned());
+    let expected = Name(name.into());
     assert_eq!(expected, name.to_owned().into());
     assert_eq!(expected, name.into());
     assert_eq!(expected, Cow::Borrowed(name).into());

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -135,7 +135,7 @@ struct Name(String);
 #[test]
 fn explicit_complex_types_name() {
     let name = "Ñolofinwë";
-    let input = Name(name.to_owned());
-    assert_eq!(String::from(input.clone()), name.to_owned());
+    let input = Name(name.into());
+    assert_eq!(String::from(input.clone()), name);
     assert_eq!(Cow::from(input.clone()), Cow::Borrowed(name));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -193,7 +193,7 @@ fn main() {
     assert_eq!(5, MyInt(5).into());
     assert_eq!(MyInt(5), MyInt::new(5));
     assert_eq!(-MyInt(5), (-5).into());
-    assert_eq!("30", format!("{}", MyInt(30)));
+    assert_eq!("30", MyInt(30).to_string());
     assert_eq!("36", format!("{:o}", MyInt(30)));
     assert_eq!("100", format!("{:b}", MyInt(4)));
     assert_eq!(!MyBool(true), false.into());
@@ -202,7 +202,7 @@ fn main() {
     assert_eq!(SimpleStruct { int1: 5 }, 5.into());
     assert_eq!(5u64, SimpleStruct { int1: 5 }.into());
     assert_eq!(Ok(SimpleStruct { int1: 5 }), "5".parse());
-    assert_eq!("5", format!("{}", SimpleStruct { int1: 5 }));
+    assert_eq!("5", SimpleStruct { int1: 5 }.to_string());
     assert_eq!(NormalStruct { int1: 5, int2: 6 }, (5, 6).into());
     assert_eq!(SimpleStruct { int1: 5 }, SimpleStruct::new(5));
     assert_eq!(NormalStruct { int1: 5, int2: 6 }, NormalStruct::new(5, 6));


### PR DESCRIPTION
Related to #202, #222




## Synopsis

Since we've [bumped MSRV to 1.65](https://github.com/JelteF/derive_more/pull/222), it's time to refactor the codebase to leverage recently available Rust features for better code ergonomics.




## Solution

This PR provides only cosmetic codebase refactoring. It does no user-facing semantics changes.

Performed refactorings:
- Use [`let`-`else` statement](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements) wherever it fits and simplifies code.
- Use [`matches!()` macro](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#matches) instead of `match` expression where it improves ergonomics.
- Use [`bool::then()`](https://doc.rust-lang.org/stable/std/primitive.bool.html#method.then)/[`bool::then_some()`](https://doc.rust-lang.org/stable/std/primitive.bool.html#method.then_some) wherever it simplifies code by eliminating `else { None }` branch.
- Use [short formatting syntax](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings) where possible (but without changing docs and tests for our formatting macros).
- Leverage full ergonomics of [`format_ident!()` macro](https://docs.rs/quote/1.0/quote/macro.format_ident.html) and remove raw `syn::Ident::new()` usages.
- Prefer `.into()` conversion over `.to_string()`/`.to_owned()` for `&str` where destination type is known to be `String` exactly (it's more future-proof this way, since we don't need to change these places if we would switch destination type to `Cow<'_, str>` or `SmartString`, etc).
- Use [`#![warn(clippy::nonstandard_macro_braces)]`](https://rust-lang.github.io/rust-clippy/rust-1.64.0#nonstandard_macro_braces) to require using the same syntax for macro calls anywhere (we were using `quote!()` in some places and `quote! {}` in others).


## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are ~~added/~~ updated
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
