### PR TITLE
Disable all features by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install minimal dependencies versions
         run: cargo +nightly update -Z minimal-versions
 
-      - run: cargo test --workspace --features testing-helpers
+      - run: cargo test --workspace --features full,testing-helpers
 
   no_std:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
              #       https://github.com/japaric/trust/pull/137
 
       - run: cargo nono check --package derive_more
-                   --no-default-features --features all_no_std
+                   --no-default-features --features full
 
   test:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `#[display("...", (<expr>),*)]` syntax instead of
   `#[display(fmt = "...", ("<expr>"),*)]`, and `#[display(bound(<bound>))]`
   instead of `#[display(bound = "<bound>")]`.
+- Add an `std` feature which should be disabled in `no_std` environments.
+- Disable all cargo features by default (except `std`) supporting and add a
+  `full` feature which can be used to get the old behaviour of supporting all derives.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `#[display("...", (<expr>),*)]` syntax instead of
   `#[display(fmt = "...", ("<expr>"),*)]`, and `#[display(bound(<bound>))]`
   instead of `#[display(bound = "<bound>")]`.
-- Add an `std` feature which should be disabled in `no_std` environments.
-- Disable all cargo features by default (except `std`) supporting and add a
-  `full` feature which can be used to get the old behaviour of supporting all derives.
+- Add the `std` feature which should be disabled in `no_std` environments.
+- Disable all Cargo features by default (except `std`) supporting and add the
+  `full` feature which can be used to get the old behaviour of supporting all
+  possible derives.
 
 ### New features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ github = { repository = "JelteF/derive_more", workflow = "CI" }
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+default = ["std"]
+
 add_assign = ["derive_more-impl/add_assign"]
 add = ["derive_more-impl/add"]
 as_mut = ["derive_more-impl/as_mut"]
@@ -61,15 +63,11 @@ not = ["derive_more-impl/not"]
 sum = ["derive_more-impl/sum"]
 try_into = ["derive_more-impl/try_into"]
 is_variant = ["derive_more-impl/is_variant"]
-std = []
 unwrap = ["derive_more-impl/unwrap"]
 
-default = [
-    "all_no_std",
-    "std",
-]
 
-all_no_std = [
+std = []
+full = [
     "add_assign",
     "add",
     "as_mut",
@@ -145,7 +143,7 @@ required-features = ["display"]
 [[test]]
 name = "error"
 path = "tests/error_tests.rs"
-required-features = ["error"]
+required-features = ["error", "std"]
 
 [[test]]
 name = "from"
@@ -220,97 +218,19 @@ required-features = ["display"]
 [[test]]
 name = "no_std"
 path = "tests/no_std.rs"
-required-features = [
-    "add_assign",
-    "add",
-    "as_mut",
-    "as_ref",
-    "constructor",
-    "deref",
-    "deref_mut",
-    "display",
-    "from",
-    "from_str",
-    "index",
-    "index_mut",
-    "into",
-    "into_iterator",
-    "mul_assign",
-    "mul",
-    "not",
-    "sum",
-    "try_into",
-    "is_variant",
-]
+required-features = ["full"]
 
 [[test]]
 name = "generics"
 path = "tests/generics.rs"
-required-features = [
-    "add_assign",
-    "add",
-    "as_mut",
-    "as_ref",
-    "constructor",
-    "deref",
-    "deref_mut",
-    "display",
-    "from",
-    "from_str",
-    "index",
-    "index_mut",
-    "into",
-    "mul_assign",
-    "mul",
-    "not",
-    "try_into",
-    "is_variant",
-]
+required-features = ["full"]
 
 [[test]]
 name = "lib"
 path = "tests/lib.rs"
-required-features = [
-    "add_assign",
-    "add",
-    "as_mut",
-    "as_ref",
-    "constructor",
-    "deref",
-    "deref_mut",
-    "display",
-    "from",
-    "from_str",
-    "index",
-    "index_mut",
-    "into",
-    "mul_assign",
-    "mul",
-    "not",
-    "try_into",
-    "is_variant",
-]
+required-features = ["full"]
 
 [[example]]
 name = "deny_missing_docs"
 path = "examples/deny_missing_docs.rs"
-required-features = [
-    "add_assign",
-    "add",
-    "as_mut",
-    "as_ref",
-    "constructor",
-    "deref",
-    "deref_mut",
-    "display",
-    "from",
-    "from_str",
-    "index",
-    "index_mut",
-    "into",
-    "mul_assign",
-    "mul",
-    "not",
-    "try_into",
-    "is_variant",
-]
+required-features = ["full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ try_into = ["derive_more-impl/try_into"]
 is_variant = ["derive_more-impl/is_variant"]
 unwrap = ["derive_more-impl/unwrap"]
 
-
 std = []
 full = [
     "add_assign",

--- a/README.md
+++ b/README.md
@@ -139,25 +139,25 @@ These don't derive traits, but derive static methods instead.
 
 ## Installation
 
-This library requires Rust 1.65 or higher. To avoid unnecessary compile time by
-default no derives are supported. You have to enable each type of derive as
-a feature.
+This library requires Rust 1.65 or higher. To avoid redundant compilation times, by
+default no derives are supported. You have to enable each type of derive as a feature
+in `Cargo.toml`:
 
 ```toml
 [dependencies]
 derive_more = "0.99.0"
 # You can specify the types of derives that you need for less time spent
-# compiling. For the full list of features see this crate its Cargo.toml.
+# compiling. For the full list of features see this crate its `Cargo.toml`.
 features = ["from", "add", "iterator"]
 
-# If you don't care much about the compile time and simply want to have support
-# for all the possible derives you can use the "full" feature
+# If you don't care much about compilation times and simply want to have
+# support for all the possible derives, you can use the "full" feature.
 features = ["full"]
 
-# If you run in a no_std environment you should disable the default features,
+# If you run in a `no_std` environment you should disable the default features,
 # because the only default feature is the "std" feature.
 # NOTE: You can combine this with "full" feature to get support for all the
-# possible derives in a no_std environment.
+#       possible derives in a `no_std` environment.
 default-features = false
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,16 +139,26 @@ These don't derive traits, but derive static methods instead.
 
 ## Installation
 
-This library requires Rust 1.65 or higher and it supports `no_std` out of the box.
-Then add the following to `Cargo.toml`:
+This library requires Rust 1.65 or higher. To avoid unnecessary compile time by
+default no derives are supported. You have to enable each type of derive as
+a feature.
 
 ```toml
 [dependencies]
 derive_more = "0.99.0"
 # You can specify the types of derives that you need for less time spent
 # compiling. For the full list of features see this crate its Cargo.toml.
-default-features = false
 features = ["from", "add", "iterator"]
+
+# If you don't care much about the compile time and simply want to have support
+# for all the possible derives you can use the "full" feature
+features = ["full"]
+
+# If you run in a no_std environment you should disable the default features,
+# because the only default feature is the "std" feature.
+# NOTE: You can combine this with "full" feature to get support for all the
+# possible derives in a no_std environment.
+default-features = false
 ```
 
 And this to the top of your Rust file:

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -32,7 +32,7 @@ unicode-xid = { version = "0.2.2", optional = true }
 rustc_version = { version = "0.4", optional = true }
 
 [dev-dependencies]
-derive_more = { path = ".." }
+derive_more = { path = "..", features = ["try_into"]}
 itertools = "0.10.5"
 
 [badges]
@@ -42,6 +42,8 @@ github = { repository = "JelteF/derive_more", workflow = "CI" }
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+default = []
+
 add_assign = []
 add = []
 as_mut = []
@@ -65,7 +67,5 @@ sum = []
 try_into = ["syn/extra-traits"]
 is_variant = ["convert_case"]
 unwrap = ["convert_case"]
-
-default = []
 
 testing-helpers = ["rustc_version"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -32,7 +32,7 @@ unicode-xid = { version = "0.2.2", optional = true }
 rustc_version = { version = "0.4", optional = true }
 
 [dev-dependencies]
-derive_more = { path = "..", features = ["try_into"]}
+derive_more = { path = "..", features = ["add", "not", "try_into"] }
 itertools = "0.10.5"
 
 [badges]
@@ -51,10 +51,10 @@ as_ref = []
 constructor = []
 deref = []
 deref_mut = []
-display = ["syn/extra-traits", "unicode-xid"]
+display = ["syn/extra-traits", "dep:unicode-xid"]
 error = ["syn/extra-traits"]
 from = ["syn/extra-traits"]
-from_str = ["convert_case"]
+from_str = ["dep:convert_case"]
 index = []
 index_mut = []
 into = ["syn/extra-traits"]
@@ -65,7 +65,7 @@ mul = ["syn/extra-traits"]
 not = ["syn/extra-traits"]
 sum = []
 try_into = ["syn/extra-traits"]
-is_variant = ["convert_case"]
-unwrap = ["convert_case"]
+is_variant = ["dep:convert_case"]
+unwrap = ["dep:convert_case"]
 
-testing-helpers = ["rustc_version"]
+testing-helpers = ["dep:rustc_version"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,18 @@
 //! [`Constructor`]: crate::Constructor
 //! [`IsVariant`]: crate::IsVariant
 //! [`Unwrap`]: crate::Unwrap
-#![doc = include_str!("../README.md")]
+
+// The README includes a doctest that requires these features. To make sure
+// that tests pass when not all features are provided we exclude it when the
+// required features are not available.
+#![cfg_attr(
+    all(
+        feature = "add",
+        feature="display",
+        feature="from",
+        feature="into"
+    ),
+    doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![forbid(non_ascii_idents, unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,18 @@
 //! [`Constructor`]: crate::Constructor
 //! [`IsVariant`]: crate::IsVariant
 //! [`Unwrap`]: crate::Unwrap
-
-// The README includes a doctest that requires these features. To make sure
-// that tests pass when not all features are provided we exclude it when the
+// The README includes doctests requiring these features. To make sure that
+// tests pass when not all features are provided we exclude it when the
 // required features are not available.
 #![cfg_attr(
     all(
         feature = "add",
-        feature="display",
-        feature="from",
-        feature="into"
+        feature = "display",
+        feature = "from",
+        feature = "into"
     ),
-    doc = include_str!("../README.md"))]
+    doc = include_str!("../README.md")
+)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![forbid(non_ascii_idents, unsafe_code)]


### PR DESCRIPTION

Resolves #210

## Synopsis

As discussed in #210 we want to disable all features by default in 1.0.
With the amount of derives that are part of this library the compile
time of the library itself becomes significant. This way we don't have
to worry about increasing people their compile time when adding more
derives.

On my machine compiling the `derive_more-impl` crate took ~4.5 seconds
when enabling all features. But when only enabling a single derive it
took 1.5 seconds.

Enabling all derives is still easy to do, by using the `full` feature.

## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
