### PR TITLE
Make CHANGELOG.md adhere closer to the Keep A Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -6,14 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## 1.0.0 - 2023-??-??
+## 1.0.0 - Unreleased
 
 ### Breaking changes
 
-- The minimum supported rust version is updated to Rust 1.65.
-- The `From` derive doesn't derive `From<()>` for enum variants without any
-  fields anymore. This feature was removed because it was considered useless in
-  practice.
+- The minimum supported Rust version (MSRV) is now Rust 1.65.
+- Add the `std` feature which should be disabled in `no_std` environments.
+- All Cargo features, except `std`, are now disabled by default. The `full`
+  feature can be used to get the old behavior of supporting all possible
+  derives.
 - The `TryFrom`, `Add`, `Sub`, `BitAnd`, `BitOr`, `BitXor`, `Not` and `Neg`
   derives now return a dedicated error type instead of a `&'static str` on
   error.
@@ -22,16 +23,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `Display` derive (and other `fmt`-like ones) now uses
   `#[display("...", (<expr>),*)]` syntax instead of
   `#[display(fmt = "...", ("<expr>"),*)]`, and `#[display(bound(<bound>))]`
-  instead of `#[display(bound = "<bound>")]`.
-- Add the `std` feature which should be disabled in `no_std` environments.
-- Disable all Cargo features by default (except `std`) supporting and add the
-  `full` feature which can be used to get the old behaviour of supporting all
-  possible derives.
+  instead of `#[display(bound = "<bound>")]`. So without the double quotes
+  around the expressions and bounds.
 - The `DebugCustom` derive is renamed to just `Debug` (gated now under a separate
   `debug` feature), and its semantics were changed to be a superset of `std` variant
   of `Debug`.
+- The `From` derive doesn't derive `From<()>` for enum variants without any
+  fields anymore. This feature was removed because it was considered useless in
+  practice.
 
-### New features
+### Added
 
 - Add support captured identifiers in `Display` derives. So now you can use:
   `#[display(fmt = "Prefix: {field}")]` instead of needing to use
@@ -39,15 +40,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `FromStr` derive support for enums that contain variants without fields.
   If you pass the name of the variant to `from_str` it will create the matching
   variant.
-- Use `const fn` in `Constructor` and `IsVariant` derives.
 
-### Improvements
+### Changed
 
-- Generate doc comments for `Unwrap` and `IsVariant`.
-- Use `#[automatically_derived]` attribute in all macros' expansion for code
-  style linters to omit the generated code.
+- The `Constructor` and `IsVariant` derives now generate `const fn` functions.
+- The `Unwrap` and `IsVariant` derives now generate doc comments.
+- `#[automatically_derived]` is now emitted from all macro expansions. This
+  should prevent code style linters from attempting to modify the generated
+  code.
 
-### Fixes
+
+### Fixed
 
 - Use a deterministic `HashSet` in all derives, this is needed for rust analyzer
   to work correctly.
@@ -56,28 +59,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.99.10 - 2020-09-11
 
-### Improvements
+### Added
 
 - `From` supports additional types for conversion: `#[from(types(u8, u16))]`.
 
 
 ## 0.99.7 - 2020-05-16
 
-### Fixes
-
-- Fix generic derives for `MulAssign`
-
-### Improvements
+### Changed
 
 - When specifying specific features of the crate to only enable specific
     derives, the `extra-traits` feature of  `syn` is not always enabled
     when those the specified features do not require it. This should speed up
     compile time of `syn` when this feature is not needed.
 
+### Fixed
+
+- Fix generic derives for `MulAssign`
 
 ## 0.99.6 - 2020-05-13
 
-### Improvements
+### Changed
 
 - Make sure output of derives is deterministic, for better support in
     rust-analyzer
@@ -85,11 +87,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.99.5 - 2020-03-28
 
-### New features
+### Added
 
 - Support for deriving `Error`!!! (many thanks to @ffuugoo and @tyranron)
 
-### Fixes
+### Fixed
 
 - Fix generic bounds for `Deref` and `DerefMut` with `forward`, i.e. put `Deref`
   bound on whole type, so on `where Box<T>: Deref` instead of on `T: Deref`.
@@ -98,14 +100,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `tests` directory is now correctly included in the crate (requested by
     Debian package maintainers)
 
-## 0.99.4 - 2020-03-28
+## 0.99.4 - 2020-03-28 [YANKED]
 
 Note: This version is yanked, because quickly after release it was found out
 tests did not run in CI.
 
 ## 0.99.3 - 2020-02-19
 
-### Fixes
+### Fixed
 
 - Fix generic bounds for `Deref` and `DerefMut` with no `forward`, i.e. no bounds
     are necessary. ([#107](https://github.com/JelteF/derive_more/issues/114))
@@ -113,14 +115,14 @@ tests did not run in CI.
 
 ## 0.99.2 - 2019-11-17
 
-### Fixes
+### Fixed
 
 - Hotfix for a regression in allowed `Display` derives using `#` flag, such as
     `{:#b}` ([#107](https://github.com/JelteF/derive_more/issues/107))
 
 ## 0.99.1 - 2019-11-12
 
-### Fixes
+### Fixed
 
 - Hotfix for a regression in allowed `From` derives
     ([#105](https://github.com/JelteF/derive_more/issues/105))
@@ -135,19 +137,19 @@ breaking backwards compatibility.
 This is why the next release with breaking changes is planned to be 1.0.0.
 
 ### Breaking changes
-
-- Requires Rust 1.36+
+- The minimum supported rust version (MSRV) is now Rust 1.36.
 - When using in a Rust 2015 crate, you should add `extern crate core` to your
   code.
 - `no_std` feature is removed, the library now supports `no_std` without having
   to configure any features.
+
+
+### Added
+
 - `Deref` derives now dereference to the type in the newtype. So if you have
   `MyBox(Box<i32>)`, dereferencing it will result in a `Box<i32>` not an `i32`.
   To get the old behaviour of forwarding the dereference you can add the
   `#[deref(forward)]` attribute on the struct or field.
-
-### New features
-
 - Derives for `AsRef`, `AsMut`, `Sum`, `Product`, `IntoIterator`.
 - Choosing the field of a struct for which to derive the newtype derive.
 - Ignoring variants of enums when deriving `From`, by using `#[from(ignore)]`.
@@ -162,29 +164,40 @@ This is why the next release with breaking changes is planned to be 1.0.0.
 - Add `#[into(owned, ref, ref_mut)]` and `#[try_into(owned, ref, ref_mut)]`
   attributes. These cause the `Into` and `TryInto` derives to also implement
   derives that return references to the inner fields.
-- Make `no_std` work out of the box
 - Allow `#[display(fmt="some shared display text for all enum variants {}")]`
   attribute on enum.
 - Better bounds inference of `Display` trait.
 
-### Other things
+### Changed
 
 - Remove dependency on `regex` to cut down compile time.
 - Use `syn` 1.0
 
 ## 0.15.0 - 2019-06-08
 
+### Fixed
+
 - Automatic detection of traits needed for `Display` format strings
 
 ## 0.14.0 - 2019-02-02
 
+### Added
+
 - Added `no_std` support
+
+### Changed
+
 - Suppress `unused_variables` warnings in derives
 
 ## 0.13.0 - 2018-10-19
 
-- Updated to `syn` v0.15
+### Added
+
 - Extended Display-like derives to support custom formats
+
+### Changed
+
+- Updated to `syn` v0.15
 
 ## 0.12.0 - 2018-09-19
 
@@ -225,10 +238,6 @@ This is why the next release with breaking changes is planned to be 1.0.0.
 
 - Allow cross crate inlining of derived methods
 
-### Internal changes
-
-- Fix most `clippy` warnings
-
 ## 0.8.0 - 2018-03-10
 
 ### Added
@@ -244,10 +253,6 @@ This is why the next release with breaking changes is planned to be 1.0.0.
 ### Fixed
 
 - Add `#[allow(missing_docs)]` to the Constructor definition
-
-### Internal changes
-
-- Run `rustfmt` on the code
 
 ## 0.7.0 - 2017-07-25
 


### PR DESCRIPTION
Cleanup of #254

> * The "Internal changes" sections under 0.7.1 and 0.9.0 have been removed - users of your library don't need (nor do they care) about internal details, so long as it works.
> * The section for 0.99.4 was retitled to include `[YANKED]`.
> * Certain changes, such as the MSRV changes, or the change about all features except `std` being disabled by default, were reworded. This is either for clarity, or to make them fit better as changelog entries.
