### PR TITLE
Fix docs on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,11 @@ jobs:
         with:
           toolchain: nightly
 
-      - run: cargo +nightly doc --workspace --all-features
+      - run: cargo +nightly doc -p derive_more-impl --features full
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
+
+      - run: cargo +nightly doc -p derive_more --features full
         env:
           RUSTDOCFLAGS: --cfg docsrs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,11 @@ jobs:
 
       - run: cargo +nightly doc -p derive_more-impl --features full
         env:
-          RUSTDOCFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs --cfg ci
 
       - run: cargo +nightly doc -p derive_more --features full
         env:
-          RUSTDOCFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs --cfg ci
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ trybuild = "1.0.56"
 github = { repository = "JelteF/derive_more", workflow = "CI" }
 
 [package.metadata.docs.rs]
+features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -40,6 +40,7 @@ itertools = "0.11.0"
 github = { repository = "JelteF/derive_more", workflow = "CI" }
 
 [package.metadata.docs.rs]
+features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -69,5 +70,32 @@ sum = []
 try_into = ["syn/extra-traits"]
 try_unwrap = ["dep:convert_case"]
 unwrap = ["dep:convert_case"]
+
+full = [
+    "add",
+    "add_assign",
+    "as_mut",
+    "as_ref",
+    "constructor",
+    "debug",
+    "deref",
+    "deref_mut",
+    "display",
+    "error",
+    "from",
+    "from_str",
+    "index",
+    "index_mut",
+    "into",
+    "into_iterator",
+    "is_variant",
+    "mul",
+    "mul_assign",
+    "not",
+    "sum",
+    "try_into",
+    "try_unwrap",
+    "unwrap",
+]
 
 testing-helpers = ["dep:rustc_version"]

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![recursion_limit = "128"]
-#![deny(rustdoc::all)]
+#![cfg_attr(any(not(docsrs), ci), deny(rustdoc::all))]
 #![forbid(non_ascii_idents, unsafe_code)]
 #![warn(clippy::nonstandard_macro_braces)]
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![recursion_limit = "128"]
-#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+#![deny(rustdoc::all)]
 #![forbid(non_ascii_idents, unsafe_code)]
 #![warn(clippy::nonstandard_macro_braces)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+#![deny(rustdoc::all)]
 #![forbid(non_ascii_idents, unsafe_code)]
 #![warn(clippy::nonstandard_macro_braces)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![deny(rustdoc::all)]
+#![cfg_attr(any(not(docsrs), ci), deny(rustdoc::all))]
 #![forbid(non_ascii_idents, unsafe_code)]
 #![warn(clippy::nonstandard_macro_braces)]
 


### PR DESCRIPTION
## Synopsis

We have a [broken build on docs.rs](https://docs.rs/crate/derive_more/1.0.0-beta.1/builds/868214) for the [latest release](https://github.com/JelteF/derive_more/releases/tag/v1.0.0-beta.1).




## Solution

- Use `full` feature on docs.rs to build crate docs.
- Add the `full` feature to `derive_more-impl` crate too, just for the same purpose.
- Correct CI to check building docs exactly as they're built on docs.rs.





## Additionally

Switch to `rustdoc::all` lints.



## Checklist

- [x] Documentation is updated
- [x] Tests are added/updated
- [x] ~~[CHANGELOG entry][l:1] is added (if required)~~




[l:1]: /CHANGELOG.md
