### PR TITLE
Fix non-hidden docs on docs.rs 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,32 @@
 // These links overwrite the ones in `README.md`
 // to become proper intra-doc links in Rust docs.
-//! [`From`]: crate::From
-//! [`Into`]: crate::Into
-//! [`FromStr`]: crate::FromStr
-//! [`TryInto`]: crate::TryInto
-//! [`IntoIterator`]: crate::IntoIterator
-//! [`AsRef`]: crate::AsRef
+//! [`From`]: macro@crate::From
+//! [`Into`]: macro@crate::Into
+//! [`FromStr`]: macro@crate::FromStr
+//! [`TryInto`]: macro@crate::TryInto
+//! [`IntoIterator`]: macro@crate::IntoIterator
+//! [`AsRef`]: macro@crate::AsRef
 //!
-//! [`Debug`]: crate::Debug
-//! [`Display`-like]: crate::Display
+//! [`Debug`]: macro@crate::Debug
+//! [`Display`-like]: macro@crate::Display
 //!
-//! [`Error`]: crate::Error
+//! [`Error`]: macro@crate::Error
 //!
-//! [`Index`]: crate::Index
-//! [`Deref`]: crate::Deref
-//! [`Not`-like]: crate::Not
-//! [`Add`-like]: crate::Add
-//! [`Mul`-like]: crate::Mul
-//! [`Sum`-like]: crate::Sum
-//! [`IndexMut`]: crate::IndexMut
-//! [`DerefMut`]: crate::DerefMut
-//! [`AddAssign`-like]: crate::AddAssign
-//! [`MulAssign`-like]: crate::MulAssign
+//! [`Index`]: macro@crate::Index
+//! [`Deref`]: macro@crate::Deref
+//! [`Not`-like]: macro@crate::Not
+//! [`Add`-like]: macro@crate::Add
+//! [`Mul`-like]: macro@crate::Mul
+//! [`Sum`-like]: macro@crate::Sum
+//! [`IndexMut`]: macro@crate::IndexMut
+//! [`DerefMut`]: macro@crate::DerefMut
+//! [`AddAssign`-like]: macro@crate::AddAssign
+//! [`MulAssign`-like]: macro@crate::MulAssign
 //!
-//! [`Constructor`]: crate::Constructor
-//! [`IsVariant`]: crate::IsVariant
-//! [`Unwrap`]: crate::Unwrap
-//! [`TryUnwrap`]: crate::TryUnwrap
+//! [`Constructor`]: macro@crate::Constructor
+//! [`IsVariant`]: macro@crate::IsVariant
+//! [`Unwrap`]: macro@crate::Unwrap
+//! [`TryUnwrap`]: macro@crate::TryUnwrap
 
 // The README includes doctests requiring these features. To make sure that
 // tests pass when not all features are provided we exclude it when the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,15 +97,14 @@ pub use self::try_unwrap::TryUnwrapError;
 // derive.
 macro_rules! re_export_traits((
     $feature:literal, $new_module_name:ident, $module:path $(, $traits:ident)* $(,)?) => {
-        #[cfg(feature = $feature)]
+        #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
         mod $new_module_name {
             pub use $module::{$($traits),*};
         }
 
-        #[cfg(feature = $feature)]
+        #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
         #[doc(hidden)]
         pub use crate::$new_module_name::*;
-
     }
 );
 


### PR DESCRIPTION
Resolves #276, #278




## Synopsis

See #276:
> Somehow docs.rs is displaying all re-exported traits anyway. Eventhough they are marked as `#[docs(hidden)]`.




## Solution

1. Do not import traits when building on `docs.rs` (fixes #276).
2. Use `macro@` prefix for README intra-doc links to disambiguate them with traits (fixes #278).

The result can be checked by running the command reproducing `docs.rs` build nearly:
```bash
RUSTDOCFLAGS='--cfg docsrs' cargo rustdoc -p derive_more --features full --open
```


## Checklist

- [x] Documentation is updated (if required)
- [x] ~~Tests are added/updated~~ (not required)
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
