### PR TITLE
Use the new parsing utils

### DIFF
--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -69,7 +69,6 @@ where
 When `AsMut` is derived for a struct with more than one field (including tuple
 structs), you must also mark one or more fields with the `#[as_mut]` attribute.
 An implementation will be generated for each indicated field.
-You can also exclude a specific field by using `#[as_mut(ignore)]` (or `#[as_mut(ignore)]`).
 
 ```rust
 # use derive_more::AsMut;
@@ -105,8 +104,46 @@ impl AsMut<i32> for MyWrapper {
 }
 ```
 
-Note that `AsMut<T>` may only be implemented once for any given type `T`. This means any attempt to
-mark more than one field of the same type with `#[as_mut]` will result in a compilation error.
+
+### Skipping
+
+Or vice versa: you can exclude a specific field by using `#[as_mut(skip)]` (or
+`#[as_mut(ignore)]`). Then, implementations will be generated for non-indicated fields.
+
+```rust
+# use derive_more::AsMut;
+#
+#[derive(AsMut)]
+struct MyWrapper {
+    #[as_mut(skip)]
+    name: String,
+    #[as_mut(ignore)]
+    num: i32,
+    valid: bool,
+}
+```
+
+Generates:
+
+```rust
+# struct MyWrapper {
+#     name: String,
+#     num: i32,
+#     valid: bool,
+# }
+impl AsMut<bool> for MyWrapper {
+    fn as_mut(&mut self) -> &mut bool {
+        &mut self.valid
+    }
+}
+```
+
+
+### Coherence
+
+Note that `AsMut<T>` may only be implemented once for any given type `T`.
+This means any attempt to mark more than one field of the same type with
+`#[as_mut]` will result in a compilation error.
 
 ```rust,compile_fail
 # use derive_more::AsMut;
@@ -138,6 +175,9 @@ struct ForwardWithOther {
     number: i32,
 }
 ```
+
+
+
 
 ## Enums
 

--- a/impl/doc/as_ref.md
+++ b/impl/doc/as_ref.md
@@ -69,7 +69,6 @@ where
 When `AsRef` is derived for a struct with more than one field (including tuple
 structs), you must also mark one or more fields with the `#[as_ref]` attribute.
 An implementation will be generated for each indicated field.
-You can also exclude a specific field by using `#[as_ref(skip)]` (or `#[as_ref(ignore)]`).
 
 ```rust
 # use derive_more::AsRef;
@@ -105,6 +104,43 @@ impl AsRef<i32> for MyWrapper {
 }
 ```
 
+
+### Skipping
+
+Or vice versa: you can exclude a specific field by using `#[as_ref(skip)]` (or
+`#[as_ref(ignore)]`). Then, implementations will be generated for non-indicated fields.
+
+```rust
+# use derive_more::AsRef;
+#
+#[derive(AsRef)]
+struct MyWrapper {
+    #[as_ref(skip)]
+    name: String,
+    #[as_ref(ignore)]
+    num: i32,
+    valid: bool,
+}
+```
+
+Generates:
+
+```rust
+# struct MyWrapper {
+#     name: String,
+#     num: i32,
+#     valid: bool,
+# }
+impl AsRef<bool> for MyWrapper {
+    fn as_ref(&self) -> &bool {
+        &self.valid
+    }
+}
+```
+
+
+### Coherence
+
 Note that `AsRef<T>` may only be implemented once for any given type `T`.
 This means any attempt to mark more than one field of the same type with
 `#[as_ref]` will result in a compilation error.
@@ -139,6 +175,9 @@ struct ForwardWithOther {
     number: i32,
 }
 ```
+
+
+
 
 ## Enums
 

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -2,7 +2,7 @@
 
 This derive macro is a clever superset of `Debug` from standard library. Additional features include:
 - not imposing redundant trait bounds;
-- `#[debug(skip)]` attribute to skip formatting struct field or enum variant;
+- `#[debug(skip)]` (or `#[debug(ignore)]`) attribute to skip formatting struct field or enum variant;
 - `#[debug("...", args...)]` to specify custom formatting either for the whole struct or enum variant, or its particular field;
 - `#[debug(bounds(...))]` to impose additional custom trait bounds.
 
@@ -39,7 +39,7 @@ struct Foo<'a, T1, T2: Trait, T3, T4> {
     c: Vec<T3>,
     #[debug("{d:p}")]
     d: &'a T1,
-    #[debug(skip)]
+    #[debug(skip)] // or #[debug(ignore)]
     e: T4,
 }
 
@@ -80,7 +80,7 @@ struct MyStruct<T, U, V, F> {
     b: U,
     #[debug("{c}")]
     c: V,
-    #[debug(skip)]
+    #[debug(skip)] // or #[debug(ignore)]
     d: F,
 }
 
@@ -110,7 +110,7 @@ struct StructFormat(&'static str, u8);
 enum E {
     Skipped {
         x: u32,
-        #[debug(skip)]
+        #[debug(skip)] // or #[debug(ignore)]
         y: u32,
     },
     Binary {

--- a/impl/doc/from.md
+++ b/impl/doc/from.md
@@ -105,7 +105,7 @@ assert_eq!(IntOrPoint::Point { x: 1, y: 2 }, (1, 2).into());
 ```
 
 By default, `From` is generated for every enum variant, but you can skip some
-variants via `#[from(skip)]` or only concrete fields via `#[from]`.
+variants via `#[from(skip)]` (or `#[from(ignore)]`) or only concrete fields via `#[from]`.
 
 ```rust
 # mod from {
@@ -125,7 +125,7 @@ enum Int {
 #[derive(Debug, From, PartialEq)]
 enum Int {
     Derived(i32),
-    #[from(skip)]
+    #[from(skip)] // or #[from(ignore)]
     NotDerived(i32),
 }
 # }

--- a/impl/doc/into.md
+++ b/impl/doc/into.md
@@ -77,7 +77,7 @@ assert_eq!(&mut 2, <&mut i32>::from(&mut Int(2)));
 ```
 
 In case there are fields, that shouldn't be included in the conversion, use the
-`#[into(skip)]` attribute.
+`#[into(skip)]` (or `#[into(ignore)]`) attribute.
 
 ```rust
 # use std::marker::PhantomData;
@@ -90,7 +90,7 @@ In case there are fields, that shouldn't be included in the conversion, use the
 #[into(i32, i64, i128)]
 struct Mass<Unit> {
     value: i32,
-    #[into(skip)]
+    #[into(skip)] // or #[into(ignore)]
     _unit: PhantomData<Unit>,
 }
 
@@ -107,6 +107,9 @@ assert_eq!(5_i128, Mass::<Gram>::new(5).into());
 #     }
 # }
 ```
+
+
+
 
 ## Enums
 

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -14,7 +14,7 @@ use syn::{
 
 use crate::{
     parsing::Type,
-    utils::{polyfill, Either},
+    utils::{forward, polyfill, skip, Either},
 };
 
 /// Expands a [`From`] derive macro.
@@ -44,7 +44,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                         Some(
                             VariantAttribute::From
                                 | VariantAttribute::Types(_)
-                                | VariantAttribute::Forward
+                                | VariantAttribute::Forward(_)
                         ),
                     ) {
                         has_explicit_from = true;
@@ -87,7 +87,7 @@ enum StructAttribute {
     Types(Punctuated<Type, token::Comma>),
 
     /// Forward [`From`] implementation.
-    Forward,
+    Forward(forward::Attribute),
 }
 
 impl StructAttribute {
@@ -125,11 +125,12 @@ impl StructAttribute {
     /// Parses single [`StructAttribute`].
     fn parse(input: ParseStream<'_>, fields: &syn::Fields) -> syn::Result<Self> {
         let ahead = input.fork();
+        if let Ok(attr) = ahead.parse::<forward::Attribute>() {
+            input.advance_to(&ahead);
+            return Ok(Self::Forward(attr));
+        }
+
         match ahead.parse::<syn::Path>() {
-            Ok(p) if p.is_ident("forward") => {
-                input.advance_to(&ahead);
-                Ok(Self::Forward)
-            }
             Ok(p) if p.is_ident("types") => legacy_error(&ahead, input.span(), fields),
             _ => input
                 .parse_terminated(Type::parse, token::Comma)
@@ -154,10 +155,10 @@ enum VariantAttribute {
     Types(Punctuated<Type, token::Comma>),
 
     /// Forward [`From`] implementation.
-    Forward,
+    Forward(forward::Attribute),
 
     /// Skip variant.
-    Skip,
+    Skip(skip::Attribute),
 }
 
 impl VariantAttribute {
@@ -192,22 +193,28 @@ impl VariantAttribute {
 
         attr.parse_args_with(|input: ParseStream<'_>| {
             let ahead = input.fork();
-            match ahead.parse::<syn::Path>() {
-                Ok(p) if p.is_ident("forward") => {
-                    input.advance_to(&ahead);
-                    Ok(Self::Forward)
-                }
-                Ok(p) if p.is_ident("skip") || p.is_ident("ignore") => {
-                    input.advance_to(&ahead);
-                    Ok(Self::Skip)
-                }
-                Ok(p) if p.is_ident("types") => {
-                    legacy_error(&ahead, input.span(), fields)
-                }
-                _ => input
-                    .parse_terminated(Type::parse, token::Comma)
-                    .map(Self::Types),
+            if let Ok(attr) = ahead.parse::<forward::Attribute>() {
+                input.advance_to(&ahead);
+                return Ok(Self::Forward(attr));
             }
+
+            let ahead = input.fork();
+            if let Ok(attr) = ahead.parse::<skip::Attribute>() {
+                input.advance_to(&ahead);
+                return Ok(Self::Skip(attr));
+            }
+
+            let ahead = input.fork();
+            if ahead
+                .parse::<syn::Path>()
+                .is_ok_and(|p| p.is_ident("types"))
+            {
+                return legacy_error(&ahead, input.span(), fields);
+            }
+
+            input
+                .parse_terminated(Type::parse, token::Comma)
+                .map(Self::Types)
         })
     }
 }
@@ -216,7 +223,7 @@ impl From<StructAttribute> for VariantAttribute {
     fn from(value: StructAttribute) -> Self {
         match value {
             StructAttribute::Types(tys) => Self::Types(tys),
-            StructAttribute::Forward => Self::Forward,
+            StructAttribute::Forward(attr) => Self::Forward(attr),
         }
     }
 }
@@ -312,7 +319,7 @@ impl<'a> Expansion<'a> {
                     }
                 })
             }
-            (Some(VariantAttribute::Forward), _) => {
+            (Some(VariantAttribute::Forward(_)), _) => {
                 let mut i = 0;
                 let mut gen_idents = Vec::with_capacity(self.fields.len());
                 let init = self.expand_fields(|ident, ty, index| {
@@ -356,7 +363,7 @@ impl<'a> Expansion<'a> {
                     }
                 })
             }
-            (Some(VariantAttribute::Skip), _) | (None, true) => {
+            (Some(VariantAttribute::Skip(_)), _) | (None, true) => {
                 Ok(TokenStream::new())
             }
         }

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -146,7 +146,7 @@ impl StructAttribute {
 /// #[from]
 /// #[from(<types>)]
 /// #[from(forward)]
-/// #[from(skip)]
+/// #[from(skip)] #[from(ignore)]
 /// ```
 enum VariantAttribute {
     /// Explicitly derive [`From`].

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, iter};
 
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens as _};
+use quote::{format_ident, quote, ToTokens as _};
 use syn::{
     ext::IdentExt as _,
     parse::{discouraged::Speculative as _, Parse, ParseStream},
@@ -14,7 +14,7 @@ use syn::{
 
 use crate::{
     parsing::Type,
-    utils::{polyfill, Either, FieldsExt as _},
+    utils::{polyfill, skip, Either, FieldsExt as _},
 };
 
 /// Expands an [`Into`] derive macro.
@@ -42,15 +42,18 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
         .fields
         .iter()
         .enumerate()
-        .filter_map(|(i, f)| match SkipFieldAttribute::parse_attrs(&f.attrs) {
-            Ok(None) => Some(Ok((
-                &f.ty,
-                f.ident
-                    .as_ref()
-                    .map_or_else(|| Either::Right(syn::Index::from(i)), Either::Left),
-            ))),
-            Ok(Some(_)) => None,
-            Err(e) => Some(Err(e)),
+        .filter_map(|(i, f)| {
+            match SkipFieldAttribute::parse_attrs(&f.attrs, &format_ident!("into")) {
+                Ok(None) => Some(Ok((
+                    &f.ty,
+                    f.ident.as_ref().map_or_else(
+                        || Either::Right(syn::Index::from(i)),
+                        Either::Left,
+                    ),
+                ))),
+                Ok(Some(_)) => None,
+                Err(e) => Some(Err(e)),
+            }
         })
         .collect::<syn::Result<Vec<_>>>()?;
     let (fields_tys, fields_idents): (Vec<_>, Vec<_>) = fields.into_iter().unzip();
@@ -253,41 +256,7 @@ impl StructAttribute {
 }
 
 /// `#[into(skip)]` field attribute.
-struct SkipFieldAttribute;
-
-impl SkipFieldAttribute {
-    /// Parses a [`SkipFieldAttribute`] from the provided [`syn::Attribute`]s.
-    fn parse_attrs(attrs: impl AsRef<[syn::Attribute]>) -> syn::Result<Option<Self>> {
-        Ok(attrs
-            .as_ref()
-            .iter()
-            .filter(|attr| attr.path().is_ident("into"))
-            .try_fold(None, |mut attrs, attr| {
-                let field_attr = attr.parse_args::<SkipFieldAttribute>()?;
-                if let Some((path, _)) = attrs.replace((attr.path(), field_attr)) {
-                    Err(syn::Error::new(
-                        path.span(),
-                        "only single `#[into(...)]` attribute is allowed here",
-                    ))
-                } else {
-                    Ok(attrs)
-                }
-            })?
-            .map(|(_, attr)| attr))
-    }
-}
-
-impl Parse for SkipFieldAttribute {
-    fn parse(content: ParseStream) -> syn::Result<Self> {
-        match content.parse::<syn::Path>()? {
-            p if p.is_ident("skip") | p.is_ident("ignore") => Ok(Self),
-            p => Err(syn::Error::new(
-                p.span(),
-                format!("expected `skip`, found: `{}`", p.into_token_stream()),
-            )),
-        }
-    }
-}
+type SkipFieldAttribute = skip::Attribute;
 
 /// [`Error`]ors for legacy syntax: `#[into(types(i32, "&str"))]`.
 fn check_legacy_syntax(

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -255,7 +255,7 @@ impl StructAttribute {
     }
 }
 
-/// `#[into(skip)]` field attribute.
+/// `#[into(skip)]`/`#[into(ignore)]` field attribute.
 type SkipFieldAttribute = skip::Attribute;
 
 /// [`Error`]ors for legacy syntax: `#[into(types(i32, "&str"))]`.

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) use self::either::Either;
 
 #[cfg(any(feature = "from", feature = "into"))]
 pub(crate) use self::fields_ext::FieldsExt;
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
 pub(crate) use self::spanning::Spanning;
 
 #[derive(Clone, Copy, Default)]
@@ -1318,7 +1318,7 @@ pub fn is_type_parameter_used_in_type(
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
 pub(crate) mod forward {
     use syn::{
         parse::{Parse, ParseStream},
@@ -1372,7 +1372,7 @@ pub(crate) mod forward {
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
 pub(crate) mod skip {
     use syn::{
         parse::{Parse, ParseStream},
@@ -1477,7 +1477,7 @@ mod either {
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut"))]
+#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
 mod spanning {
     use std::ops::{Deref, DerefMut};
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -25,7 +25,12 @@ pub(crate) use self::either::Either;
 
 #[cfg(any(feature = "from", feature = "into"))]
 pub(crate) use self::fields_ext::FieldsExt;
-#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
+#[cfg(any(
+    feature = "as_ref",
+    feature = "as_mut",
+    feature = "from",
+    feature = "into"
+))]
 pub(crate) use self::spanning::Spanning;
 
 #[derive(Clone, Copy, Default)]
@@ -1372,7 +1377,12 @@ pub(crate) mod forward {
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
+#[cfg(any(
+    feature = "as_ref",
+    feature = "as_mut",
+    feature = "from",
+    feature = "into"
+))]
 pub(crate) mod skip {
     use syn::{
         parse::{Parse, ParseStream},
@@ -1504,7 +1514,12 @@ mod either {
     }
 }
 
-#[cfg(any(feature = "as_ref", feature = "as_mut", feature = "from"))]
+#[cfg(any(
+    feature = "as_ref",
+    feature = "as_mut",
+    feature = "from",
+    feature = "into"
+))]
 mod spanning {
     use std::ops::{Deref, DerefMut};
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -29,7 +29,8 @@ pub(crate) use self::fields_ext::FieldsExt;
     feature = "as_ref",
     feature = "as_mut",
     feature = "from",
-    feature = "into"
+    feature = "into",
+    feature = "debug",
 ))]
 pub(crate) use self::spanning::Spanning;
 
@@ -1381,7 +1382,8 @@ pub(crate) mod forward {
     feature = "as_ref",
     feature = "as_mut",
     feature = "from",
-    feature = "into"
+    feature = "into",
+    feature = "debug",
 ))]
 pub(crate) mod skip {
     use syn::{
@@ -1518,7 +1520,8 @@ mod either {
     feature = "as_ref",
     feature = "as_mut",
     feature = "from",
-    feature = "into"
+    feature = "into",
+    feature = "debug",
 ))]
 mod spanning {
     use std::ops::{Deref, DerefMut};

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -25,9 +25,9 @@ pub(crate) use self::either::Either;
 pub(crate) use self::fields_ext::FieldsExt;
 #[cfg(any(
     feature = "as_ref",
+    feature = "debug",
     feature = "from",
     feature = "into",
-    feature = "debug",
 ))]
 pub(crate) use self::spanning::Spanning;
 
@@ -1377,9 +1377,9 @@ pub(crate) mod forward {
 
 #[cfg(any(
     feature = "as_ref",
+    feature = "debug",
     feature = "from",
     feature = "into",
-    feature = "debug",
 ))]
 pub(crate) mod skip {
     use syn::{
@@ -1396,31 +1396,6 @@ pub(crate) mod skip {
     /// #[<attribute>(ignore)]
     /// ```
     pub(crate) struct Attribute(&'static str);
-
-    impl Attribute {
-        pub(crate) fn parse_attrs(
-            attrs: impl AsRef<[syn::Attribute]>,
-            attr_ident: &syn::Ident,
-        ) -> syn::Result<Option<Spanning<Self>>> {
-            attrs
-                .as_ref()
-                .iter()
-                .filter(|attr| attr.path().is_ident(attr_ident))
-                .try_fold(None, |mut attrs, attr| {
-                    let parsed = Spanning::new(attr.parse_args()?, attr.span());
-                    if attrs.replace(parsed).is_some() {
-                        Err(syn::Error::new(
-                            attr.span(),
-                            format!(
-                                "only single `#[{attr_ident}(skip)]`/`#[{attr_ident}(ignore)]` attribute is allowed here"
-                            ),
-                        ))
-                    } else {
-                        Ok(attrs)
-                    }
-                })
-        }
-    }
 
     impl Parse for Attribute {
         fn parse(content: ParseStream<'_>) -> syn::Result<Self> {
@@ -1439,6 +1414,33 @@ pub(crate) mod skip {
         /// Returns the concrete name of this attribute (`skip` or `ignore`).
         pub(crate) const fn name(&self) -> &'static str {
             self.0
+        }
+
+        /// Parses an [`Attribute`] from the provided [`syn::Attribute`]s, preserving its [`Span`].
+        ///
+        /// [`Span`]: proc_macro2::Span
+        pub(crate) fn parse_attrs(
+            attrs: impl AsRef<[syn::Attribute]>,
+            attr_ident: &syn::Ident,
+        ) -> syn::Result<Option<Spanning<Self>>> {
+            attrs
+                .as_ref()
+                .iter()
+                .filter(|attr| attr.path().is_ident(attr_ident))
+                .try_fold(None, |mut attrs, attr| {
+                    let parsed = Spanning::new(attr.parse_args()?, attr.span());
+                    if attrs.replace(parsed).is_some() {
+                        Err(syn::Error::new(
+                            attr.span(),
+                            format!(
+                                "only single `#[{attr_ident}(skip)]`/`#[{attr_ident}(ignore)]` \
+                                 attribute is allowed here",
+                            ),
+                        ))
+                    } else {
+                        Ok(attrs)
+                    }
+                })
         }
     }
 }
@@ -1513,9 +1515,9 @@ mod either {
 
 #[cfg(any(
     feature = "as_ref",
+    feature = "debug",
     feature = "from",
     feature = "into",
-    feature = "debug",
 ))]
 mod spanning {
     use std::ops::{Deref, DerefMut};


### PR DESCRIPTION
First suggested [here](https://github.com/JelteF/derive_more/pull/286#discussion_r1297046342)


## Synopsis

<!-- Give a brief overview of the problem -->

There's some repetition around parsing the same attributes in different derives


## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

Refactor `Into`, `From`, and `Debug` derives to use the `skip` and `forward` attribute parsing utils


## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
