### PR TITLE
Fix IntoIterator derived bounds (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix `Error` derive not working with `const` generics.
 - Support trait objects for source in Error, e.g.
   `Box<dyn Error + Send + 'static>`
-- Fix bounds on derived `IntoIterator` impls for generic structs
+- Fix bounds on derived `IntoIterator` impls for generic structs.
   ([#284](https://github.com/JelteF/derive_more/pull/284))
 
 ## 0.99.10 - 2020-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix `Error` derive not working with `const` generics.
 - Support trait objects for source in Error, e.g.
   `Box<dyn Error + Send + 'static>`
+- Fix bounds on derived `IntoIterator` impls for generic structs
+  ([#284](https://github.com/JelteF/derive_more/pull/284))
 
 ## 0.99.10 - 2020-09-11
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -152,27 +152,6 @@ pub fn add_extra_ty_param_bound<'a>(
     generics
 }
 
-pub fn add_extra_ty_param_bound_ref<'a>(
-    generics: &'a Generics,
-    bound: &'a TokenStream,
-    ref_type: RefType,
-) -> Generics {
-    match ref_type {
-        RefType::No => add_extra_ty_param_bound(generics, bound),
-        _ => {
-            let generics = generics.clone();
-            let idents = generics.type_params().map(|x| &x.ident);
-            let ref_with_lifetime = ref_type.reference_with_lifetime();
-            add_extra_where_clauses(
-                &generics,
-                quote! {
-                    where #(#ref_with_lifetime #idents: #bound),*
-                },
-            )
-        }
-    }
-}
-
 pub fn add_extra_generic_param(
     generics: &Generics,
     generic_param: TokenStream,

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -142,9 +142,9 @@ fn generic_bounds() {
 }
 
 #[derive(IntoIterator)]
-struct Generic3<'a, T> {
-    #[into_iterator(owned, ref, ref_mut)]
-    items: Vec<&'a mut T>,
+struct Generic3<'a, 'b, T> {
+    #[into_iterator(owned)]
+    items: &'a mut Vec<&'b mut T>,
 }
 
 #[test]
@@ -152,10 +152,15 @@ fn generic_refs() {
     let mut numbers = vec![1, 2, 3];
     let mut numbers2 = numbers.clone();
 
-    let number_refs = numbers.iter_mut().collect::<Vec<_>>();
-    let number_refs2 = numbers2.iter_mut().collect::<Vec<_>>();
+    let mut number_refs = numbers.iter_mut().collect::<Vec<_>>();
+    let mut number_refs2 = numbers2.iter_mut().collect::<Vec<_>>();
 
-    test_into_iter_all(Generic3 { items: number_refs }, number_refs2);
+    test_into_iter(
+        Generic3 {
+            items: &mut number_refs,
+        },
+        &number_refs2.iter_mut().collect::<Vec<_>>(),
+    )
 }
 
 #[derive(IntoIterator)]

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -37,6 +37,7 @@ struct MyVec(Vec<i32>);
 #[test]
 fn tuple_single() {
     let numbers = vec![1, 2, 3];
+
     test_into_iter_all(MyVec(numbers.clone()), numbers);
 }
 
@@ -49,6 +50,7 @@ struct Numbers {
 #[test]
 fn named_single() {
     let numbers = vec![1, 2, 3];
+
     test_into_iter_all(
         Numbers {
             numbers: numbers.clone(),
@@ -67,6 +69,7 @@ struct Numbers2 {
 
 fn named_many() {
     let numbers = vec![1, 2, 3];
+
     test_into_iter_all(
         Numbers2 {
             numbers: numbers.clone(),
@@ -105,6 +108,7 @@ struct Generic1<T> {
 #[test]
 fn generic() {
     let numbers = vec![1, 2, 3];
+
     test_into_iter_all(
         Generic1 {
             items: numbers.clone(),
@@ -127,6 +131,7 @@ where
 fn generic_bounds() {
     let numbers = vec![1, 2, 3];
     let useless = false;
+
     test_into_iter_all(
         Generic2 {
             items: numbers.clone(),
@@ -146,8 +151,10 @@ struct Generic3<'a, T> {
 fn generic_refs() {
     let mut numbers = vec![1, 2, 3];
     let mut numbers2 = numbers.clone();
+
     let number_refs = numbers.iter_mut().collect::<Vec<_>>();
     let number_refs2 = numbers2.iter_mut().collect::<Vec<_>>();
+
     test_into_iter_all(Generic3 { items: number_refs }, number_refs2);
 }
 
@@ -161,6 +168,7 @@ struct Generic4<T> {
 #[test]
 fn generic_owned() {
     let numbers = vec![1, 2, 3];
+
     test_into_iter(
         Generic4 {
             items: numbers.clone(),

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -53,7 +53,10 @@ struct Generic1<T> {
 }
 
 #[derive(IntoIterator)]
-struct Generic2<'a, T, U> {
+struct Generic2<'a, T, U: Send>
+where
+    T: Send,
+{
     #[into_iterator(owned, ref, ref_mut)]
     items: Vec<T>,
     useless: &'a U,

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -45,3 +45,22 @@ impl ::core::iter::IntoIterator for Numbers3 {
         <Vec<i32> as ::core::iter::IntoIterator>::into_iter(self.numbers)
     }
 }
+
+#[derive(IntoIterator)]
+struct Generic1<T> {
+    #[into_iterator(owned, ref, ref_mut)]
+    items: Vec<T>,
+}
+
+#[derive(IntoIterator)]
+struct Generic2<'a, T, U> {
+    #[into_iterator(owned, ref, ref_mut)]
+    items: Vec<T>,
+    useless: &'a U,
+}
+
+#[derive(IntoIterator)]
+struct Generic3<'a, 'b, T> {
+    #[into_iterator(owned, ref, ref_mut)]
+    items: &'a mut Vec<&'b mut T>,
+}

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -2,12 +2,13 @@
 #![allow(dead_code, unused_imports)]
 
 #[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use derive_more::IntoIterator;
 

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -150,3 +150,22 @@ fn generic_refs() {
     let number_refs2 = numbers2.iter_mut().collect::<Vec<_>>();
     test_into_iter_all(Generic3 { items: number_refs }, number_refs2);
 }
+
+#[derive(IntoIterator)]
+struct Generic4<T> {
+    #[into_iterator]
+    items: Vec<T>,
+    useless: bool,
+}
+
+#[test]
+fn generic_owned() {
+    let numbers = vec![1, 2, 3];
+    test_into_iter(
+        Generic4 {
+            items: numbers.clone(),
+            useless: true,
+        },
+        &numbers,
+    );
+}


### PR DESCRIPTION
Resolves #208 

## Synopsis

For generic structs, some derived IntoIterator bounds are based on the struct's type parameters, rather than the field used in the implementation.

## Solution

Require only the type of the field used to be `IntoIterator`


## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)


## Note

I don't think this is a breaking change, since no program where the newly added bounds aren't satisfied would have compiled.

[l:1]: /CHANGELOG.md
