### PR TITLE
Fix installing `tomljson` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,10 @@ jobs:
       - name: Install tomljson
         run: go install github.com/pelletier/go-toml/cmd/tomljson@latest
 
-      - run: tomljson Cargo.toml
+      - run: |
+          echo "$GOPATH"
+          echo "$PATH"
+          tomljson Cargo.toml
 
       - run: ci/test_all_features.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
       - run: |
           echo "$GOPATH"
           echo "$PATH"
+          find / -name tomljson
           tomljson Cargo.toml
 
       - run: ci/test_all_features.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,6 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "${HOME}/go/bin" >> $GITHUB_PATH
 
-      - run: |
-          tomljson Cargo.toml
-
       - run: ci/test_all_features.sh
         env:
           GOBIN: "$HOME/go/bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,11 @@ jobs:
       - run: rustup default nightly
 
       - name: Install tomljson
-        run: go install github.com/pelletier/go-toml/cmd/tomljson@latest
+        run: |
+          go install github.com/pelletier/go-toml/cmd/tomljson@latest
+          echo "${HOME}/go/bin" >> $GITHUB_PATH
 
       - run: |
-          echo "$GOPATH"
-          echo "$PATH"
-          find / -name tomljson
           tomljson Cargo.toml
 
       - run: ci/test_all_features.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
   ##########################
 
   clippy:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +32,6 @@ jobs:
       - run: cargo clippy --workspace --all-features -- -D warnings
 
   rustfmt:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +50,6 @@ jobs:
   ###########
 
   msrv:
-    if: false
     name: MSRV
     strategy:
       fail-fast: false
@@ -79,7 +76,6 @@ jobs:
       - run: cargo test --workspace --features testing-helpers
 
   no_std:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -99,7 +95,6 @@ jobs:
                    --no-default-features --features all_no_std
 
   test:
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +140,6 @@ jobs:
   #################
 
   rustdoc:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -165,7 +159,7 @@ jobs:
   #############
 
   release-github:
-    name: release on GitHub
+    name: release (GitHub)
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs:
       - clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - run: rustup default nightly
 
       - name: Install tomljson
-        run: go get github.com/pelletier/go-toml/cmd/tomljson
+        run: go install github.com/pelletier/go-toml/cmd/tomljson@latest
 
       - run: ci/test_all_features.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,9 @@ jobs:
       - name: Install tomljson
         run: |
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
-          echo "${HOME}/go/bin" >> $GITHUB_PATH
+          echo "$HOME/go/bin" >> $GITHUB_PATH
 
       - run: ci/test_all_features.sh
-        env:
-          GOBIN: "$HOME/go/bin"
-          PATH: "$PATH:$GOBIN"
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   ##########################
 
   clippy:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,6 +33,7 @@ jobs:
       - run: cargo clippy --workspace --all-features -- -D warnings
 
   rustfmt:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -50,6 +52,7 @@ jobs:
   ###########
 
   msrv:
+    if: false
     name: MSRV
     strategy:
       fail-fast: false
@@ -76,6 +79,7 @@ jobs:
       - run: cargo test --workspace --features testing-helpers
 
   no_std:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -95,6 +99,7 @@ jobs:
                    --no-default-features --features all_no_std
 
   test:
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +133,8 @@ jobs:
       - name: Install tomljson
         run: go install github.com/pelletier/go-toml/cmd/tomljson@latest
 
+      - run: tomljson Cargo.toml
+
       - run: ci/test_all_features.sh
         env:
           GOBIN: "$HOME/go/bin"
@@ -141,6 +148,7 @@ jobs:
   #################
 
   rustdoc:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -eux
 
 for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|testing-helpers'); do
     cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eux
+#!/usr/bin/env bash
+set -euxo pipefail
 
 for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|testing-helpers'); do
     cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";


### PR DESCRIPTION
## Synopsis

`tomljson` fails to install on CI now due to newer Go versions: https://github.com/JelteF/derive_more/actions/runs/3987055224/jobs/6836368442#step:5:11

More info:  https://golang.org/doc/go-get-install-deprecation




## Solution

Try to use `go install` instead, as the error message suggests.




## Checklist

- [x] ~~Documentation is updated~~ (if required)
- [x] ~~Tests are added/updated~~ (if required)
- [x] ~~[CHANGELOG entry][l:1] is added~~ (if required)




[l:1]: /CHANGELOG.md
