### PR TITLE
Add `compile_error!` if no derive features enabled (#245)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - run: cargo test --workspace --features testing-helpers
+      - run: cargo test --workspace --features full,testing-helpers
 
   test-features:
     name: test features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,34 @@ pub mod ops;
 mod r#str;
 #[cfg(feature = "from_str")]
 pub use self::r#str::FromStrError;
+
+#[cfg(not(any(
+    feature = "full",
+    feature = "add_assign",
+    feature = "add",
+    feature = "as_mut",
+    feature = "as_ref",
+    feature = "constructor",
+    feature = "debug",
+    feature = "deref",
+    feature = "deref_mut",
+    feature = "display",
+    feature = "error",
+    feature = "from",
+    feature = "from_str",
+    feature = "index",
+    feature = "index_mut",
+    feature = "into",
+    feature = "into_iterator",
+    feature = "is_variant",
+    feature = "iterator",
+    feature = "mul_assign",
+    feature = "mul",
+    feature = "not",
+    feature = "sum",
+    feature = "try_into",
+    feature = "unwrap"
+)))]
+compile_error!(
+    "at least one derive feature must be enabled (or the \"full\" one enabling all the derives)"
+);


### PR DESCRIPTION
Resolves #245



## Synopsis

From https://github.com/JelteF/derive_more/issues/245#issue-1613696886:
> In [#244 (comment)](https://github.com/JelteF/derive_more/issues/244#issuecomment-1458316209) a user had an issue with the new approach of no default features introduced by #234. To guide users we should probably add a clear error if no features (other than `std`) are selected. Since that would result in a useless dependency. In that error we could hint towards specifying features or going for the `"full"` feature.




## Solution

Add `compile_error!()` to `derive_more` crate if no derive features were specified.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] ~~Tests are added/updated~~ (seems no easy way to test that)
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
