### PR TITLE
Run all tests in no_std environments if std feature is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
 
   test-features:
     name: test features
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        std: [std, no_std]
+        std: ["std", "no_std"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,6 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        std: [std, '']
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -132,7 +128,8 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - run: ci/test_all_features.sh ${{ matrix.std }}
+      - run: ci/test_all_features.sh
+      - run: ci/test_all_features.sh std
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        std: [std, no_std]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -128,8 +132,7 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - run: ci/test_all_features.sh
-      - run: ci/test_all_features.sh std
+      - run: ci/test_all_features.sh ${{ matrix.std }}
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
+    matrix:
+      std: [std, '']
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
@@ -128,7 +130,7 @@ jobs:
           go install github.com/pelletier/go-toml/cmd/tomljson@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - run: ci/test_all_features.sh
+      - run: ci/test_all_features.sh ${{ matrix.std }}
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,10 @@ jobs:
   test-features:
     name: test features
     runs-on: ubuntu-latest
-    matrix:
-      std: [std, '']
+    strategy:
+      fail-fast: false
+      matrix:
+        std: [std, '']
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   should prevent code style linters from attempting to modify the generated
   code.
 - Upgrade to `syn` 2.0.
+- The `Error` derive now works in nightly `no_std` environments when enabling
+  `#![feature(error_in_core)]`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ is_variant = ["derive_more-impl/is_variant"]
 unwrap = ["derive_more-impl/unwrap"]
 try_unwrap = ["derive_more-impl/try_unwrap"]
 
-std = ["derive_more-impl/std"]
+std = []
 full = [
     "add_assign",
     "add",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ members = ["impl"]
 [dependencies]
 derive_more-impl = { version = "=0.99.17", path = "impl" }
 
+[build-dependencies]
+rustc_version = { version = "0.4", optional = true }
+
 [dev-dependencies]
 rustversion = "1.0"
 trybuild = "1.0.56"
@@ -50,7 +53,7 @@ debug = ["derive_more-impl/debug"]
 deref = ["derive_more-impl/deref"]
 deref_mut = ["derive_more-impl/deref_mut"]
 display = ["derive_more-impl/display"]
-error = ["derive_more-impl/error", "std"]
+error = ["derive_more-impl/error"]
 from = ["derive_more-impl/from"]
 from_str = ["derive_more-impl/from_str"]
 index = ["derive_more-impl/index"]
@@ -67,7 +70,7 @@ is_variant = ["derive_more-impl/is_variant"]
 unwrap = ["derive_more-impl/unwrap"]
 try_unwrap = ["derive_more-impl/try_unwrap"]
 
-std = []
+std = ["derive_more-impl/std"]
 full = [
     "add_assign",
     "add",
@@ -96,7 +99,7 @@ full = [
     "try_unwrap",
 ]
 
-testing-helpers = ["derive_more-impl/testing-helpers"]
+testing-helpers = ["derive_more-impl/testing-helpers", "dep:rustc_version"]
 
 [[test]]
 name = "add_assign"
@@ -151,7 +154,7 @@ required-features = ["display"]
 [[test]]
 name = "error"
 path = "tests/error_tests.rs"
-required-features = ["error", "std"]
+required-features = ["error"]
 
 [[test]]
 name = "from"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+#[cfg(not(feature = "testing-helpers"))]
+fn detect_nightly() {}
+
+#[cfg(feature = "testing-helpers")]
+fn detect_nightly() {
+    use rustc_version::{version_meta, Channel};
+
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}
+
+fn main() {
+    detect_nightly();
+}

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -3,8 +3,8 @@ set -euxo pipefail
 
 for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
     if [ "${1:-}" = 'std' ]; then
-        cargo test -p derive_more --tests --no-default-features --features "$feature,std,testing-helpers";
+        cargo +nightly test -p derive_more --tests --no-default-features --features "$feature,std,testing-helpers";
     else
-        cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
+        cargo +nightly test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
     fi
 done

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|testing-helpers'); do
-    cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
+for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
+    if [ "${1:-}" = 'std' ]; then
+        cargo test -p derive_more --tests --no-default-features --features "$feature,std,testing-helpers";
+    else
+        cargo test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
+    fi
 done

--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+
+std=''
+if [ "${1:-}" = 'std' ]; then
+    std=',std'
+fi
+
 set -euxo pipefail
 
 for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
-    if [ "${1:-}" = 'std' ]; then
-        cargo +nightly test -p derive_more --tests --no-default-features --features "$feature,std,testing-helpers";
-    else
-        cargo +nightly test -p derive_more --tests --no-default-features --features "$feature,testing-helpers";
-    fi
+    cargo +nightly test -p derive_more --tests --no-default-features --features "$feature$std,testing-helpers"
 done

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -71,6 +71,4 @@ is_variant = ["dep:convert_case"]
 unwrap = ["dep:convert_case"]
 try_unwrap = ["dep:convert_case"]
 
-std = []
-
 testing-helpers = ["dep:rustc_version"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -33,7 +33,7 @@ unicode-xid = { version = "0.2.2", optional = true }
 rustc_version = { version = "0.4", optional = true }
 
 [dev-dependencies]
-derive_more = { path = "..", features = ["add", "debug", "error", "from_str", "not", "try_into", "try_unwrap"] }
+derive_more = { path = "..", features = ["add", "debug", "error", "from_str", "not", "std", "try_into", "try_unwrap"] }
 itertools = "0.11.0"
 
 [badges]
@@ -70,5 +70,7 @@ try_into = ["syn/extra-traits"]
 is_variant = ["dep:convert_case"]
 unwrap = ["dep:convert_case"]
 try_unwrap = ["dep:convert_case"]
+
+std = []
 
 testing-helpers = ["dep:rustc_version"]

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -46,8 +46,7 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 
 If you want to use the `Error` derive on `no_std` environments, then you need to
 compile with nightly and enable this feature:
-```rust
-# #[cfg(nightly)]
+```ignore
 #![feature(error_in_core)]
 ```
 

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -47,6 +47,7 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 If you want to use the `Error` derive on `no_std` environments, then you need to
 compile with nightly and enable this feature:
 ```rust
+# #[cfg(nightly)]
 #![feature(error_in_core)]
 ```
 

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -54,6 +54,8 @@ Backtraces don't work though, because the `Backtrace` type is only available in
 `std`.
 
 
+
+
 ## Example usage
 
 ```rust

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -42,13 +42,23 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 `#[error(not(source))]`.
 
 
+### What works in `no_std`?
+
+If you want to use the `Error` derive on `no_std` environments, then you need to
+compile with nightly and enable this feature:
+```rust
+#![feature(error_in_core)]
+```
+
+Backtraces don't work though, because the `Backtrace` type is only available in
+`std`.
 
 
 ## Example usage
 
 ```rust
 # #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
-// Nightly requires enabling this features:
+// Nightly requires enabling these features:
 // #![feature(error_generic_member_access, provide_any)]
 # #[cfg(not(nightly))] fn main() {}
 # #[cfg(nightly)] fn main() {

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -18,7 +18,7 @@ pub fn expand(
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!{ ::derive_more::Error },
+        quote!{ ::derive_more::__private::Error },
         trait_name.to_lowercase(),
         allowed_attr_params(),
     )?;
@@ -39,7 +39,7 @@ pub fn expand(
 
     let source = source.map(|source| {
         quote! {
-            fn source(&self) -> Option<&(dyn ::derive_more::Error + 'static)> {
+            fn source(&self) -> Option<&(dyn ::derive_more::__private::Error + 'static)> {
                 use ::derive_more::__private::AsDynError;
                 #source
             }
@@ -73,7 +73,7 @@ pub fn expand(
             &generics,
             quote! {
                 where
-                    #(#bounds: ::core::fmt::Debug + ::core::fmt::Display + ::derive_more::Error + 'static),*
+                    #(#bounds: ::core::fmt::Debug + ::core::fmt::Display + ::derive_more::__private::Error + 'static),*
             },
         );
     }
@@ -82,7 +82,7 @@ pub fn expand(
 
     let render = quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::Error for #ident #ty_generics #where_clause {
+        impl #impl_generics ::derive_more::__private::Error for #ident #ty_generics #where_clause {
             #source
             #provide
         }
@@ -207,7 +207,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
         let source_provider = self.source.map(|source| {
             let source_expr = &self.data.members[source];
             quote! {
-                ::derive_more::Error::provide(&#source_expr, demand);
+                ::derive_more::__private::Error::provide(&#source_expr, demand);
             }
         });
         let backtrace_provider = self
@@ -237,7 +237,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
-                        ::derive_more::Error::provide(source, demand);
+                        ::derive_more::__private::Error::provide(source, demand);
                     }
                 })
             }
@@ -249,7 +249,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 Some(quote! {
                     #pattern => {
                         demand.provide_ref::<::std::backtrace::Backtrace>(backtrace);
-                        ::derive_more::Error::provide(source, demand);
+                        ::derive_more::__private::Error::provide(source, demand);
                     }
                 })
             }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -18,7 +18,7 @@ pub fn expand(
     let state = State::with_attr_params(
         input,
         trait_name,
-        quote!{ ::derive_more::__private::Error },
+        quote! { ::derive_more::__private::Error },
         trait_name.to_lowercase(),
         allowed_attr_params(),
     )?;

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -331,12 +331,16 @@ impl<'a> Expansion<'a> {
     /// Generates trait bounds for a struct or an enum variant.
     fn generate_bounds(&self) -> Vec<syn::WherePredicate> {
         let Some(fmt) = &self.attrs.fmt else {
-            return self.fields.iter().next().map(|f| {
-                let ty = &f.ty;
-                let trait_ident = &self.trait_ident;
-                vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
-            })
-            .unwrap_or_default();
+            return self
+                .fields
+                .iter()
+                .next()
+                .map(|f| {
+                    let ty = &f.ty;
+                    let trait_ident = &self.trait_ident;
+                    vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
+                })
+                .unwrap_or_default();
         };
 
         fmt.bounded_types(self.fields)

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -331,16 +331,12 @@ impl<'a> Expansion<'a> {
     /// Generates trait bounds for a struct or an enum variant.
     fn generate_bounds(&self) -> Vec<syn::WherePredicate> {
         let Some(fmt) = &self.attrs.fmt else {
-            return self
-                .fields
-                .iter()
-                .next()
-                .map(|f| {
-                    let ty = &f.ty;
-                    let trait_ident = &self.trait_ident;
-                    vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
-                })
-                .unwrap_or_default();
+            return self.fields.iter().next().map(|f| {
+                let ty = &f.ty;
+                let trait_ident = &self.trait_ident;
+                vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
+            })
+            .unwrap_or_default();
         };
 
         fmt.bounded_types(self.fields)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,15 @@ pub use self::r#str::FromStrError;
 #[cfg(feature = "error")]
 mod vendor;
 
-
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "error")]
 pub mod __private {
+    #[cfg(not(feature = "std"))]
+    pub use ::core::error::Error;
     #[cfg(feature = "std")]
     pub use ::std::error::Error;
 
-    #[cfg(not(feature = "std"))]
-    pub use ::core::error::Error;
     pub use crate::vendor::thiserror::aserror::AsDynError;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,16 @@ pub use self::r#str::FromStrError;
 #[cfg(feature = "error")]
 mod vendor;
 
-#[cfg(all(feature = "std", feature = "error"))]
-pub use ::std::error::Error;
-
-#[cfg(all(not(feature = "std"), feature = "error"))]
-pub use ::core::error::Error;
 
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "error")]
 pub mod __private {
+    #[cfg(feature = "std")]
+    pub use ::std::error::Error;
+
+    #[cfg(not(feature = "std"))]
+    pub use ::core::error::Error;
     pub use crate::vendor::thiserror::aserror::AsDynError;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,12 @@ pub use self::r#str::FromStrError;
 #[cfg(feature = "error")]
 mod vendor;
 
+#[cfg(all(feature = "std", feature = "error"))]
+pub use ::std::error::Error;
+
+#[cfg(all(not(feature = "std"), feature = "error"))]
+pub use ::core::error::Error;
+
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 // These links overwrite the ones in `README.md`
 // to become proper intra-doc links in Rust docs.
 //! [`From`]: crate::From

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::panic::UnwindSafe;
+
+#[cfg(not(feature = "std"))]
+use core::error::Error;
+
+use core::panic::UnwindSafe;
 
 pub trait AsDynError<'a>: Sealed {
     fn as_dyn_error(&self) -> &(dyn Error + 'a);

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "std")]
-use std::error::Error;
 #[cfg(not(feature = "std"))]
 use core::error::Error;
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use core::panic::UnwindSafe;
 

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "std")]
 use std::error::Error;
-
 #[cfg(not(feature = "std"))]
 use core::error::Error;
 

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::Add;

--- a/tests/add_assign.rs
+++ b/tests/add_assign.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::AddAssign;

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -46,7 +46,7 @@ fn single_field_struct() {
 
 #[cfg(feature = "std")]
 mod pathbuf {
-    use std::path::PahBuf;
+    use std::path::PathBuf;
 
     use super::*;
 

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use core::ptr;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec, vec::Vec};
-
+use core::ptr;
 
 use derive_more::AsMut;
 
@@ -46,8 +46,9 @@ fn single_field_struct() {
 
 #[cfg(feature = "std")]
 mod pathbuf {
-    use super::*;
     use std::path::PahBuf;
+
+    use super::*;
 
     #[derive(AsMut)]
     struct MultiFieldTuple(#[as_mut] String, #[as_mut] PathBuf, Vec<usize>);

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -1,7 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use std::path::PathBuf;
-use std::ptr;
+use core::ptr;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec, vec::Vec};
+
 
 use derive_more::AsMut;
 
@@ -39,36 +44,63 @@ fn single_field_struct() {
     assert!(ptr::eq(&mut item.first, item.as_mut()));
 }
 
-#[derive(AsMut)]
-struct MultiFieldTuple(#[as_mut] String, #[as_mut] PathBuf, Vec<usize>);
+#[cfg(feature = "std")]
+mod pathbuf {
+    use super::*;
+    use std::path::PahBuf;
 
-#[test]
-fn multi_field_tuple() {
-    let mut item = MultiFieldTuple("test".into(), PathBuf::new(), vec![]);
+    #[derive(AsMut)]
+    struct MultiFieldTuple(#[as_mut] String, #[as_mut] PathBuf, Vec<usize>);
 
-    assert!(ptr::eq(&mut item.0, item.as_mut()));
-    assert!(ptr::eq(&mut item.1, item.as_mut()));
-}
+    #[test]
+    fn multi_field_tuple() {
+        let mut item = MultiFieldTuple("test".into(), PathBuf::new(), vec![]);
 
-#[derive(AsMut)]
-struct MultiFieldStruct {
-    #[as_mut]
-    first: String,
-    #[as_mut]
-    second: PathBuf,
-    third: Vec<usize>,
-}
+        assert!(ptr::eq(&mut item.0, item.as_mut()));
+        assert!(ptr::eq(&mut item.1, item.as_mut()));
+    }
 
-#[test]
-fn multi_field_struct() {
-    let mut item = MultiFieldStruct {
-        first: "test".into(),
-        second: PathBuf::new(),
-        third: vec![],
-    };
+    #[derive(AsMut)]
+    struct MultiFieldStruct {
+        #[as_mut]
+        first: String,
+        #[as_mut]
+        second: PathBuf,
+        third: Vec<usize>,
+    }
 
-    assert!(ptr::eq(&mut item.first, item.as_mut()));
-    assert!(ptr::eq(&mut item.second, item.as_mut()));
+    #[test]
+    fn multi_field_struct() {
+        let mut item = MultiFieldStruct {
+            first: "test".into(),
+            second: PathBuf::new(),
+            third: vec![],
+        };
+
+        assert!(ptr::eq(&mut item.first, item.as_mut()));
+        assert!(ptr::eq(&mut item.second, item.as_mut()));
+    }
+
+    #[derive(AsMut)]
+    struct MultiFieldGenericStruct<T> {
+        #[as_mut]
+        first: Vec<T>,
+        #[as_mut]
+        second: PathBuf,
+        third: Vec<usize>,
+    }
+
+    #[test]
+    fn multi_field_generic_struct() {
+        let mut item = MultiFieldGenericStruct {
+            first: b"test".to_vec(),
+            second: PathBuf::new(),
+            third: vec![],
+        };
+
+        assert!(ptr::eq(&mut item.first, item.as_mut()));
+        assert!(ptr::eq(&mut item.second, item.as_mut()));
+    }
 }
 
 #[derive(AsMut)]
@@ -81,25 +113,4 @@ fn single_field_generic_struct() {
     let mut item = SingleFieldGenericStruct { first: "test" };
 
     assert!(ptr::eq(&mut item.first, item.as_mut()));
-}
-
-#[derive(AsMut)]
-struct MultiFieldGenericStruct<T> {
-    #[as_mut]
-    first: Vec<T>,
-    #[as_mut]
-    second: PathBuf,
-    third: Vec<usize>,
-}
-
-#[test]
-fn multi_field_generic_struct() {
-    let mut item = MultiFieldGenericStruct {
-        first: b"test".to_vec(),
-        second: PathBuf::new(),
-        third: vec![],
-    };
-
-    assert!(ptr::eq(&mut item.first, item.as_mut()));
-    assert!(ptr::eq(&mut item.second, item.as_mut()));
 }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -46,7 +46,7 @@ fn single_field_struct() {
 
 #[cfg(feature = "std")]
 mod pathbuf {
-    use std::path::PahBuf;
+    use std::path::PathBuf;
 
     use super::*;
 

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -1,7 +1,11 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use std::path::PathBuf;
-use std::ptr;
+use core::ptr;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec, vec::Vec};
 
 use derive_more::AsRef;
 
@@ -39,36 +43,42 @@ fn single_field_struct() {
     assert!(ptr::eq(&item.first, item.as_ref()));
 }
 
-#[derive(AsRef)]
-struct MultiFieldTuple(#[as_ref] String, #[as_ref] PathBuf, Vec<usize>);
+#[cfg(feature = "std")]
+mod pathbuf {
+    use super::*;
+    use std::path::PahBuf;
 
-#[test]
-fn multi_field_tuple() {
-    let item = MultiFieldTuple("test".into(), PathBuf::new(), vec![]);
+    #[derive(AsRef)]
+    struct MultiFieldTuple(#[as_ref] String, #[as_ref] PathBuf, Vec<usize>);
 
-    assert!(ptr::eq(&item.0, item.as_ref()));
-    assert!(ptr::eq(&item.1, item.as_ref()));
-}
+    #[test]
+    fn multi_field_tuple() {
+        let item = MultiFieldTuple("test".into(), PathBuf::new(), vec![]);
 
-#[derive(AsRef)]
-struct MultiFieldStruct {
-    #[as_ref]
-    first: String,
-    #[as_ref]
-    second: PathBuf,
-    third: Vec<usize>,
-}
+        assert!(ptr::eq(&item.0, item.as_ref()));
+        assert!(ptr::eq(&item.1, item.as_ref()));
+    }
 
-#[test]
-fn multi_field_struct() {
-    let item = MultiFieldStruct {
-        first: "test".into(),
-        second: PathBuf::new(),
-        third: vec![],
-    };
+    #[derive(AsRef)]
+    struct MultiFieldStruct {
+        #[as_ref]
+        first: String,
+        #[as_ref]
+        second: PathBuf,
+        third: Vec<usize>,
+    }
 
-    assert!(ptr::eq(&item.first, item.as_ref()));
-    assert!(ptr::eq(&item.second, item.as_ref()));
+    #[test]
+    fn multi_field_struct() {
+        let item = MultiFieldStruct {
+            first: "test".into(),
+            second: PathBuf::new(),
+            third: vec![],
+        };
+
+        assert!(ptr::eq(&item.first, item.as_ref()));
+        assert!(ptr::eq(&item.second, item.as_ref()));
+    }
 }
 
 #[derive(AsRef)]

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use core::ptr;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec, vec::Vec};
+use core::ptr;
 
 use derive_more::AsRef;
 
@@ -45,8 +46,9 @@ fn single_field_struct() {
 
 #[cfg(feature = "std")]
 mod pathbuf {
-    use super::*;
     use std::path::PahBuf;
+
+    use super::*;
 
     #[derive(AsRef)]
     struct MultiFieldTuple(#[as_ref] String, #[as_ref] PathBuf, Vec<usize>);

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::Constructor;

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -4,16 +4,12 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-use alloc::format;
-
-use derive_more::Debug;
-
 mod structs {
-    use super::*;
-
     mod unit {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Unit;
@@ -36,7 +32,10 @@ mod structs {
     }
 
     mod single_field {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Tuple(i32);
@@ -58,7 +57,10 @@ mod structs {
         }
 
         mod str_field {
-            use super::*;
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug("i32")] i32);
@@ -85,7 +87,10 @@ mod structs {
         }
 
         mod interpolated_field {
-            use super::*;
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug("{_0}.{}", _0)] i32);
@@ -112,7 +117,10 @@ mod structs {
         }
 
         mod ignore {
-            use super::*;
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug(ignore)] i32);
@@ -134,7 +142,10 @@ mod structs {
     }
 
     mod multi_field {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Tuple(i32, i32);
@@ -172,7 +183,10 @@ mod structs {
         }
 
         mod str_field {
-            use super::*;
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(i32, #[debug("i32")] i32);
@@ -215,7 +229,10 @@ mod structs {
         }
 
         mod interpolated_field {
-            use super::*;
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(i32, #[debug("{_0}.{}", _1)] i32);
@@ -258,7 +275,10 @@ mod structs {
         }
 
         mod ignore {
-            use super::*;
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug(ignore)] i32, i32);
@@ -300,10 +320,8 @@ mod structs {
 }
 
 mod enums {
-    use super::*;
-
     mod no_variants {
-        use super::*;
+        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Void {}
@@ -313,7 +331,10 @@ mod enums {
     }
 
     mod unit_variant {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Enum {
@@ -334,7 +355,10 @@ mod enums {
     }
 
     mod single_field_variant {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Enum {
@@ -420,7 +444,10 @@ mod enums {
     }
 
     mod multi_field_variant {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Enum {
@@ -545,7 +572,10 @@ mod enums {
 }
 
 mod generic {
-    use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
+
+    use derive_more::Debug;
 
     struct NotDebug;
 
@@ -831,7 +861,10 @@ mod generic {
     }
 
     mod associated_type_field_enumerator {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         trait Trait {
             type Type;
@@ -888,7 +921,10 @@ mod generic {
     }
 
     mod complex_type_field_enumerator {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Struct<T>(T);
@@ -944,7 +980,10 @@ mod generic {
     }
 
     mod reference {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[test]
         fn auto_generic_reference() {
@@ -968,7 +1007,10 @@ mod generic {
     }
 
     mod indirect {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Struct<T>(T);
@@ -989,7 +1031,10 @@ mod generic {
     }
 
     mod bound {
-        use super::*;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
 
         #[test]
         fn simple() {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -3,14 +3,17 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::format;
 
+use derive_more::Debug;
+
 mod structs {
     use super::*;
+
     mod unit {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Unit;
@@ -34,7 +37,6 @@ mod structs {
 
     mod single_field {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Tuple(i32);
@@ -57,7 +59,6 @@ mod structs {
 
         mod str_field {
             use super::*;
-            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug("i32")] i32);
@@ -85,7 +86,6 @@ mod structs {
 
         mod interpolated_field {
             use super::*;
-            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug("{_0}.{}", _0)] i32);
@@ -113,7 +113,6 @@ mod structs {
 
         mod ignore {
             use super::*;
-            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug(ignore)] i32);
@@ -136,7 +135,6 @@ mod structs {
 
     mod multi_field {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Tuple(i32, i32);
@@ -175,7 +173,6 @@ mod structs {
 
         mod str_field {
             use super::*;
-            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(i32, #[debug("i32")] i32);
@@ -219,7 +216,6 @@ mod structs {
 
         mod interpolated_field {
             use super::*;
-            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(i32, #[debug("{_0}.{}", _1)] i32);
@@ -263,7 +259,6 @@ mod structs {
 
         mod ignore {
             use super::*;
-            use derive_more::Debug;
 
             #[derive(Debug)]
             struct Tuple(#[debug(ignore)] i32, i32);
@@ -306,8 +301,9 @@ mod structs {
 
 mod enums {
     use super::*;
+
     mod no_variants {
-        use derive_more::Debug;
+        use super::*;
 
         #[derive(Debug)]
         enum Void {}
@@ -318,7 +314,6 @@ mod enums {
 
     mod unit_variant {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Enum {
@@ -340,7 +335,6 @@ mod enums {
 
     mod single_field_variant {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Enum {
@@ -427,7 +421,6 @@ mod enums {
 
     mod multi_field_variant {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         enum Enum {
@@ -553,7 +546,6 @@ mod enums {
 
 mod generic {
     use super::*;
-    use derive_more::Debug;
 
     struct NotDebug;
 
@@ -840,7 +832,6 @@ mod generic {
 
     mod associated_type_field_enumerator {
         use super::*;
-        use derive_more::Debug;
 
         trait Trait {
             type Type;
@@ -898,7 +889,6 @@ mod generic {
 
     mod complex_type_field_enumerator {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Struct<T>(T);
@@ -955,7 +945,6 @@ mod generic {
 
     mod reference {
         use super::*;
-        use derive_more::Debug;
 
         #[test]
         fn auto_generic_reference() {
@@ -980,7 +969,6 @@ mod generic {
 
     mod indirect {
         use super::*;
-        use derive_more::Debug;
 
         #[derive(Debug)]
         struct Struct<T>(T);
@@ -1002,7 +990,6 @@ mod generic {
 
     mod bound {
         use super::*;
-        use derive_more::Debug;
 
         #[test]
         fn simple() {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,7 +1,15 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+
 mod structs {
+    use super::*;
     mod unit {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -25,6 +33,7 @@ mod structs {
     }
 
     mod single_field {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -47,6 +56,7 @@ mod structs {
         }
 
         mod str_field {
+            use super::*;
             use derive_more::Debug;
 
             #[derive(Debug)]
@@ -74,6 +84,7 @@ mod structs {
         }
 
         mod interpolated_field {
+            use super::*;
             use derive_more::Debug;
 
             #[derive(Debug)]
@@ -101,6 +112,7 @@ mod structs {
         }
 
         mod ignore {
+            use super::*;
             use derive_more::Debug;
 
             #[derive(Debug)]
@@ -123,6 +135,7 @@ mod structs {
     }
 
     mod multi_field {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -161,6 +174,7 @@ mod structs {
         }
 
         mod str_field {
+            use super::*;
             use derive_more::Debug;
 
             #[derive(Debug)]
@@ -204,6 +218,7 @@ mod structs {
         }
 
         mod interpolated_field {
+            use super::*;
             use derive_more::Debug;
 
             #[derive(Debug)]
@@ -247,6 +262,7 @@ mod structs {
         }
 
         mod ignore {
+            use super::*;
             use derive_more::Debug;
 
             #[derive(Debug)]
@@ -289,17 +305,19 @@ mod structs {
 }
 
 mod enums {
+    use super::*;
     mod no_variants {
         use derive_more::Debug;
 
         #[derive(Debug)]
         enum Void {}
 
-        const fn assert<T: std::fmt::Debug>() {}
+        const fn assert<T: core::fmt::Debug>() {}
         const _: () = assert::<Void>();
     }
 
     mod unit_variant {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -321,6 +339,7 @@ mod enums {
     }
 
     mod single_field_variant {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -407,6 +426,7 @@ mod enums {
     }
 
     mod multi_field_variant {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -532,6 +552,7 @@ mod enums {
 }
 
 mod generic {
+    use super::*;
     use derive_more::Debug;
 
     struct NotDebug;
@@ -818,6 +839,7 @@ mod generic {
     }
 
     mod associated_type_field_enumerator {
+        use super::*;
         use derive_more::Debug;
 
         trait Trait {
@@ -875,6 +897,7 @@ mod generic {
     }
 
     mod complex_type_field_enumerator {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -931,6 +954,7 @@ mod generic {
     }
 
     mod reference {
+        use super::*;
         use derive_more::Debug;
 
         #[test]
@@ -955,6 +979,7 @@ mod generic {
     }
 
     mod indirect {
+        use super::*;
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -976,6 +1001,7 @@ mod generic {
     }
 
     mod bound {
+        use super::*;
         use derive_more::Debug;
 
         #[test]

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -1,4 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, unused_imports)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use ::alloc::{boxed::Box,vec::Vec};
 
 use derive_more::Deref;
 

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -3,8 +3,9 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
-use ::alloc::{boxed::Box,vec::Vec};
+use ::alloc::{boxed::Box, vec::Vec};
 
 use derive_more::Deref;
 

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -1,6 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, unused_imports)]
 
 use derive_more::DerefMut;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, format, vec, vec::Vec};
 
 #[derive(DerefMut)]
 #[deref_mut(forward)]

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -1,12 +1,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, unused_imports)]
 
-use derive_more::DerefMut;
-
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, vec, vec::Vec};
+
+use derive_more::DerefMut;
 
 #[derive(DerefMut)]
 #[deref_mut(forward)]

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,9 +1,17 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, unused_imports)]
 
-use std::{
-    fmt::{Binary, Display},
-    path::PathBuf,
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
 };
+
+use core::fmt::{Binary, Display};
 
 use derive_more::{Binary, Display, Octal, UpperHex};
 
@@ -331,6 +339,7 @@ mod enums {
 }
 
 mod generic {
+    use super::*;
     use derive_more::Display;
 
     trait Bound {}

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -3,6 +3,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::{
     boxed::Box,
@@ -10,7 +11,6 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-
 use core::fmt::{Binary, Display};
 
 use derive_more::{Binary, Display, Octal, UpperHex};
@@ -340,7 +340,6 @@ mod enums {
 
 mod generic {
     use super::*;
-    use derive_more::Display;
 
     trait Bound {}
 

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -12,6 +12,7 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
+    #[cfg(std)]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
         field: i32,
@@ -98,6 +99,7 @@ fn named_implicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
+#[cfg(std)]
 #[test]
 fn named_implicit_boxed_source() {
     let err = TestErr::NamedImplicitBoxedSource {

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -12,7 +12,7 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
-    #[cfg(std)]
+    #[cfg(feature = "std")]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
         field: i32,
@@ -99,7 +99,7 @@ fn named_implicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(std)]
+#[cfg(feature = "std")]
 #[test]
 fn named_implicit_boxed_source() {
     let err = TestErr::NamedImplicitBoxedSource {

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "std")]
 use std::error::Error;
+
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 
 use derive_more::Error;
 
@@ -29,17 +33,17 @@ use derive_more::Error;
 /// ```
 macro_rules! derive_display {
     (@fmt) => {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
             write!(f, "")
         }
     };
     ($type:ident) => {
-        impl ::std::fmt::Display for $type {
+        impl ::core::fmt::Display for $type {
             derive_display!(@fmt);
         }
     };
     ($type:ident, $($type_parameters:ident),*) => {
-        impl<$($type_parameters),*> ::std::fmt::Display for $type<$($type_parameters),*> {
+        impl<$($type_parameters),*> ::core::fmt::Display for $type<$($type_parameters),*> {
             derive_display!(@fmt);
         }
     };
@@ -50,7 +54,7 @@ mod derives_for_generic_enums_with_source;
 mod derives_for_generic_structs_with_source;
 mod derives_for_structs_with_source;
 
-#[cfg(nightly)]
+#[cfg(all(feature = "std", nightly))]
 mod nightly;
 
 derive_display!(SimpleErr);

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,9 +1,3 @@
-#[cfg(feature = "std")]
-use std::error::Error;
-
-#[cfg(not(feature = "std"))]
-use core::error::Error;
-
 use derive_more::Error;
 
 /// Derives `std::fmt::Display` for structs/enums.

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "std")]
-use std::error::Error;
 #[cfg(not(feature = "std"))]
 use core::error::Error;
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use derive_more::Error;
 

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "std")]
+use std::error::Error;
+
+#[cfg(not(feature = "std"))]
+use core::error::Error;
+
 use derive_more::Error;
 
 /// Derives `std::fmt::Display` for structs/enums.

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "std")]
 use std::error::Error;
-
 #[cfg(not(feature = "std"))]
 use core::error::Error;
 

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 mod error;

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -1,5 +1,16 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    string::{String,ToString},
+    borrow::{Cow},
+};
+
+
+#[cfg(feature = "std")]
 use std::borrow::Cow;
 
 use derive_more::From;
@@ -181,7 +192,7 @@ struct Name(String);
 fn explicit_complex_types_name() {
     let name = "Eärendil";
     let expected = Name(name.into());
-    assert_eq!(expected, name.to_owned().into());
+    assert_eq!(expected, name.to_string().into());
     assert_eq!(expected, name.into());
     assert_eq!(expected, Cow::Borrowed(name).into());
 }

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -3,13 +3,12 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::{
-    string::{String,ToString},
-    borrow::{Cow},
+    borrow::Cow,
+    string::{String, ToString},
 };
-
-
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -3,6 +3,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -1,4 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 use derive_more::FromStr;
 

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, non_camel_case_types)]
 
 use derive_more::{

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -3,6 +3,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -1,4 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, unused_imports)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 use derive_more::Index;
 

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -1,6 +1,13 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use std::borrow::Cow;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    string::{String},
+    borrow::Cow,
+};
 
 use derive_more::Into;
 

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -3,11 +3,9 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
-use alloc::{
-    string::{String},
-    borrow::Cow,
-};
+use alloc::{borrow::Cow, string::String};
 
 use derive_more::Into;
 

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -6,6 +6,8 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::{borrow::Cow, string::String};
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 use derive_more::Into;
 

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -3,10 +3,9 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
-use alloc::{
-    vec::Vec,
-};
+use alloc::vec::Vec;
 
 use derive_more::IntoIterator;
 

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -1,4 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code, unused_imports)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    vec::Vec,
+};
 
 use derive_more::IntoIterator;
 

--- a/tests/is_variant.rs
+++ b/tests/is_variant.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::IsVariant;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 use derive_more::{
     Add, AddAssign, Binary, BitAnd, BitOr, BitXor, Constructor, Deref, DerefMut,
     Display, Div, From, FromStr, Index, IndexMut, Into, IntoIterator, Mul, MulAssign,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use derive_more::{
     Add, AddAssign, Binary, BitAnd, BitOr, BitXor, Constructor, Deref, DerefMut,
     Display, Div, From, FromStr, Index, IndexMut, Into, IntoIterator, Mul, MulAssign,

--- a/tests/mul.rs
+++ b/tests/mul.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::Mul;

--- a/tests/mul_assign.rs
+++ b/tests/mul_assign.rs
@@ -1,6 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use derive_more::MulAssign;
 

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::Not;

--- a/tests/sum.rs
+++ b/tests/sum.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use derive_more::Sum;
 
 #[derive(Sum)]

--- a/tests/sum.rs
+++ b/tests/sum.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 use derive_more::Sum;
 
 #[derive(Sum)]

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -1,4 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 use derive_more::TryInto;
 

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -3,6 +3,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -3,6 +3,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -1,4 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 use derive_more::TryUnwrap;
 

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use derive_more::Unwrap;


### PR DESCRIPTION
## Synopsis

This adds the following line to all of our test files.
```rust
 #![cfg_attr(not(feature = "std"), no_std)]
```

This way we test that all our features also work in no_std environments.


## Checklist

- [ ] ~Documentation is updated (if required)~
- [x] Tests are added/updated (if required)
- [ ] ~[CHANGELOG entry][l:1] is added (if required)~




[l:1]: /CHANGELOG.md
