### PR TITLE
Add `derive` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#206](https://github.com/JelteF/derive_more/pull/206))
 - Add support for container format in `Debug` derive with the same syntax as `Display` derives.
   ([#279](https://github.com/JelteF/derive_more/pull/279))
+- `derive_more::derive` module exporting only macros, without traits. ([#290](https://github.com/JelteF/derive_more/pull/290))
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,14 @@ pub mod __private {
     pub use crate::vendor::thiserror::aserror::AsDynError;
 }
 
+/// Module containing macro definitions only, without corresponding traits.
+///
+/// Use it in your import paths, if you don't want to import traits, but only macros.
+pub mod derive {
+    #[doc(inline)]
+    pub use derive_more_impl::*;
+}
+
 // The modules containing error types and other helpers.
 
 #[cfg(feature = "add")]


### PR DESCRIPTION
Resolves https://github.com/JelteF/derive_more/issues/259#issuecomment-1673947234




## Solution

Add `derive_more::derive` module, re-exporting macros only.




## Checklist

- [x] Documentation is updated
- [x] ~~Tests are added/updated~~ (not required)
- [x] [CHANGELOG entry][l:1] is added




[l:1]: /CHANGELOG.md
