### PR TITLE
Support Error in no_std environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
 
   test-features:
     name: test features
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        std: [std, no_std]
+        std: ["std", "no_std"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,6 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        std: [std, '']
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -132,7 +128,8 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - run: ci/test_all_features.sh ${{ matrix.std }}
+      - run: ci/test_all_features.sh
+      - run: ci/test_all_features.sh std
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        std: [std, no_std]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -128,8 +132,7 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - run: ci/test_all_features.sh
-      - run: ci/test_all_features.sh std
+      - run: ci/test_all_features.sh ${{ matrix.std }}
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
+    matrix:
+      std: [std, '']
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -128,7 +130,7 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - run: ci/test_all_features.sh
+      - run: ci/test_all_features.sh ${{ matrix.std }}
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,10 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
-    matrix:
-      std: [std, '']
+    strategy:
+      fail-fast: false
+      matrix:
+        std: [std, '']
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   should prevent code style linters from attempting to modify the generated
   code.
 - Upgrade to `syn` 2.0.
+- The `Error` derive now works in nightly `no_std` environments when enabling
+  `#![feature(error_in_core)]`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ is_variant = ["derive_more-impl/is_variant"]
 unwrap = ["derive_more-impl/unwrap"]
 try_unwrap = ["derive_more-impl/try_unwrap"]
 
-std = ["derive_more-impl/std"]
+std = []
 full = [
     "add_assign",
     "add",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ members = ["impl"]
 [dependencies]
 derive_more-impl = { version = "=0.99.17", path = "impl" }
 
+[build-dependencies]
+rustc_version = { version = "0.4", optional = true }
+
 [dev-dependencies]
 rustversion = "1.0"
 trybuild = "1.0.56"
@@ -50,7 +53,7 @@ debug = ["derive_more-impl/debug"]
 deref = ["derive_more-impl/deref"]
 deref_mut = ["derive_more-impl/deref_mut"]
 display = ["derive_more-impl/display"]
-error = ["derive_more-impl/error", "std"]
+error = ["derive_more-impl/error"]
 from = ["derive_more-impl/from"]
 from_str = ["derive_more-impl/from_str"]
 index = ["derive_more-impl/index"]
@@ -67,7 +70,7 @@ is_variant = ["derive_more-impl/is_variant"]
 unwrap = ["derive_more-impl/unwrap"]
 try_unwrap = ["derive_more-impl/try_unwrap"]
 
-std = []
+std = ["derive_more-impl/std"]
 full = [
     "add_assign",
     "add",
@@ -96,7 +99,7 @@ full = [
     "try_unwrap",
 ]
 
-testing-helpers = ["derive_more-impl/testing-helpers"]
+testing-helpers = ["derive_more-impl/testing-helpers", "dep:rustc_version"]
 
 [[test]]
 name = "add_assign"
@@ -151,7 +154,7 @@ required-features = ["display"]
 [[test]]
 name = "error"
 path = "tests/error_tests.rs"
-required-features = ["error", "std"]
+required-features = ["error"]
 
 [[test]]
 name = "from"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+#[cfg(not(feature = "testing-helpers"))]
+fn detect_nightly() {}
+
+#[cfg(feature = "testing-helpers")]
+fn detect_nightly() {
+    use rustc_version::{version_meta, Channel};
+
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}
+
+fn main() {
+    detect_nightly();
+}

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+
+std=''
+if [ "${1:-}" = 'std' ]; then
+    std=',std'
+fi
+
 set -euxo pipefail
 
 for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
-    if [ "${1:-}" = 'std' ]; then
-        cargo test -p derive_more --tests --no-default-features --features "$feature,std,testing-helpers";
-    else
-        cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
-    fi
+    cargo +nightly test -p derive_more --tests --no-default-features --features "$feature$std,testing-helpers"
 done

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|testing-helpers'); do
-    cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
+for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
+    if [ "${1:-}" = 'std' ]; then
+        cargo test -p derive_more --tests --no-default-features --features "$feature,std,testing-helpers";
+    else
+        cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
+    fi
 done

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -71,6 +71,4 @@ is_variant = ["dep:convert_case"]
 unwrap = ["dep:convert_case"]
 try_unwrap = ["dep:convert_case"]
 
-std = []
-
 testing-helpers = ["dep:rustc_version"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -33,7 +33,7 @@ unicode-xid = { version = "0.2.2", optional = true }
 rustc_version = { version = "0.4", optional = true }
 
 [dev-dependencies]
-derive_more = { path = "..", features = ["add", "debug", "error", "from_str", "not", "try_into", "try_unwrap"] }
+derive_more = { path = "..", features = ["add", "debug", "error", "from_str", "not", "std", "try_into", "try_unwrap"] }
 itertools = "0.11.0"
 
 [badges]
@@ -70,5 +70,7 @@ try_into = ["syn/extra-traits"]
 is_variant = ["dep:convert_case"]
 unwrap = ["dep:convert_case"]
 try_unwrap = ["dep:convert_case"]
+
+std = []
 
 testing-helpers = ["dep:rustc_version"]

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -46,8 +46,7 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 
 If you want to use the `Error` derive on `no_std` environments, then you need to
 compile with nightly and enable this feature:
-```rust
-# #[cfg(nightly)]
+```ignore
 #![feature(error_in_core)]
 ```
 

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -47,6 +47,7 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 If you want to use the `Error` derive on `no_std` environments, then you need to
 compile with nightly and enable this feature:
 ```rust
+# #[cfg(nightly)]
 #![feature(error_in_core)]
 ```
 

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -54,6 +54,8 @@ Backtraces don't work though, because the `Backtrace` type is only available in
 `std`.
 
 
+
+
 ## Example usage
 
 ```rust

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -42,13 +42,23 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 `#[error(not(source))]`.
 
 
+### What works in `no_std`?
+
+If you want to use the `Error` derive on `no_std` environments, then you need to
+compile with nightly and enable this feature:
+```rust
+#![feature(error_in_core)]
+```
+
+Backtraces don't work though, because the `Backtrace` type is only available in
+`std`.
 
 
 ## Example usage
 
 ```rust
 # #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
-// Nightly requires enabling this features:
+// Nightly requires enabling these features:
 // #![feature(error_generic_member_access, provide_any)]
 # #[cfg(not(nightly))] fn main() {}
 # #[cfg(nightly)] fn main() {

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -18,7 +18,7 @@ pub fn expand(
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!{ ::derive_more::Error },
+        quote!{ ::derive_more::__private::Error },
         trait_name.to_lowercase(),
         allowed_attr_params(),
     )?;
@@ -39,7 +39,7 @@ pub fn expand(
 
     let source = source.map(|source| {
         quote! {
-            fn source(&self) -> Option<&(dyn ::derive_more::Error + 'static)> {
+            fn source(&self) -> Option<&(dyn ::derive_more::__private::Error + 'static)> {
                 use ::derive_more::__private::AsDynError;
                 #source
             }
@@ -73,7 +73,7 @@ pub fn expand(
             &generics,
             quote! {
                 where
-                    #(#bounds: ::core::fmt::Debug + ::core::fmt::Display + ::derive_more::Error + 'static),*
+                    #(#bounds: ::core::fmt::Debug + ::core::fmt::Display + ::derive_more::__private::Error + 'static),*
             },
         );
     }
@@ -82,7 +82,7 @@ pub fn expand(
 
     let render = quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::Error for #ident #ty_generics #where_clause {
+        impl #impl_generics ::derive_more::__private::Error for #ident #ty_generics #where_clause {
             #source
             #provide
         }
@@ -207,7 +207,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
         let source_provider = self.source.map(|source| {
             let source_expr = &self.data.members[source];
             quote! {
-                ::derive_more::Error::provide(&#source_expr, demand);
+                ::derive_more::__private::Error::provide(&#source_expr, demand);
             }
         });
         let backtrace_provider = self
@@ -237,7 +237,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
-                        ::derive_more::Error::provide(source, demand);
+                        ::derive_more::__private::Error::provide(source, demand);
                     }
                 })
             }
@@ -249,7 +249,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 Some(quote! {
                     #pattern => {
                         demand.provide_ref::<::std::backtrace::Backtrace>(backtrace);
-                        ::derive_more::Error::provide(source, demand);
+                        ::derive_more::__private::Error::provide(source, demand);
                     }
                 })
             }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -18,7 +18,7 @@ pub fn expand(
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!{ ::derive_more::__private::Error },
+        quote! { ::derive_more::__private::Error },
         trait_name.to_lowercase(),
         allowed_attr_params(),
     )?;

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -331,12 +331,16 @@ impl<'a> Expansion<'a> {
     /// Generates trait bounds for a struct or an enum variant.
     fn generate_bounds(&self) -> Vec<syn::WherePredicate> {
         let Some(fmt) = &self.attrs.fmt else {
-            return self.fields.iter().next().map(|f| {
-                let ty = &f.ty;
-                let trait_ident = &self.trait_ident;
-                vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
-            })
-            .unwrap_or_default();
+            return self
+                .fields
+                .iter()
+                .next()
+                .map(|f| {
+                    let ty = &f.ty;
+                    let trait_ident = &self.trait_ident;
+                    vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
+                })
+                .unwrap_or_default();
         };
 
         fmt.bounded_types(self.fields)

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -331,16 +331,12 @@ impl<'a> Expansion<'a> {
     /// Generates trait bounds for a struct or an enum variant.
     fn generate_bounds(&self) -> Vec<syn::WherePredicate> {
         let Some(fmt) = &self.attrs.fmt else {
-            return self
-                .fields
-                .iter()
-                .next()
-                .map(|f| {
-                    let ty = &f.ty;
-                    let trait_ident = &self.trait_ident;
-                    vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
-                })
-                .unwrap_or_default();
+            return self.fields.iter().next().map(|f| {
+                let ty = &f.ty;
+                let trait_ident = &self.trait_ident;
+                vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
+            })
+            .unwrap_or_default();
         };
 
         fmt.bounded_types(self.fields)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,15 @@ pub use self::r#str::FromStrError;
 #[cfg(feature = "error")]
 mod vendor;
 
-
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "error")]
 pub mod __private {
+    #[cfg(not(feature = "std"))]
+    pub use ::core::error::Error;
     #[cfg(feature = "std")]
     pub use ::std::error::Error;
 
-    #[cfg(not(feature = "std"))]
-    pub use ::core::error::Error;
     pub use crate::vendor::thiserror::aserror::AsDynError;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,16 @@ pub use self::r#str::FromStrError;
 #[cfg(feature = "error")]
 mod vendor;
 
-#[cfg(all(feature = "std", feature = "error"))]
-pub use ::std::error::Error;
-
-#[cfg(all(not(feature = "std"), feature = "error"))]
-pub use ::core::error::Error;
 
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "error")]
 pub mod __private {
+    #[cfg(feature = "std")]
+    pub use ::std::error::Error;
+
+    #[cfg(not(feature = "std"))]
+    pub use ::core::error::Error;
     pub use crate::vendor::thiserror::aserror::AsDynError;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,12 @@ pub use self::r#str::FromStrError;
 #[cfg(feature = "error")]
 mod vendor;
 
+#[cfg(all(feature = "std", feature = "error"))]
+pub use ::std::error::Error;
+
+#[cfg(all(not(feature = "std"), feature = "error"))]
+pub use ::core::error::Error;
+
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 // These links overwrite the ones in `README.md`
 // to become proper intra-doc links in Rust docs.
 //! [`From`]: crate::From

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::panic::UnwindSafe;
+
+#[cfg(not(feature = "std"))]
+use core::error::Error;
+
+use core::panic::UnwindSafe;
 
 pub trait AsDynError<'a>: Sealed {
     fn as_dyn_error(&self) -> &(dyn Error + 'a);

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "std")]
-use std::error::Error;
 #[cfg(not(feature = "std"))]
 use core::error::Error;
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use core::panic::UnwindSafe;
 

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "std")]
 use std::error::Error;
-
 #[cfg(not(feature = "std"))]
 use core::error::Error;
 

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -12,6 +12,7 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
+    #[cfg(std)]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
         field: i32,
@@ -98,6 +99,7 @@ fn named_implicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
+#[cfg(std)]
 #[test]
 fn named_implicit_boxed_source() {
     let err = TestErr::NamedImplicitBoxedSource {

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -12,7 +12,7 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
-    #[cfg(std)]
+    #[cfg(feature = "std")]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
         field: i32,
@@ -99,7 +99,7 @@ fn named_implicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(std)]
+#[cfg(feature = "std")]
 #[test]
 fn named_implicit_boxed_source() {
     let err = TestErr::NamedImplicitBoxedSource {

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "std")]
 use std::error::Error;
+
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 
 use derive_more::Error;
 
@@ -29,17 +33,17 @@ use derive_more::Error;
 /// ```
 macro_rules! derive_display {
     (@fmt) => {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
             write!(f, "")
         }
     };
     ($type:ident) => {
-        impl ::std::fmt::Display for $type {
+        impl ::core::fmt::Display for $type {
             derive_display!(@fmt);
         }
     };
     ($type:ident, $($type_parameters:ident),*) => {
-        impl<$($type_parameters),*> ::std::fmt::Display for $type<$($type_parameters),*> {
+        impl<$($type_parameters),*> ::core::fmt::Display for $type<$($type_parameters),*> {
             derive_display!(@fmt);
         }
     };
@@ -50,7 +54,7 @@ mod derives_for_generic_enums_with_source;
 mod derives_for_generic_structs_with_source;
 mod derives_for_structs_with_source;
 
-#[cfg(nightly)]
+#[cfg(all(feature = "std", nightly))]
 mod nightly;
 
 derive_display!(SimpleErr);

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,9 +1,3 @@
-#[cfg(feature = "std")]
-use std::error::Error;
-
-#[cfg(not(feature = "std"))]
-use core::error::Error;
-
 use derive_more::Error;
 
 /// Derives `std::fmt::Display` for structs/enums.

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "std")]
-use std::error::Error;
 #[cfg(not(feature = "std"))]
 use core::error::Error;
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use derive_more::Error;
 

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "std")]
+use std::error::Error;
+
+#[cfg(not(feature = "std"))]
+use core::error::Error;
+
 use derive_more::Error;
 
 /// Derives `std::fmt::Display` for structs/enums.

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "std")]
 use std::error::Error;
-
 #[cfg(not(feature = "std"))]
 use core::error::Error;
 

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 mod error;


### PR DESCRIPTION
Resolves #261



## Synopsis

The `Error` derive can be made to work well for the most part in
`no_std` environments by enabling `#![feature(error_in_core)]`. This
changes the `Error` derive slightly to import `Error` and related
traits from core, when the `std` feature is disabled.

In passing this also fixes actually running the nightly error tests. They were not actually run anymore because there was no `build.rs` file in the root of the repo, only in the `impl` package. So the `nightly` config was not available in tests.

## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
