### PR TITLE
Lift trait bounds from `#[debug(skip)]` fields (#281)

### DIFF
--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -47,9 +47,10 @@ trait Trait { type Type; }
 ```
 
 The following where clauses would be generated:
-* `T1: Display + Pointer`
-* `<T2 as Trait>::Type: Debug`
-* `Bar<T3>: Display`
+- `T1: Display`
+- `<T2 as Trait>::Type: Display`
+- `Vec<T3>: Debug`
+- `&'a T1: Pointer`
 
 
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -574,10 +574,17 @@ mod enums {
 mod generic {
     #[cfg(not(feature = "std"))]
     use alloc::format;
+    use core::fmt;
 
     use derive_more::Debug;
 
     struct NotDebug;
+
+    impl fmt::Display for NotDebug {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_tuple("NotDebug").finish()
+        }
+    }
 
     #[derive(Debug)]
     struct NamedGenericStruct<T> {
@@ -626,6 +633,14 @@ mod generic {
         assert_eq!(
             format!("{:#?}", InterpolatedNamedGenericStruct { field: 1 }),
             "InterpolatedNamedGenericStruct {\n    field: 1.1,\n}",
+        );
+        assert_eq!(
+            format!("{:?}", InterpolatedNamedGenericStruct { field: NotDebug }),
+            "InterpolatedNamedGenericStruct { field: NotDebug.NotDebug }",
+        );
+        assert_eq!(
+            format!("{:#?}", InterpolatedNamedGenericStruct { field: NotDebug }),
+            "InterpolatedNamedGenericStruct {\n    field: NotDebug.NotDebug,\n}",
         );
     }
 
@@ -756,6 +771,14 @@ mod generic {
         assert_eq!(
             format!("{:#?}", InterpolatedUnnamedGenericStruct(2)),
             "InterpolatedUnnamedGenericStruct(\n    2.2,\n)",
+        );
+        assert_eq!(
+            format!("{:?}", InterpolatedUnnamedGenericStruct(NotDebug)),
+            "InterpolatedUnnamedGenericStruct(NotDebug.NotDebug)",
+        );
+        assert_eq!(
+            format!("{:#?}", InterpolatedUnnamedGenericStruct(NotDebug)),
+            "InterpolatedUnnamedGenericStruct(\n    NotDebug.NotDebug,\n)",
         );
     }
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -579,14 +579,6 @@ mod generic {
 
     struct NotDebug;
 
-    trait Bound {}
-
-    impl Bound for () {}
-
-    fn display_bound<T: Bound>(_: &T) -> &'static str {
-        "()"
-    }
-
     #[derive(Debug)]
     struct NamedGenericStruct<T> {
         field: T,
@@ -600,6 +592,23 @@ mod generic {
         assert_eq!(
             format!("{:#?}", NamedGenericStruct { field: 1 }),
             "NamedGenericStruct {\n    field: 1,\n}",
+        );
+    }
+
+    #[derive(Debug)]
+    struct NamedGenericStructIgnored<T> {
+        #[debug(ignore)]
+        field: T,
+    }
+    #[test]
+    fn named_generic_struct_ignored() {
+        assert_eq!(
+            format!("{:?}", NamedGenericStructIgnored { field: NotDebug }),
+            "NamedGenericStructIgnored { .. }",
+        );
+        assert_eq!(
+            format!("{:#?}", NamedGenericStructIgnored { field: NotDebug }),
+            "NamedGenericStructIgnored { .. }",
         );
     }
 
@@ -719,6 +728,20 @@ mod generic {
         assert_eq!(
             format!("{:#?}", UnnamedGenericStruct(2)),
             "UnnamedGenericStruct(\n    2,\n)",
+        );
+    }
+
+    #[derive(Debug)]
+    struct UnnamedGenericStructIgnored<T>(#[debug(skip)] T);
+    #[test]
+    fn unnamed_generic_struct_ignored() {
+        assert_eq!(
+            format!("{:?}", UnnamedGenericStructIgnored(NotDebug)),
+            "UnnamedGenericStructIgnored(..)",
+        );
+        assert_eq!(
+            format!("{:#?}", UnnamedGenericStructIgnored(NotDebug)),
+            "UnnamedGenericStructIgnored(..)",
         );
     }
 


### PR DESCRIPTION
Resolves #281




## Synopsis

See #281:
> ```rs
> struct NoDebug;
>                                      
> #[derive(derive_more::Debug)]
> struct HasDebug<T>(#[debug(skip)] T);
>                                      
> dbg!(HasDebug(NoDebug));
> ```
>
> I'd be fine with needing to manually specify something like `#[debug(bounds())]`.




## Solution

Fix how `ignore`/`skip` attributes are considered in bounding of `derive(Debug)` macro.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
