### PR TITLE
Move fmt module to __private module

### DIFF
--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -268,7 +268,7 @@ impl<'a> Expansion<'a> {
                 let ident_str = self.ident.to_string();
 
                 let out = quote! {
-                    &mut ::derive_more::fmt::debug_tuple(
+                    &mut ::derive_more::__private::debug_tuple(
                         __derive_more_f,
                         #ident_str,
                     )
@@ -281,7 +281,7 @@ impl<'a> Expansion<'a> {
                             Ok::<_, Error>(out)
                         }
                         Some(FieldAttribute::Fmt(fmt)) => Ok(quote! {
-                            ::derive_more::fmt::DebugTuple::field(
+                            ::derive_more::__private::DebugTuple::field(
                                 #out,
                                 &::core::format_args!(#fmt),
                             )
@@ -289,15 +289,15 @@ impl<'a> Expansion<'a> {
                         None => {
                             let ident = format_ident!("_{i}");
                             Ok(quote! {
-                                ::derive_more::fmt::DebugTuple::field(#out, #ident)
+                                ::derive_more::__private::DebugTuple::field(#out, #ident)
                             })
                         }
                     },
                 )?;
                 Ok(if exhaustive {
-                    quote! { ::derive_more::fmt::DebugTuple::finish(#out) }
+                    quote! { ::derive_more::__private::DebugTuple::finish(#out) }
                 } else {
-                    quote! { ::derive_more::fmt::DebugTuple::finish_non_exhaustive(#out) }
+                    quote! { ::derive_more::__private::DebugTuple::finish_non_exhaustive(#out) }
                 })
             }
             syn::Fields::Named(named) => {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,7 +1,7 @@
 //! [`core::fmt::DebugTuple`] reimplementation with
 //! [`DebugTuple::finish_non_exhaustive()`] method.
 
-pub use core::fmt::{Debug, Error, Formatter, Result, Write};
+use core::fmt::{Debug, Formatter, Result, Write};
 
 /// Same as [`core::fmt::DebugTuple`], but with
 /// [`DebugTuple::finish_non_exhaustive()`] method.
@@ -34,13 +34,13 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Example
     ///
     /// ```rust
-    /// use derive_more::fmt;
+    /// use derive_more::__private::debug_tuple;
     ///
     /// struct Foo(i32, String);
     ///
-    /// impl fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         fmt::debug_tuple(fmt, "Foo")
+    /// impl core::fmt::Debug for Foo {
+    ///     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    ///         debug_tuple(fmt, "Foo")
     ///             .field(&self.0) // We add the first field.
     ///             .field(&self.1) // We add the second field.
     ///             .finish() // We're good to go!
@@ -78,13 +78,13 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Example
     ///
     /// ```
-    /// use derive_more::fmt;
+    /// use derive_more::__private::debug_tuple;
     ///
     /// struct Foo(i32, String);
     ///
-    /// impl fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         fmt::debug_tuple(fmt, "Foo")
+    /// impl core::fmt::Debug for Foo {
+    ///     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    ///         debug_tuple(fmt, "Foo")
     ///             .field(&self.0)
     ///             .field(&self.1)
     ///             .finish() // You need to call it to "finish" the
@@ -116,13 +116,13 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Example
     ///
     /// ```rust
-    /// use derive_more::fmt;
+    /// use derive_more::__private::debug_tuple;
     ///
     /// struct Bar(i32, f32);
     ///
-    /// impl fmt::Debug for Bar {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         fmt::debug_tuple(fmt, "Bar")
+    /// impl core::fmt::Debug for Bar {
+    ///     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    ///         debug_tuple(fmt, "Bar")
     ///             .field(&self.0)
     ///             .finish_non_exhaustive() // Show that some other field(s) exist.
     ///     }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -34,12 +34,13 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Example
     ///
     /// ```rust
+    /// use core::fmt;
     /// use derive_more::__private::debug_tuple;
     ///
     /// struct Foo(i32, String);
     ///
-    /// impl core::fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    /// impl fmt::Debug for Foo {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         debug_tuple(fmt, "Foo")
     ///             .field(&self.0) // We add the first field.
     ///             .field(&self.1) // We add the second field.
@@ -78,12 +79,13 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Example
     ///
     /// ```
+    /// use core::fmt;
     /// use derive_more::__private::debug_tuple;
     ///
     /// struct Foo(i32, String);
     ///
-    /// impl core::fmt::Debug for Foo {
-    ///     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    /// impl fmt::Debug for Foo {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         debug_tuple(fmt, "Foo")
     ///             .field(&self.0)
     ///             .field(&self.1)
@@ -116,12 +118,13 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Example
     ///
     /// ```rust
+    /// use core::fmt;
     /// use derive_more::__private::debug_tuple;
     ///
     /// struct Bar(i32, f32);
     ///
-    /// impl core::fmt::Debug for Bar {
-    ///     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    /// impl fmt::Debug for Bar {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         debug_tuple(fmt, "Bar")
     ///             .field(&self.0)
     ///             .finish_non_exhaustive() // Show that some other field(s) exist.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod try_unwrap;
 pub use self::try_unwrap::TryUnwrapError;
 
 #[cfg(feature = "debug")]
-pub mod fmt;
+mod fmt;
 
 #[cfg(any(feature = "add", feature = "not"))]
 pub mod ops;
@@ -75,9 +75,12 @@ mod vendor;
 
 // Not public API.
 #[doc(hidden)]
-#[cfg(feature = "error")]
 pub mod __private {
+    #[cfg(feature = "error")]
     pub use crate::vendor::thiserror::aserror::AsDynError;
+
+    #[cfg(feature = "debug")]
+    pub use crate::fmt::{debug_tuple, DebugTuple};
 }
 
 #[cfg(not(any(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 // These links overwrite the ones in `README.md`
 // to become proper intra-doc links in Rust docs.
 //! [`From`]: crate::From
@@ -42,6 +40,8 @@
     ),
     doc = include_str!("../README.md")
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![forbid(non_ascii_idents, unsafe_code)]
@@ -77,9 +77,9 @@ mod vendor;
 // Not public API.
 #[doc(hidden)]
 pub mod __private {
-    #[cfg(not(feature = "std"))]
+    #[cfg(all(feature = "error", not(feature = "std")))]
     pub use ::core::error::Error;
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "error", feature = "std"))]
     pub use ::std::error::Error;
 
     #[cfg(feature = "error")]


### PR DESCRIPTION
There were a whole bunch of exports and re-exports in the `fmt` module
of things that should not be public API of this crate, but instead are
implementation details. So this limits the amount of things we export
from that module, and it also moves the things we do export the
`__private` module.
