### PR TITLE
Support multiple attribute occurrences

### DIFF
--- a/tests/from.rs
+++ b/tests/from.rs
@@ -111,7 +111,8 @@ fn auto_ignore_with_forward_field2() {
 
 #[derive(Debug, Eq, PartialEq)]
 #[derive(From)]
-#[from(types(u8, u16, u32))]
+#[from(types(u8, u16))]
+#[from(types(u32))]
 struct MyIntExplicit(u64);
 
 #[test]

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -18,7 +18,8 @@ struct EmptyUnit;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[derive(Into)]
-#[into(owned(types(i64, i128)), ref, ref_mut)]
+#[into(owned(types(i64)), ref, ref_mut)]
+#[into(owned(types(i128)), ref, ref_mut)]
 struct MyInt(i32);
 
 #[test]
@@ -59,7 +60,8 @@ struct Point2DWithIgnored {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[derive(Into)]
-#[into(owned(types(i64, i128)), ref, ref_mut, types(i32))]
+#[into(owned(types(i64, i128)), ref, ref_mut)]
+#[into(types(i32))]
 struct MyIntExplicit(MyInt);
 
 #[test]
@@ -77,7 +79,8 @@ fn explicit_types_struct_all() {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[derive(Into)]
-#[into(owned(types(i32, i64, i128)), ref(types(i32)), ref_mut(types(i32)))]
+#[into(owned(types(i32, i64, i128)))]
+#[into(ref(types(i32)), ref_mut(types(i32)))]
 struct MyIntsExplicit(i32, MyInt, MyIntExplicit);
 
 #[test]


### PR DESCRIPTION
## Synopsis

It is impossible to feature-gate additional type conversions in `From`, `Into` derive macros. Code such as:

```rust
#[derive(From)]
#[from(types(u8, u16))]
#[cfg_attr(feature = "myfeature", from(types(u32)))]
struct MyIntExplicit(u64);
```

will fail to compile with `Only a single attribute is allowed` when `myfeature` is enabled.

## Solution

Instead of err-ing on second occurrence of the attribute when building `MetaInfo`, just proceed and collect all additional attributes into it. Anyway user will see the error message if they'll try to provide types to attributes, expansions of which will result in conflicting implementations.

As I understand the inner working of the macro, that's all there is to it to support multiple attributes?

## Checklist

- [ ] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [ ] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
