### PR TITLE
Unite `as_ref` and `as_mut` features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `Into` derive now uses `#[into(<types>)]` instead of `#[into(types(<types>))]`
   and ignores field type itself.
 - Importing a derive macro now also import its corresponding trait.
-- The `Error` derive is updated with changes to the `error_generic_member_access` unstable feature for nightly users. ([#200](https://github.com/JelteF/derive_more/pull/200), [#294](https://github.com/JelteF/derive_more/pull/294))
-- The `as_mut` feature is removed, and the `AsMut` derive is now part of the `as_ref` feature
-  ([#295](https://github.com/JelteF/derive_more/pull/295))
+- The `Error` derive is updated with changes to the `error_generic_member_access`
+  unstable feature for nightly users. ([#200](https://github.com/JelteF/derive_more/pull/200),
+  [#294](https://github.com/JelteF/derive_more/pull/294))
+- The `as_mut` feature is removed, and the `AsMut` derive is now gated by the
+  `as_ref` feature. ([#295](https://github.com/JelteF/derive_more/pull/295))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   and ignores field type itself.
 - Importing a derive macro now also import its corresponding trait.
 - The `Error` derive is updated with changes to the `error_generic_member_access` unstable feature for nightly users. ([#200](https://github.com/JelteF/derive_more/pull/200), [#294](https://github.com/JelteF/derive_more/pull/294))
+- The `as_mut` feature is removed, and the `AsMut` derive is now part of the `as_ref` feature
+  ([#295](https://github.com/JelteF/derive_more/pull/295))
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ default = ["std"]
 
 add_assign = ["derive_more-impl/add_assign"]
 add = ["derive_more-impl/add"]
-as_mut = ["derive_more-impl/as_mut"]
 as_ref = ["derive_more-impl/as_ref"]
 constructor = ["derive_more-impl/constructor"]
 debug = ["derive_more-impl/debug"]
@@ -75,7 +74,6 @@ std = []
 full = [
     "add",
     "add_assign",
-    "as_mut",
     "as_ref",
     "constructor",
     "debug",
@@ -114,7 +112,7 @@ required-features = ["add"]
 [[test]]
 name = "as_mut"
 path = "tests/as_mut.rs"
-required-features = ["as_mut"]
+required-features = ["as_ref"]
 
 [[test]]
 name = "as_ref"
@@ -229,7 +227,7 @@ required-features = ["try_unwrap"]
 [[test]]
 name = "compile_fail"
 path = "tests/compile_fail/mod.rs"
-required-features = ["as_ref", "as_mut", "debug", "display", "from", "into"]
+required-features = ["as_ref", "debug", "display", "from", "into"]
 
 [[test]]
 name = "no_std"

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ These are traits that are used to convert automatically between types.
 3. [`FromStr`]
 4. [`TryInto`]
 5. [`IntoIterator`]
-6. [`AsRef`]
-7. [`AsMut`]
+6. [`AsRef`], [`AsMut`]
 
 
 ### Formatting traits

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -48,7 +48,6 @@ default = []
 
 add = []
 add_assign = []
-as_mut = []
 as_ref = []
 constructor = []
 debug = ["syn/extra-traits", "dep:unicode-xid"]
@@ -74,7 +73,6 @@ unwrap = ["dep:convert_case"]
 full = [
     "add",
     "add_assign",
-    "as_mut",
     "as_ref",
     "constructor",
     "debug",

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -1,8 +1,6 @@
 //! Implementations of [`AsRef`]/[`AsMut`] derive macros.
 
-#[cfg(feature = "as_mut")]
 pub(crate) mod r#mut;
-#[cfg(feature = "as_ref")]
 pub(crate) mod r#ref;
 
 use proc_macro2::TokenStream;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -21,7 +21,7 @@ mod add_assign_like;
 mod add_helpers;
 #[cfg(any(feature = "add", feature = "mul"))]
 mod add_like;
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(feature = "as_ref")]
 mod r#as;
 #[cfg(feature = "constructor")]
 mod constructor;
@@ -133,8 +133,7 @@ create_derive!(
     bit_xor_assign_derive,
 );
 
-create_derive!("as_mut", r#as::r#mut, AsMut, as_mut_derive, as_mut);
-
+create_derive!("as_ref", r#as::r#mut, AsMut, as_mut_derive, as_mut);
 create_derive!("as_ref", r#as::r#ref, AsRef, as_ref_derive, as_ref);
 
 create_derive!("constructor", constructor, Constructor, constructor_derive);

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -15,7 +15,6 @@ use syn::{
 
 #[cfg(any(
     feature = "as_ref",
-    feature = "as_mut",
     feature = "debug",
     feature = "display",
     feature = "from",
@@ -25,7 +24,7 @@ pub(crate) use self::either::Either;
 
 #[cfg(any(feature = "from", feature = "into"))]
 pub(crate) use self::fields_ext::FieldsExt;
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(feature = "as_ref")]
 pub(crate) use self::spanning::Spanning;
 
 #[derive(Clone, Copy, Default)]
@@ -1318,7 +1317,7 @@ pub fn is_type_parameter_used_in_type(
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(feature = "as_ref")]
 pub(crate) mod forward {
     use syn::{
         parse::{Parse, ParseStream},
@@ -1372,7 +1371,7 @@ pub(crate) mod forward {
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(feature = "as_ref")]
 pub(crate) mod skip {
     use syn::{
         parse::{Parse, ParseStream},
@@ -1410,7 +1409,6 @@ pub(crate) mod skip {
 
 #[cfg(any(
     feature = "as_ref",
-    feature = "as_mut",
     feature = "debug",
     feature = "display",
     feature = "from",
@@ -1477,7 +1475,7 @@ mod either {
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(feature = "as_ref")]
 mod spanning {
     use std::ops::{Deref, DerefMut};
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -21,7 +21,6 @@ use syn::{
     feature = "into",
 ))]
 pub(crate) use self::either::Either;
-
 #[cfg(any(feature = "from", feature = "into"))]
 pub(crate) use self::fields_ext::FieldsExt;
 #[cfg(feature = "as_ref")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ re_export_traits!(
     BitXorAssign,
     SubAssign,
 );
-re_export_traits!("as_ref", as_ref_traits, core::convert, AsRef, AsMut);
+re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
 re_export_traits!("debug", debug_traits, core::fmt, Debug);
 re_export_traits!("deref", deref_traits, core::ops, Deref);
 re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,7 @@ re_export_traits!(
     BitXorAssign,
     SubAssign,
 );
-re_export_traits!("as_mut", as_mut_traits, core::convert, AsMut);
-re_export_traits!("as_ref", as_ref_traits, core::convert, AsRef);
+re_export_traits!("as_ref", as_ref_traits, core::convert, AsRef, AsMut);
 re_export_traits!("debug", debug_traits, core::fmt, Debug);
 re_export_traits!("deref", deref_traits, core::ops, Deref);
 re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
@@ -216,11 +215,8 @@ pub use derive_more_impl::{
     AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, SubAssign,
 };
 
-#[cfg(feature = "as_mut")]
-pub use derive_more_impl::AsMut;
-
 #[cfg(feature = "as_ref")]
-pub use derive_more_impl::AsRef;
+pub use derive_more_impl::{AsMut, AsRef};
 
 #[cfg(feature = "constructor")]
 pub use derive_more_impl::Constructor;
@@ -289,7 +285,6 @@ pub use derive_more_impl::Unwrap;
     feature = "full",
     feature = "add",
     feature = "add_assign",
-    feature = "as_mut",
     feature = "as_ref",
     feature = "constructor",
     feature = "debug",


### PR DESCRIPTION
First suggested [here](https://github.com/JelteF/derive_more/pull/286#issuecomment-1678901955)


## Synopsis

`AsRef` and `AsMut` derives are effectively the same regarding implementation, so using separate features for them doesn't make sense.

## Solution

Use the `as_ref` feature for both derives


## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
