### PR TITLE
Fix generated `Error::provide` and tests to reflect changes in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `Into` derive now uses `#[into(<types>)]` instead of `#[into(types(<types>))]`
   and ignores field type itself.
 - Importing a derive macro now also import its corresponding trait.
-- The `Error` derive is updated with changes to the `error_generic_member_access` unstable feature
+- The `Error` derive is updated with changes to the `error_generic_member_access` unstable feature for nightly users. ([#200](https://github.com/JelteF/derive_more/pull/200), [#294](https://github.com/JelteF/derive_more/pull/294))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `Into` derive now uses `#[into(<types>)]` instead of `#[into(types(<types>))]`
   and ignores field type itself.
 - Importing a derive macro now also import its corresponding trait.
+- The `Error` derive is updated with changes to the `error_generic_member_access` unstable feature
 
 ### Added
 

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -59,12 +59,13 @@ Backtraces don't work though, because the `Backtrace` type is only available in
 ## Example usage
 
 ```rust
-# #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
+# #![cfg_attr(nightly, feature(error_generic_member_access, error_in_core))]
 // Nightly requires enabling these features:
-// #![feature(error_generic_member_access, provide_any)]
+// #![feature(error_generic_member_access, error_in_core)]
 # #[cfg(not(nightly))] fn main() {}
 # #[cfg(nightly)] fn main() {
-# use std::{any, error::Error as _, backtrace::Backtrace};
+# use core::error::{request_ref, request_value, Error as __};
+# use std::backtrace::Backtrace;
 #
 # use derive_more::{Display, Error, From};
 
@@ -129,7 +130,7 @@ enum CompoundError {
 }
 
 assert!(Simple.source().is_none());
-assert!(any::request_ref::<Backtrace>(&Simple).is_none());
+assert!(request_ref::<Backtrace>(&Simple).is_none());
 assert!(WithSource::default().source().is_some());
 assert!(WithExplicitSource::default().source().is_some());
 assert!(Tuple::default().source().is_some());
@@ -139,7 +140,7 @@ let with_source_and_backtrace = WithSourceAndBacktrace {
     backtrace: Backtrace::capture(),
 };
 assert!(with_source_and_backtrace.source().is_some());
-assert!(any::request_ref::<Backtrace>(&with_source_and_backtrace).is_some());
+assert!(request_ref::<Backtrace>(&with_source_and_backtrace).is_some());
 
 assert!(CompoundError::Simple.source().is_none());
 assert!(CompoundError::from(Simple).source().is_some());

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -47,7 +47,7 @@ pub fn expand(
 
     let provide = provide.map(|provide| {
         quote! {
-            fn provide<'_demand>(&'_demand self, demand: &mut ::core::any::Demand<'_demand>) {
+            fn provide<'_request>(&'_request self, request: &mut ::core::error::Request<'_request>) {
                 #provide
             }
         }
@@ -205,7 +205,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
         let source_provider = self.source.map(|source| {
             let source_expr = &self.data.members[source];
             quote! {
-                ::derive_more::Error::provide(&#source_expr, demand);
+                ::derive_more::Error::provide(&#source_expr, request);
             }
         });
         let backtrace_provider = self
@@ -215,7 +215,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
             .then(|| {
                 let backtrace_expr = &self.data.members[backtrace];
                 quote! {
-                    demand.provide_ref::<::std::backtrace::Backtrace>(&#backtrace_expr);
+                    request.provide_ref::<::std::backtrace::Backtrace>(&#backtrace_expr);
                 }
             });
 
@@ -235,7 +235,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
-                        ::derive_more::Error::provide(source, demand);
+                        ::derive_more::Error::provide(source, request);
                     }
                 })
             }
@@ -246,8 +246,8 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 );
                 Some(quote! {
                     #pattern => {
-                        demand.provide_ref::<::std::backtrace::Backtrace>(backtrace);
-                        ::derive_more::Error::provide(source, demand);
+                        request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
+                        ::derive_more::Error::provide(source, request);
                     }
                 })
             }
@@ -255,7 +255,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 let pattern = self.data.matcher(&[backtrace], &[quote! { backtrace }]);
                 Some(quote! {
                     #pattern => {
-                        demand.provide_ref::<::std::backtrace::Backtrace>(backtrace);
+                        request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                     }
                 })
             }

--- a/tests/error/nightly/derives_for_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_enums_with_backtrace.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::any;
+use core::error::{request_ref, request_value};
 
 use super::*;
 
@@ -146,7 +146,7 @@ impl TestErr {
     }
 
     fn get_source_backtrace(&self) -> &Backtrace {
-        any::request_ref(match self {
+        request_ref(match self {
             Self::NamedExplicitBacktraceFromSource { err }
             | Self::NamedExplicitDifferentSourceAndBacktrace { err, .. }
             | Self::NamedImplicitDifferentSourceAndBacktrace { err, .. }
@@ -163,14 +163,14 @@ type MyBacktrace = Backtrace;
 
 #[test]
 fn unit() {
-    assert!(any::request_ref::<Backtrace>(&TestErr::Unit).is_none());
+    assert!(request_ref::<Backtrace>(&TestErr::Unit).is_none());
 }
 
 #[test]
 fn named_implicit_no_backtrace() {
     let err = TestErr::NamedImplicitNoBacktrace { field: 0 };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn named_implicit_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -191,7 +191,7 @@ fn named_implicit_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -202,7 +202,7 @@ fn named_explicit_no_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -212,7 +212,7 @@ fn named_explicit_no_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn named_explicit_backtrace() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -233,7 +233,7 @@ fn named_explicit_no_backtrace_redundant() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -243,7 +243,7 @@ fn named_explicit_backtrace_by_field_name_redundant() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -254,7 +254,7 @@ fn named_explicit_backtrace_by_field_type_redundant() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -266,7 +266,7 @@ fn named_explicit_suppresses_implicit() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
 }
@@ -280,8 +280,8 @@ fn named_implicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -293,8 +293,8 @@ fn named_explicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -306,8 +306,8 @@ fn named_explicit_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_source_backtrace);
 }
 
@@ -321,8 +321,8 @@ fn named_implicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }
@@ -337,8 +337,8 @@ fn named_explicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }
@@ -347,14 +347,14 @@ fn named_explicit_different_source_and_backtrace() {
 fn unnamed_implicit_no_backtrace() {
     let err = TestErr::UnnamedImplicitNoBacktrace(0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_implicit_backtrace() {
     let err = TestErr::UnnamedImplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -362,14 +362,14 @@ fn unnamed_implicit_backtrace() {
 fn unnamed_explicit_no_backtrace() {
     let err = TestErr::UnnamedExplicitNoBacktrace(Backtrace::force_capture(), 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_explicit_backtrace() {
     let err = TestErr::UnnamedExplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -378,7 +378,7 @@ fn unnamed_explicit_no_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitNoBacktraceRedundant(Backtrace::force_capture(), 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -386,7 +386,7 @@ fn unnamed_explicit_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitBacktraceRedundant(Backtrace::force_capture(), 0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -398,7 +398,7 @@ fn unnamed_explicit_suppresses_implicit() {
         0,
     );
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
 }
@@ -410,8 +410,8 @@ fn unnamed_implicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -421,8 +421,8 @@ fn unnamed_explicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -432,8 +432,8 @@ fn unnamed_explicit_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_source_backtrace);
 }
 
@@ -447,8 +447,8 @@ fn unnamed_implicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }
@@ -463,8 +463,8 @@ fn unnamed_explicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }

--- a/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::any;
+use core::error::{request_ref, request_value};
 
 use super::*;
 
@@ -109,14 +109,14 @@ type MyBacktrace = Backtrace;
 
 #[test]
 fn unit() {
-    assert!(any::request_ref::<Backtrace>(&TestErr::<i32>::Unit).is_none());
+    assert!(request_ref::<Backtrace>(&TestErr::<i32>::Unit).is_none());
 }
 
 #[test]
 fn named_implicit_no_backtrace() {
     let err = TestErr::NamedImplicitNoBacktrace { field: 0 };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -126,7 +126,7 @@ fn named_implicit_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -137,7 +137,7 @@ fn named_implicit_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -148,7 +148,7 @@ fn named_explicit_no_backtrace_by_field_name() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -158,7 +158,7 @@ fn named_explicit_no_backtrace_by_field_type() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn named_explicit_backtrace() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -179,7 +179,7 @@ fn named_explicit_no_backtrace_redundant() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn named_explicit_backtrace_by_field_name_redundant() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -200,7 +200,7 @@ fn named_explicit_backtrace_by_field_type_redundant() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -212,7 +212,7 @@ fn named_explicit_suppresses_implicit() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
 }
@@ -221,14 +221,14 @@ fn named_explicit_suppresses_implicit() {
 fn unnamed_implicit_no_backtrace() {
     let err = TestErr::UnnamedImplicitNoBacktrace(0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_implicit_backtrace() {
     let err = TestErr::UnnamedImplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -236,14 +236,14 @@ fn unnamed_implicit_backtrace() {
 fn unnamed_explicit_no_backtrace() {
     let err = TestErr::UnnamedExplicitNoBacktrace(Backtrace::force_capture(), 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
 fn unnamed_explicit_backtrace() {
     let err = TestErr::UnnamedExplicitBacktrace(Backtrace::force_capture(), 0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -252,7 +252,7 @@ fn unnamed_explicit_no_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitNoBacktraceRedundant(Backtrace::force_capture(), 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
 }
 
 #[test]
@@ -260,7 +260,7 @@ fn unnamed_explicit_backtrace_redundant() {
     let err =
         TestErr::UnnamedExplicitBacktraceRedundant(Backtrace::force_capture(), 0, 0);
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
 }
 
@@ -272,7 +272,7 @@ fn unnamed_explicit_suppresses_implicit() {
         0,
     );
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_unused_backtrace);
 }
@@ -327,7 +327,7 @@ impl<T: Error> BoundedTestErr<T> {
     }
 
     fn get_source_backtrace(&self) -> &Backtrace {
-        any::request_ref(match self {
+        request_ref(match self {
             Self::NamedExplicitBacktraceFromSource { err }
             | Self::NamedExplicitDifferentSourceAndBacktrace { err, .. }
             | Self::NamedImplicitDifferentSourceAndBacktrace { err, .. }
@@ -349,8 +349,8 @@ fn named_implicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -362,8 +362,8 @@ fn named_explicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -375,8 +375,8 @@ fn named_explicit_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_source_backtrace);
 }
 
@@ -390,8 +390,8 @@ fn named_implicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }
@@ -406,8 +406,8 @@ fn named_explicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }
@@ -419,8 +419,8 @@ fn unnamed_implicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -430,8 +430,8 @@ fn unnamed_explicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -441,8 +441,8 @@ fn unnamed_explicit_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_source_backtrace);
 }
 
@@ -456,8 +456,8 @@ fn unnamed_implicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }
@@ -472,8 +472,8 @@ fn unnamed_explicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .get_stored_backtrace);
     assert_bt!(!=, err, .get_source_backtrace);
 }

--- a/tests/error/nightly/derives_for_generic_structs_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_structs_with_backtrace.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::any;
+use core::error::{request_ref, request_value};
 
 use super::*;
 
@@ -12,7 +12,7 @@ fn named_implicit_no_backtrace() {
         field: T,
     }
 
-    assert!(any::request_ref::<Backtrace>(&TestErr::<i32>::default()).is_none());
+    assert!(request_ref::<Backtrace>(&TestErr::<i32>::default()).is_none());
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn named_implicit_backtrace_by_field_name() {
         backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err);
 }
 
@@ -47,7 +47,7 @@ fn named_implicit_backtrace_by_field_type() {
         implicit_backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, implicit_backtrace);
 }
 
@@ -63,7 +63,7 @@ fn named_explicit_no_backtrace_by_field_name() {
 
     type MyBacktrace = Backtrace;
 
-    assert!(any::request_ref::<Backtrace>(&TestErr {
+    assert!(request_ref::<Backtrace>(&TestErr {
         backtrace: Backtrace::force_capture(),
         field: 0
     })
@@ -80,7 +80,7 @@ fn named_explicit_no_backtrace_by_field_type() {
         field: T,
     }
 
-    assert!(any::request_ref::<Backtrace>(&TestErr {
+    assert!(request_ref::<Backtrace>(&TestErr {
         implicit_backtrace: Backtrace::force_capture(),
         field: 0
     })
@@ -103,7 +103,7 @@ fn named_explicit_backtrace() {
         explicit_backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, explicit_backtrace);
 }
 
@@ -120,7 +120,7 @@ fn named_explicit_no_backtrace_redundant() {
 
     type MyBacktrace = Backtrace;
 
-    assert!(any::request_ref::<Backtrace>(&TestErr {
+    assert!(request_ref::<Backtrace>(&TestErr {
         not_backtrace: Backtrace::force_capture(),
         field: 0
     })
@@ -143,7 +143,7 @@ fn named_explicit_backtrace_by_field_name_redundant() {
         backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err);
 }
 
@@ -161,7 +161,7 @@ fn named_explicit_backtrace_by_field_type_redundant() {
         implicit_backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, implicit_backtrace);
 }
 
@@ -184,7 +184,7 @@ fn named_explicit_suppresses_implicit() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, not_backtrace);
     assert_bt!(!=, err);
 }
@@ -205,8 +205,8 @@ fn named_implicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -225,8 +225,8 @@ fn named_explicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -245,9 +245,9 @@ fn named_explicit_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
-    assert_bt!(==, err, any::request_ref::<Backtrace>(&err.err).unwrap());
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, request_ref::<Backtrace>(&err.err).unwrap());
 }
 
 #[test]
@@ -268,10 +268,10 @@ fn named_implicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, backtrace);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.err).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.err).unwrap());
 }
 
 #[test]
@@ -293,10 +293,10 @@ fn named_explicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, backtrace);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.err).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.err).unwrap());
 }
 
 #[test]
@@ -305,7 +305,7 @@ fn unnamed_implicit_no_backtrace() {
     #[derive(Default, Debug, Error)]
     struct TestErr<T>(T, T);
 
-    assert!(any::request_ref::<Backtrace>(&TestErr::<i32>::default()).is_none());
+    assert!(request_ref::<Backtrace>(&TestErr::<i32>::default()).is_none());
 }
 
 #[test]
@@ -315,7 +315,7 @@ fn unnamed_implicit_backtrace() {
     struct TestErr<T>(Backtrace, T, T);
 
     let err = TestErr(Backtrace::force_capture(), 0, 0);
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
 }
 
@@ -326,8 +326,7 @@ fn unnamed_explicit_no_backtrace() {
     struct TestErr<T>(#[error(not(backtrace))] Backtrace, T);
 
     assert!(
-        any::request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0))
-            .is_none()
+        request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0)).is_none()
     );
 }
 
@@ -340,7 +339,7 @@ fn unnamed_explicit_backtrace() {
     type MyBacktrace = Backtrace;
 
     let err = TestErr(Backtrace::force_capture(), 0, 0);
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
 }
 
@@ -356,8 +355,7 @@ fn unnamed_explicit_no_backtrace_redundant() {
     type MyBacktrace = Backtrace;
 
     assert!(
-        any::request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0))
-            .is_none()
+        request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0)).is_none()
     );
 }
 
@@ -368,7 +366,7 @@ fn unnamed_explicit_backtrace_redundant() {
     struct TestErr<T>(#[error(backtrace)] Backtrace, T, T);
 
     let err = TestErr(Backtrace::force_capture(), 0, 0);
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
 }
 
@@ -386,7 +384,7 @@ fn unnamed_explicit_suppresses_implicit() {
         0,
     );
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
     assert_bt!(!=, err, .1);
 }
@@ -402,8 +400,8 @@ fn unnamed_implicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -417,8 +415,8 @@ fn unnamed_explicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -432,9 +430,9 @@ fn unnamed_explicit_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
-    assert_bt!(==, err, any::request_ref::<Backtrace>(&err.0).unwrap());
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, request_ref::<Backtrace>(&err.0).unwrap());
 }
 
 #[test]
@@ -451,10 +449,10 @@ fn unnamed_implicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .1);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.0).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.0).unwrap());
 }
 
 #[test]
@@ -471,8 +469,8 @@ fn unnamed_explicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .1);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.0).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.0).unwrap());
 }

--- a/tests/error/nightly/derives_for_structs_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_structs_with_backtrace.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 
-use std::any;
+use core::error::{request_ref, request_value};
 
 use super::*;
 
 #[test]
 fn unit() {
-    assert!(any::request_ref::<Backtrace>(&SimpleErr).is_none());
+    assert!(request_ref::<Backtrace>(&SimpleErr).is_none());
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn named_implicit_no_backtrace() {
         field: i32,
     }
 
-    assert!(any::request_ref::<Backtrace>(&TestErr::default()).is_none());
+    assert!(request_ref::<Backtrace>(&TestErr::default()).is_none());
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn named_implicit_backtrace_by_field_name() {
         backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err);
 }
 
@@ -52,7 +52,7 @@ fn named_implicit_backtrace_by_field_type() {
         implicit_backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, implicit_backtrace);
 }
 
@@ -68,7 +68,7 @@ fn named_explicit_no_backtrace_by_field_name() {
 
     type MyBacktrace = Backtrace;
 
-    assert!(any::request_ref::<Backtrace>(&TestErr {
+    assert!(request_ref::<Backtrace>(&TestErr {
         backtrace: Backtrace::force_capture(),
         field: 0
     })
@@ -85,7 +85,7 @@ fn named_explicit_no_backtrace_by_field_type() {
         field: i32,
     }
 
-    assert!(any::request_ref::<Backtrace>(&TestErr {
+    assert!(request_ref::<Backtrace>(&TestErr {
         implicit_backtrace: Backtrace::force_capture(),
         field: 0
     })
@@ -108,7 +108,7 @@ fn named_explicit_backtrace() {
         explicit_backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, explicit_backtrace);
 }
 
@@ -125,7 +125,7 @@ fn named_explicit_no_backtrace_redundant() {
 
     type MyBacktrace = Backtrace;
 
-    assert!(any::request_ref::<Backtrace>(&TestErr {
+    assert!(request_ref::<Backtrace>(&TestErr {
         not_backtrace: Backtrace::force_capture(),
         field: 0
     })
@@ -148,7 +148,7 @@ fn named_explicit_backtrace_by_field_name_redundant() {
         backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err);
 }
 
@@ -166,7 +166,7 @@ fn named_explicit_backtrace_by_field_type_redundant() {
         implicit_backtrace: Backtrace::force_capture(),
         field: 0,
     };
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, implicit_backtrace);
 }
 
@@ -189,7 +189,7 @@ fn named_explicit_suppresses_implicit() {
         field: 0,
     };
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, not_backtrace);
     assert_bt!(!=, err);
 }
@@ -210,8 +210,8 @@ fn named_implicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -230,8 +230,8 @@ fn named_explicit_no_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -250,9 +250,9 @@ fn named_explicit_backtrace_from_source() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
-    assert_bt!(==, err, any::request_ref::<Backtrace>(&err.err).unwrap());
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, request_ref::<Backtrace>(&err.err).unwrap());
 }
 
 #[test]
@@ -273,10 +273,10 @@ fn named_implicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, backtrace);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.err).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.err).unwrap());
 }
 
 #[test]
@@ -298,10 +298,10 @@ fn named_explicit_different_source_and_backtrace() {
     };
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, backtrace);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.err).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.err).unwrap());
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn unnamed_implicit_no_backtrace() {
     #[derive(Default, Debug, Error)]
     struct TestErr(i32, i32);
 
-    assert!(any::request_ref::<Backtrace>(&TestErr::default()).is_none());
+    assert!(request_ref::<Backtrace>(&TestErr::default()).is_none());
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn unnamed_implicit_backtrace() {
     struct TestErr(Backtrace, i32, i32);
 
     let err = TestErr(Backtrace::force_capture(), 0, 0);
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
 }
 
@@ -331,8 +331,7 @@ fn unnamed_explicit_no_backtrace() {
     struct TestErr(#[error(not(backtrace))] Backtrace, i32);
 
     assert!(
-        any::request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0))
-            .is_none()
+        request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0)).is_none()
     );
 }
 
@@ -345,7 +344,7 @@ fn unnamed_explicit_backtrace() {
     type MyBacktrace = Backtrace;
 
     let err = TestErr(Backtrace::force_capture(), 0, 0);
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
 }
 
@@ -361,8 +360,7 @@ fn unnamed_explicit_no_backtrace_redundant() {
     type MyBacktrace = Backtrace;
 
     assert!(
-        any::request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0))
-            .is_none()
+        request_ref::<Backtrace>(&TestErr(Backtrace::force_capture(), 0)).is_none()
     );
 }
 
@@ -373,7 +371,7 @@ fn unnamed_explicit_backtrace_redundant() {
     struct TestErr(#[error(backtrace)] Backtrace, i32, i32);
 
     let err = TestErr(Backtrace::force_capture(), 0, 0);
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
 }
 
@@ -391,7 +389,7 @@ fn unnamed_explicit_suppresses_implicit() {
         0,
     );
 
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
+    assert!(request_ref::<Backtrace>(&err).is_some());
     assert_bt!(==, err, .0);
     assert_bt!(!=, err, .1);
 }
@@ -407,8 +405,8 @@ fn unnamed_implicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -422,8 +420,8 @@ fn unnamed_explicit_no_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_none());
-    assert!(any::request_value::<i32>(&err).is_none());
+    assert!(request_ref::<Backtrace>(&err).is_none());
+    assert!(request_value::<i32>(&err).is_none());
 }
 
 #[test]
@@ -437,9 +435,9 @@ fn unnamed_explicit_backtrace_from_source() {
     });
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
-    assert_bt!(==, err, any::request_ref::<Backtrace>(&err.0).unwrap());
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
+    assert_bt!(==, err, request_ref::<Backtrace>(&err.0).unwrap());
 }
 
 #[test]
@@ -456,10 +454,10 @@ fn unnamed_implicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .1);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.0).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.0).unwrap());
 }
 
 #[test]
@@ -476,8 +474,8 @@ fn unnamed_explicit_different_source_and_backtrace() {
     );
 
     assert!(err.source().is_some());
-    assert!(any::request_ref::<Backtrace>(&err).is_some());
-    assert_eq!(any::request_value::<i32>(&err), Some(42));
+    assert!(request_ref::<Backtrace>(&err).is_some());
+    assert_eq!(request_value::<i32>(&err), Some(42));
     assert_bt!(==, err, .1);
-    assert_bt!(!=, err, any::request_ref::<Backtrace>(&err.0).unwrap());
+    assert_bt!(!=, err, request_ref::<Backtrace>(&err.0).unwrap());
 }

--- a/tests/error/nightly/mod.rs
+++ b/tests/error/nightly/mod.rs
@@ -40,7 +40,7 @@ use super::*;
 /// ```
 macro_rules! assert_bt {
     (@impl $macro:ident, $error:expr, $backtrace:expr) => {
-        $macro!(std::any::request_ref::<Backtrace>(&$error).unwrap().to_string(), $backtrace.to_string());
+        $macro!(::core::error::request_ref::<Backtrace>(&$error).unwrap().to_string(), $backtrace.to_string());
     };
     (@expand $macro:ident, $error:expr, .$backtrace:ident) => {
         assert_bt!(@impl $macro, $error, $error.$backtrace())
@@ -85,8 +85,8 @@ impl Default for BacktraceErr {
 }
 
 impl Error for BacktraceErr {
-    fn provide<'a>(&'a self, demand: &mut std::any::Demand<'a>) {
-        demand
+    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        request
             .provide_ref::<Backtrace>(&self.backtrace)
             .provide_value::<i32>(42);
     }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
-#![cfg_attr(not(feature = "std"), feature(error_in_core))]
+#![cfg_attr(nightly, feature(error_generic_member_access, error_in_core))]
 
 mod error;


### PR DESCRIPTION
## Synopsis

<!-- Give a brief overview of the problem -->

Update derive and tests to work on the latest nightly with the changes in [this PR](https://github.com/rust-lang/rust/pull/113464).


## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

Use `error::{Request, request_ref, request_value}` instead of `any::{Demand, request_ref, request_value}`

Currently `request_value` is not re-exported from `core::error` in `std::error`, which means backtrace tests require `#![feature(error_in_core)]`

Presumably this is a bug, and will be fixed later


## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
