### PR TITLE
Fix legacy diagnostic for `Display`-like macros

### DIFF
--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -13,8 +13,15 @@ use syn::{
     TypeParamBound, Variant, WhereClause,
 };
 
+#[cfg(any(
+    feature = "debug",
+    feature = "display",
+    feature = "from",
+    feature = "into",
+))]
+pub(crate) use self::either::Either;
 #[cfg(any(feature = "from", feature = "into"))]
-pub(crate) use self::{either::Either, fields_ext::FieldsExt};
+pub(crate) use self::fields_ext::FieldsExt;
 
 #[derive(Clone, Copy, Default)]
 pub struct DeterministicState;
@@ -1347,10 +1354,16 @@ pub fn is_type_parameter_used_in_type(
     }
 }
 
-#[cfg(any(feature = "from", feature = "into"))]
+#[cfg(any(
+    feature = "debug",
+    feature = "display",
+    feature = "from",
+    feature = "into",
+))]
 mod either {
     use proc_macro2::TokenStream;
     use quote::ToTokens;
+    use syn::parse::{Parse, ParseStream};
 
     /// Either [`Left`] or [`Right`].
     ///
@@ -1362,6 +1375,20 @@ mod either {
 
         /// Right variant.
         Right(R),
+    }
+
+    impl<L, R> Parse for Either<L, R>
+    where
+        L: Parse,
+        R: Parse,
+    {
+        fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+            if L::parse(&input.fork()).is_ok() {
+                L::parse(input).map(Self::Left)
+            } else {
+                R::parse(input).map(Self::Right)
+            }
+        }
     }
 
     impl<L, R, T> Iterator for Either<L, R>

--- a/tests/compile_fail/debug/legacy_fmt_syntax.rs
+++ b/tests/compile_fail/debug/legacy_fmt_syntax.rs
@@ -4,4 +4,8 @@ pub struct Foo {
     bar: String,
 }
 
+#[derive(derive_more::Debug)]
+#[debug(fmt = "Stuff({}): {}", _0)]
+pub struct Bar(String);
+
 fn main() {}

--- a/tests/compile_fail/debug/legacy_fmt_syntax.stderr
+++ b/tests/compile_fail/debug/legacy_fmt_syntax.stderr
@@ -3,3 +3,9 @@ error: legacy syntax, remove `fmt =` and use `"Stuff({}): {}", bar` instead
   |
 3 |     #[debug(fmt = "Stuff({}): {}", "bar")]
   |             ^^^
+
+error: legacy syntax, remove `fmt =` and use `"Stuff({}): {}", _0` instead
+ --> tests/compile_fail/debug/legacy_fmt_syntax.rs:8:9
+  |
+8 | #[debug(fmt = "Stuff({}): {}", _0)]
+  |         ^^^

--- a/tests/compile_fail/display/legacy_fmt_syntax.rs
+++ b/tests/compile_fail/display/legacy_fmt_syntax.rs
@@ -4,4 +4,8 @@ pub struct Foo {
     bar: String,
 }
 
+#[derive(derive_more::Display)]
+#[display(fmt = "Stuff({}): {}", _0)]
+pub struct Bar(String);
+
 fn main() {}

--- a/tests/compile_fail/display/legacy_fmt_syntax.stderr
+++ b/tests/compile_fail/display/legacy_fmt_syntax.stderr
@@ -5,7 +5,7 @@ error: legacy syntax, remove `fmt =` and use `"Stuff({}): {}", bar` instead
   |           ^^^
 
 error: legacy syntax, remove `fmt =` and use `"Stuff({}): {}", _0` instead
-  --> tests/compile_fail/display/legacy_fmt_syntax.rs:8:11
+ --> tests/compile_fail/display/legacy_fmt_syntax.rs:8:11
   |
 8 | #[display(fmt = "Stuff({}): {}", _0)]
   |           ^^^

--- a/tests/compile_fail/display/legacy_fmt_syntax.stderr
+++ b/tests/compile_fail/display/legacy_fmt_syntax.stderr
@@ -3,3 +3,9 @@ error: legacy syntax, remove `fmt =` and use `"Stuff({}): {}", bar` instead
   |
 2 | #[display(fmt = "Stuff({}): {}", "bar")]
   |           ^^^
+
+error: legacy syntax, remove `fmt =` and use `"Stuff({}): {}", _0` instead
+  --> tests/compile_fail/display/legacy_fmt_syntax.rs:8:11
+  |
+8 | #[display(fmt = "Stuff({}): {}", _0)]
+  |           ^^^


### PR DESCRIPTION
Related to #225




## Synopsis

Diagnostic introduced in #225 regarding old syntax usage, displays incorrect message in case formatting arguments are specified as identifiers (not string literals):

```rust
#[derive(derive_more::Display)]
#[display(fmt = "Stuff({}): {}", _0)]
pub struct Bar(String);
```

```
error: unknown attribute, expected `bound(...)`
 --> tests/compile_fail/display/legacy_fmt_syntax.rs:8:11
  |
8 | #[display(fmt = "Stuff({}): {}", _0)]
  |           ^^^
```

In my experience, this situation happens very often in the wild.



## Solution

Fix the diagnostic to consider ident formatting arguments properly.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated (if required)
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
