### PR TITLE
Add missing README.md include in impl/Cargo.toml

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -15,6 +15,7 @@ include = [
     "src/**/*.rs",
     "doc/**/*.md",
     "Cargo.toml",
+    "README.md",
     "LICENSE",
 ]
 


### PR DESCRIPTION
The packaged crate fails to build otherwise (because of the include_str in lib.rs)
