### PR TITLE
Selective AsRef/AsMut impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
-
         with:
           toolchain: ${{ matrix.toolchain }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
+
         with:
           toolchain: ${{ matrix.toolchain }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#279](https://github.com/JelteF/derive_more/pull/279))
 - `derive_more::derive` module exporting only macros, without traits.
   ([#290](https://github.com/JelteF/derive_more/pull/290))
-- Add support for selective forwarding in the `AsRef`/`AsMut` derive
+- Add support for selective forwarding to `AsRef`/`AsMut` derives.
   ([#298](https://github.com/JelteF/derive_more/pull/298))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for container format in `Debug` derive with the same syntax as `Display` derives.
   ([#279](https://github.com/JelteF/derive_more/pull/279))
 - `derive_more::derive` module exporting only macros, without traits. ([#290](https://github.com/JelteF/derive_more/pull/290))
+- Add support for selective forwarding in the `AsRef`/`AsMut` derive
+  ([#298](https://github.com/JelteF/derive_more/pull/298))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#279](https://github.com/JelteF/derive_more/pull/279))
 - `derive_more::derive` module exporting only macros, without traits.
   ([#290](https://github.com/JelteF/derive_more/pull/290))
-- Add support for selective forwarding to `AsRef`/`AsMut` derives.
+- Add support for specifying concrete types to `AsRef`/`AsMut` derives.
   ([#298](https://github.com/JelteF/derive_more/pull/298))
 
 ### Changed

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -48,7 +48,7 @@ default = []
 
 add = []
 add_assign = []
-as_ref = ["syn/extra-traits"]
+as_ref = ["syn/extra-traits", "syn/visit"]
 constructor = []
 debug = ["syn/extra-traits", "dep:unicode-xid"]
 deref = []

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -48,7 +48,7 @@ default = []
 
 add = []
 add_assign = []
-as_ref = []
+as_ref = ["syn/extra-traits"]
 constructor = []
 debug = ["syn/extra-traits", "dep:unicode-xid"]
 deref = []

--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -61,34 +61,44 @@ where
 }
 ```
 
-It's also possible to specify concrete types to derive forwarded
-impls for with `#[as_mut(<types>)]`.
+It's also possible to specify concrete types to derive impls for with `#[as_mut(<types>)]`.
+
+These types can include both the type of the field, and types for which the field type implements `AsMut`.
 
 ```rust
 # use derive_more::AsMut;
 #
 #[derive(AsMut)]
-#[as_mut(str, [u8])]
+#[as_mut(str, [u8], String)]
 struct Types(String);
 
 let mut item = Types("test".to_owned());
 let _: &mut str = item.as_mut();
 let _: &mut [u8] = item.as_mut();
+let _: &mut String = item.as_mut();_
 ```
 
-Generates:
+When either the field type or the type specified to convert into contain type parameters,
+they're compared for string equality, and when there's no match assumed to be different types.
+
+For example
 
 ```rust
-# struct Types(String);
-impl AsMut<str> for Types {
-    fn as_mut(&mut self) -> &mut str {
-        <String as ::core::convert::AsMut<str>>::as_mut(&mut self.0)
-    }
-}
+# use derive_more::AsMut;
+#
+#[derive(AsMut)]
+#[as_ref(i32)]
+struct Generic<T>(T);
+```
 
-impl AsMut<[u8]> for Types {
-    fn as_mut(&mut self) -> &mut [u8] {
-        <String as ::core::convert::AsMut<[u8]>>::as_mut(&mut self.0)
+Generates a forwarded impl
+
+```rust
+# struct Generic<T>(T);
+#
+impl<T: AsMut<i32>> AsMut<i32> for Generic<T> {
+    fn as_mut(&self) -> &i32 {
+        <T as ::core::convert::AsMut<i32>>::as_mut(&mut self.0)
     }
 }
 ```

--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -105,7 +105,7 @@ An implementation will be generated for each indicated field.
 #
 #[derive(AsMut)]
 struct MyWrapper {
-    #[as_mut]
+    #[as_mut(str)]
     name: String,
     #[as_mut]
     num: i32,
@@ -121,9 +121,9 @@ Generates:
 #     num: i32,
 #     valid: bool,
 # }
-impl AsMut<String> for MyWrapper {
+impl AsMut<str> for MyWrapper {
     fn as_mut(&mut self) -> &mut String {
-        &mut self.name
+        <String as ::core::convert::AsMut<str>>::as_mut(&mut self.name)
     }
 }
 
@@ -134,6 +134,20 @@ impl AsMut<i32> for MyWrapper {
 }
 ```
 
+Only conversions that use a single field are possible with this derive.
+Something like this wouldn't work, due to the nature of the `AsMut` trait:
+
+```rust,compile_fail
+# use derive_more::AsRef
+#
+// Error! `#[as_ref(...)]` attribute can only be placed on structs with exactly one field
+#[derive(AsRef)]
+#[as_ref((str, [u8]))]
+struct MyWrapper(String, Vec<u8>)
+```
+
+If you need to convert into multiple references, consider using the
+[`Into`](crate::Into) derive with `#[into(ref_mut)]`.
 
 ### Skipping
 

--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -78,7 +78,7 @@ let _: &mut [u8] = item.as_mut();
 let _: &mut String = item.as_mut();_
 ```
 
-When either the field type or the type specified to convert into contain type parameters,
+When either the field type or the type specified to convert into contain generic parameters,
 they're compared for string equality, and when there's no match assumed to be different types.
 
 For example

--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -31,7 +31,7 @@ impl AsMut<String> for MyWrapper {
 }
 ```
 
-It's also possible to use the `#[as_mut(forward)]` attribute to forward
+The `#[as_mut(forward)]` attribute can be used to forward
 to the `as_mut` implementation of the field. So here `SingleFieldForward`
 implements all `AsMut` for all types that `Vec<i32>` implements `AsMut` for.
 
@@ -61,7 +61,37 @@ where
 }
 ```
 
+It's also possible to specify concrete types to derive forwarded
+impls for with `#[as_mut(<types>)]`.
 
+```rust
+# use derive_more::AsMut;
+#
+#[derive(AsMut)]
+#[as_mut(str, [u8])]
+struct Types(String);
+
+let mut item = Types("test".to_owned());
+let _: &mut str = item.as_mut();
+let _: &mut [u8] = item.as_mut();
+```
+
+Generates:
+
+```rust
+# struct Types(String);
+impl AsMut<str> for Types {
+    fn as_mut(&mut self) -> &mut str {
+        <String as ::core::convert::AsMut<str>>::as_mut(&mut self.0)
+    }
+}
+
+impl AsMut<[u8]> for Types {
+    fn as_mut(&mut self) -> &mut [u8] {
+        <String as ::core::convert::AsMut<[u8]>>::as_mut(&mut self.0)
+    }
+}
+```
 
 
 ## Structs with Multiple Fields
@@ -137,6 +167,28 @@ struct ForwardWithOther {
     #[as_mut]
     number: i32,
 }
+```
+
+Multiple forwarded impls with concrete types, however, can be used.
+
+```rust
+# use derive_more::AsMut;
+#
+#[derive(AsMut)]
+struct Types {
+    #[as_mut(str)]
+    str: String,
+    #[as_mut([u8])]
+    vec: Vec<u8>,
+}
+
+let mut item = Types {
+    str: "test".to_owned(),
+    vec: vec![0u8],
+};
+
+let _: &mut str = item.as_mut();
+let _: &mut [u8] = item.as_mut();
 ```
 
 ## Enums

--- a/impl/doc/as_ref.md
+++ b/impl/doc/as_ref.md
@@ -106,7 +106,7 @@ An implementation will be generated for each indicated field.
 #
 #[derive(AsRef)]
 struct MyWrapper {
-    #[as_ref]
+    #[as_ref(str)]
     name: String,
     #[as_ref]
     num: i32,
@@ -122,9 +122,9 @@ Generates:
 #     num: i32,
 #     valid: bool,
 # }
-impl AsRef<String> for MyWrapper {
+impl AsRef<str> for MyWrapper {
     fn as_ref(&self) -> &String {
-        &self.name
+        <String as ::core::convert::AsRef<str>>::as_ref(&self.name)
     }
 }
 
@@ -134,6 +134,21 @@ impl AsRef<i32> for MyWrapper {
     }
 }
 ```
+
+Only conversions that use a single field are possible with this derive.
+Something like this wouldn't work, due to the nature of the `AsRef` trait:
+
+```rust,compile_fail
+# use derive_more::AsRef
+#
+// Error! `#[as_ref(...)]` attribute can only be placed on structs with exactly one field
+#[derive(AsRef)]
+#[as_ref((str, [u8]))]
+struct MyWrapper(String, Vec<u8>)
+```
+
+If you need to convert into multiple references, consider using the
+[`Into`](crate::Into) derive with `#[into(ref)]`.
 
 
 ### Skipping

--- a/impl/doc/as_ref.md
+++ b/impl/doc/as_ref.md
@@ -31,7 +31,7 @@ impl AsRef<String> for MyWrapper {
 }
 ```
 
-It's also possible to use the `#[as_ref(forward)]` attribute to forward
+The `#[as_ref(forward)]` attribute can be used to forward
 to the `as_ref` implementation of the field. So here `SingleFieldForward`
 implements all `AsRef` for all types that `Vec<i32>` implements `AsRef` for.
 
@@ -61,6 +61,37 @@ where
 }
 ```
 
+It's also possible to specify concrete types to derive forwarded
+impls for with `#[as_ref(<types>)]`.
+
+```rust
+# use derive_more::AsRef;
+#
+#[derive(AsRef)]
+#[as_ref(str, [u8])]
+struct Types(String);
+
+let item = Types("test".to_owned());
+let _: &str = item.as_ref();
+let _: &[u8] = item.as_ref();
+```
+
+Generates:
+
+```rust
+# struct Types(String);
+impl AsRef<str> for Types {
+    fn as_ref(&self) -> &str {
+        <String as ::core::convert::AsRef<str>>::as_ref(&self.0)
+    }
+}
+
+impl AsRef<[u8]> for Types {
+    fn as_ref(&self) -> &[u8] {
+        <String as ::core::convert::AsRef<[u8]>>::as_ref(&self.0)
+    }
+}
+```
 
 
 
@@ -139,6 +170,29 @@ struct ForwardWithOther {
     number: i32,
 }
 ```
+
+Multiple forwarded impls with concrete types, however, can be used.
+
+```rust
+# use derive_more::AsRef;
+#
+#[derive(AsRef)]
+struct Types {
+    #[as_ref(str)]
+    str: String,
+    #[as_ref([u8])]
+    vec: Vec<u8>,
+}
+
+let item = Types {
+    str: "test".to_owned(),
+    vec: vec![0u8],
+};
+
+let _: &str = item.as_ref();
+let _: &[u8] = item.as_ref();
+```
+
 
 ## Enums
 

--- a/impl/doc/as_ref.md
+++ b/impl/doc/as_ref.md
@@ -61,34 +61,44 @@ where
 }
 ```
 
-It's also possible to specify concrete types to derive forwarded
-impls for with `#[as_ref(<types>)]`.
+It's also possible to specify concrete types to derive impls for with `#[as_ref(<types>)]`.
+
+These types can include both the type of the field, and types for which the field type implements `AsRef`.
 
 ```rust
 # use derive_more::AsRef;
 #
 #[derive(AsRef)]
-#[as_ref(str, [u8])]
+#[as_ref(str, [u8], String)]
 struct Types(String);
 
 let item = Types("test".to_owned());
 let _: &str = item.as_ref();
 let _: &[u8] = item.as_ref();
+let _: &String = item.as_ref();
 ```
 
-Generates:
+When either the field type or the type specified to convert into contain type parameters,
+they're compared for string equality, and when there's no match assumed to be different types.
+
+For example
 
 ```rust
-# struct Types(String);
-impl AsRef<str> for Types {
-    fn as_ref(&self) -> &str {
-        <String as ::core::convert::AsRef<str>>::as_ref(&self.0)
-    }
-}
+# use derive_more::AsRef;
+#
+#[derive(AsRef)]
+#[as_ref(i32)]
+struct Generic<T>(T);
+```
 
-impl AsRef<[u8]> for Types {
-    fn as_ref(&self) -> &[u8] {
-        <String as ::core::convert::AsRef<[u8]>>::as_ref(&self.0)
+Generates a forwarded impl
+
+```rust
+# struct Generic<T>(T);
+#
+impl<T: AsRef<i32>> AsRef<i32> for Generic<T> {
+    fn as_ref(&self) -> &i32 {
+        <T as ::core::convert::AsRef<i32>>::as_ref(&self.0)
     }
 }
 ```
@@ -123,7 +133,7 @@ Generates:
 #     valid: bool,
 # }
 impl AsRef<str> for MyWrapper {
-    fn as_ref(&self) -> &String {
+    fn as_ref(&self) -> &str {
         <String as ::core::convert::AsRef<str>>::as_ref(&self.name)
     }
 }

--- a/impl/doc/as_ref.md
+++ b/impl/doc/as_ref.md
@@ -78,7 +78,7 @@ let _: &[u8] = item.as_ref();
 let _: &String = item.as_ref();
 ```
 
-When either the field type or the type specified to convert into contain type parameters,
+When either the field type or the type specified to convert into contain generic parameters,
 they're compared for string equality, and when there's no match assumed to be different types.
 
 For example

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -158,7 +158,7 @@ pub fn expand(
 /// - Optional `mut` token indicating [`AsMut`] expansion.
 type ExpansionCtx<'a> = (&'a syn::Ident, &'a syn::Ident, Option<&'a Token![mut]>);
 
-/// Expansion of a macro for generating [`AsRef`]/[`AsMut`] implementation for a single field of a
+/// Expansion of a macro for generating [`AsRef`]/[`AsMut`] implementations for a single field of a
 /// struct.
 struct Expansion<'a> {
     /// [`ExpansionCtx] of the derived trait.
@@ -176,7 +176,7 @@ struct Expansion<'a> {
     /// Index of the [`syn::Field`].
     field_index: usize,
 
-    /// Arguments on the attribute
+    /// Arguments specifying which conversions should be generated
     args: Option<AsArgs>,
 }
 

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -386,7 +386,8 @@ enum AsArgs {
     /// Blanket impl, fully forwarding to the field type.
     Forward(forward::Attribute),
 
-    /// Forward implementation, but only impl for specified types.
+    /// Impl for specified types, which can include both the type of the field,
+    /// and types for which the field type implements `AsRef`
     Types(Punctuated<syn::Type, Token![,]>),
 }
 

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -39,7 +39,7 @@ pub fn expand(
         )),
     }?;
 
-    let expansions = if let Some(args) =
+    let expansions = if let Some(attr) =
         StructAttribute::parse_attrs(&input.attrs, attr_ident)?
     {
         if data.fields.len() != 1 {
@@ -70,7 +70,7 @@ pub fn expand(
             generics: &input.generics,
             field,
             field_index: 0,
-            args: Some(args.into_inner()),
+            args: Some(attr.into_inner()),
         }]
     } else {
         let attrs = data
@@ -273,6 +273,11 @@ enum FieldAttribute {
 }
 
 /// Arguments specifying which conversions should be generated
+///
+/// ```rust,ignore
+/// #[as_ref(forward)]
+/// #[as_ref(<types>)]x
+/// ```
 enum AsArgs {
     /// Blanket impl, fully forwarding to the field type
     Forward(forward::Attribute),
@@ -336,6 +341,7 @@ impl FieldAttribute {
             })
     }
 
+    /// Conversion into arguments on the attribute, if any
     fn into_args(self) -> Option<AsArgs> {
         match self {
             Self::Args(args) => Some(args),

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -228,7 +228,7 @@ impl<'a> ToTokens for Expansion<'a> {
                             .predicates
                             .push(parse_quote! { #return_ty: ?::core::marker::Sized });
                     }
-                    if contains_param {
+                    if is_blanket || contains_param {
                         generics
                             .make_where_clause()
                             .predicates
@@ -245,7 +245,7 @@ impl<'a> ToTokens for Expansion<'a> {
 
                 let mut body = quote! { & #mut_ self.#field_ident };
                 if is_forward {
-                    if contains_param {
+                    if is_blanket || contains_param {
                         body = quote! {
                             <#field_ty as #trait_ty>::#method_ident(#body)
                         };

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -276,7 +276,7 @@ enum FieldAttribute {
 ///
 /// ```rust,ignore
 /// #[as_ref(forward)]
-/// #[as_ref(<types>)]x
+/// #[as_ref(<types>)]
 /// ```
 enum AsArgs {
     /// Blanket impl, fully forwarding to the field type
@@ -341,7 +341,7 @@ impl FieldAttribute {
             })
     }
 
-    /// Conversion into arguments on the attribute, if any
+    /// Extracts conversion arguments on the attribute, if any
     fn into_args(self) -> Option<AsArgs> {
         match self {
             Self::Args(args) => Some(args),

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -15,9 +15,7 @@ use syn::{
     Token,
 };
 
-use crate::utils::{
-    contains_any_of, forward, skip, Either, HashSet, ParamSearch, Spanning,
-};
+use crate::utils::{forward, skip, Either, HashSet, ParamSearch, Spanning};
 
 /// Expands an [`AsRef`]/[`AsMut`] derive macro.
 pub fn expand(
@@ -212,7 +210,7 @@ impl<'a> ToTokens for Expansion<'a> {
             param_consts,
         };
 
-        let field_contains_param = contains_any_of(field_ty, &param_search);
+        let field_contains_param = param_search.any_in(field_ty);
 
         let is_blanket = matches!(&self.args, Some(AsArgs::Forward(_)));
 
@@ -248,7 +246,7 @@ impl<'a> ToTokens for Expansion<'a> {
                     break 'ver Direct;
                 }
 
-                if field_contains_param || contains_any_of(&return_ty, &param_search) {
+                if field_contains_param || param_search.any_in(&return_ty) {
                     break 'ver Forwarded;
                 }
 

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -256,8 +256,9 @@ impl<'a> ToTokens for Expansion<'a> {
                 ImplVersion::Specialized => Cow::Owned(quote! {
                     use ::derive_more::__private::ExtractRef as _;
 
-                    let conv: ::derive_more::__private::Conv<& #mut_ #field_ty, #return_ty>
-                        = Default::default();
+                    let conv =
+                        <::derive_more::__private::Conv<& #mut_ #field_ty, #return_ty>
+                         as ::core::default::Default>::default();
                     (&&conv).__extract_ref(#field_ref)
                 }),
             };

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -126,18 +126,14 @@ pub fn expand(
                 .enumerate()
                 .zip(attrs)
                 .filter_map(|((i, field), attr)| match attr.map(Spanning::into_inner) {
-                    attr @ Some(FieldAttribute::Empty | FieldAttribute::Args(_)) => {
+                    Some(attr @ (FieldAttribute::Empty | FieldAttribute::Args(_))) => {
                         Some(Expansion {
                             trait_info,
                             ident: &input.ident,
                             generics: &input.generics,
                             field,
                             field_index: i,
-                            args: if let Some(FieldAttribute::Args(args)) = attr {
-                                Some(args)
-                            } else {
-                                None
-                            },
+                            args: attr.into_args(),
                         })
                     }
                     Some(FieldAttribute::Skip(_)) => unreachable!(),
@@ -338,6 +334,13 @@ impl FieldAttribute {
                     Ok(Some(parsed))
                 }
             })
+    }
+
+    fn into_args(self) -> Option<AsArgs> {
+        match self {
+            Self::Args(args) => Some(args),
+            Self::Empty | Self::Skip(_) => None,
+        }
     }
 }
 

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -330,7 +330,7 @@ impl FieldAttribute {
                             Ok(Some(Spanning::new(Self::Args(AsArgs::Types(tys)), span)))
                         }
                         _ => Err(syn::Error::new(
-                            span,
+                            parsed.span,
                             format!("only single `#[{attr_ident}(...)]` attribute is allowed here")
                         ))
                     }
@@ -375,7 +375,7 @@ impl StructAttribute {
                             Ok(Some(Spanning::new(Self::Types(tys), span)))
                         },
                         _ => Err(syn::Error::new(
-                            span,
+                            parsed.span,
                             format!("only single `#[{attr_ident}(...)]` attribute is allowed here"),
                         ))
                     }

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -15,7 +15,7 @@ use syn::{
     Token,
 };
 
-use crate::utils::{contains_any_of, forward, skip, Either, HashSet, Spanning};
+use crate::utils::{forward, skip, type_contains_any_of, Either, HashSet, Spanning};
 
 /// Expands an [`AsRef`]/[`AsMut`] derive macro.
 pub fn expand(
@@ -192,7 +192,7 @@ impl<'a> ToTokens for Expansion<'a> {
             .map(|param| &param.ident)
             .collect();
 
-        let field_contains_param = contains_any_of(&self.field.ty, &param_idents);
+        let field_contains_param = type_contains_any_of(field_ty, &param_idents);
 
         let is_blanket = matches!(&self.args, Some(AsArgs::Forward(_)));
 
@@ -214,7 +214,9 @@ impl<'a> ToTokens for Expansion<'a> {
                     break 'ver ImplKind::Direct;
                 }
 
-                if field_contains_param || contains_any_of(&return_ty, &param_idents) {
+                if field_contains_param
+                    || type_contains_any_of(&return_ty, &param_idents)
+                {
                     break 'ver ImplKind::Forwarded;
                 }
 

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -15,10 +15,7 @@ use syn::{
     Token,
 };
 
-use crate::{
-    parsing::Type,
-    utils::{forward, skip, Either, Spanning},
-};
+use crate::utils::{forward, skip, Either, Spanning};
 
 /// Expands an [`AsRef`]/[`AsMut`] derive macro.
 pub fn expand(
@@ -347,7 +344,7 @@ enum AsArgs {
     Forward(forward::Attribute),
 
     /// Forward implementation, but only impl for specified types.
-    Types(Punctuated<Type, Token![,]>),
+    Types(Punctuated<syn::Type, Token![,]>),
 }
 
 impl Parse for AsArgs {
@@ -359,7 +356,7 @@ impl Parse for AsArgs {
         }
 
         input
-            .parse_terminated(Type::parse, Token![,])
+            .parse_terminated(syn::Type::parse, Token![,])
             .map(Self::Types)
     }
 }

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -200,9 +200,16 @@ impl<'a> ToTokens for Expansion<'a> {
             .map(|param| &param.lifetime.ident)
             .collect();
 
+        let param_consts: HashSet<_> = self
+            .generics
+            .const_params()
+            .map(|param| &param.ident)
+            .collect();
+
         let param_search = ParamSearch {
             param_tys,
             param_lfs,
+            param_consts,
         };
 
         let field_contains_param = contains_any_of(field_ty, &param_search);

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -56,7 +56,6 @@ mod mul_like;
 #[cfg(feature = "not")]
 mod not_like;
 #[cfg(any(
-    feature = "as_ref",
     feature = "debug",
     feature = "display",
     feature = "from",

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -56,6 +56,7 @@ mod mul_like;
 #[cfg(feature = "not")]
 mod not_like;
 #[cfg(any(
+    feature = "as_ref",
     feature = "debug",
     feature = "display",
     feature = "from",

--- a/impl/src/parsing.rs
+++ b/impl/src/parsing.rs
@@ -243,15 +243,15 @@ pub fn seq<const N: usize>(
     mut parsers: [&mut dyn FnMut(Cursor<'_>) -> ParsingResult<'_>; N],
 ) -> impl FnMut(Cursor<'_>) -> ParsingResult<'_> + '_ {
     move |c| {
-        parsers
-            .iter_mut()
-            .fold(Some((TokenStream::new(), c)), |out, parser| {
-                let (mut out, mut c) = out?;
+        parsers.iter_mut().try_fold(
+            (TokenStream::new(), c),
+            |(mut out, mut c), parser| {
                 let (stream, cursor) = parser(c)?;
                 out.extend(stream);
                 c = cursor;
                 Some((out, c))
-            })
+            },
+        )
     }
 }
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1708,10 +1708,10 @@ mod param_search {
                 return;
             }
 
-            self.found = tp
-                .path
-                .get_ident()
-                .map_or(false, |ident| self.search.param_tys.contains(ident));
+            self.found = tp.path.get_ident().map_or(false, |ident| {
+                self.search.param_tys.contains(ident)
+                    || self.search.param_consts.contains(ident)
+            });
 
             syn::visit::visit_type_path(self, tp)
         }

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -32,7 +32,7 @@ pub(crate) use self::fields_ext::FieldsExt;
 pub(crate) use self::spanning::Spanning;
 
 #[cfg(feature = "as_ref")]
-pub(crate) use self::type_search::contains_any_of;
+pub(crate) use self::type_search::type_contains_any_of;
 
 #[derive(Clone, Copy, Default)]
 pub struct DeterministicState;
@@ -1712,7 +1712,7 @@ mod type_search {
         }
     }
 
-    pub(crate) fn contains_any_of(
+    pub(crate) fn type_contains_any_of(
         ty: &syn::Type,
         search: &HashSet<&syn::Ident>,
     ) -> bool {

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -32,7 +32,7 @@ pub(crate) use self::fields_ext::FieldsExt;
 pub(crate) use self::spanning::Spanning;
 
 #[cfg(feature = "as_ref")]
-pub(crate) use self::param_search::{contains_any_of, ParamSearch};
+pub(crate) use self::param_search::ParamSearch;
 
 #[derive(Clone, Copy, Default)]
 pub struct DeterministicState;
@@ -1697,6 +1697,17 @@ mod param_search {
         pub param_consts: HashSet<&'a syn::Ident>,
     }
 
+    impl<'a> ParamSearch<'a> {
+        pub(crate) fn any_in(&self, ty: &syn::Type) -> bool {
+            let mut visitor = TypeSearchVisitor {
+                search: self,
+                found: false,
+            };
+            visitor.visit_type(ty);
+            visitor.found
+        }
+    }
+
     struct TypeSearchVisitor<'a> {
         search: &'a ParamSearch<'a>,
         found: bool,
@@ -1738,15 +1749,5 @@ mod param_search {
 
             syn::visit::visit_expr_path(self, ep)
         }
-    }
-
-    pub(crate) fn contains_any_of(ty: &syn::Type, search: &ParamSearch<'_>) -> bool {
-        let mut visitor = TypeSearchVisitor {
-            search,
-            found: false,
-        };
-
-        visitor.visit_type(ty);
-        visitor.found
     }
 }

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1715,11 +1715,7 @@ mod param_search {
 
     impl<'a, 'ast> Visit<'ast> for TypeSearchVisitor<'a> {
         fn visit_type_path(&mut self, tp: &'ast syn::TypePath) {
-            if self.found {
-                return;
-            }
-
-            self.found = tp.path.get_ident().map_or(false, |ident| {
+            self.found |= tp.path.get_ident().map_or(false, |ident| {
                 self.search.param_tys.contains(ident)
                     || self.search.param_consts.contains(ident)
             });
@@ -1728,21 +1724,13 @@ mod param_search {
         }
 
         fn visit_lifetime(&mut self, lf: &'ast syn::Lifetime) {
-            if self.found {
-                return;
-            }
-
-            self.found = self.search.param_lfs.contains(&lf.ident);
+            self.found |= self.search.param_lfs.contains(&lf.ident);
 
             syn::visit::visit_lifetime(self, lf)
         }
 
         fn visit_expr_path(&mut self, ep: &'ast syn::ExprPath) {
-            if self.found {
-                return;
-            }
-
-            self.found = ep
+            self.found |= ep
                 .path
                 .get_ident()
                 .map_or(false, |ident| self.search.param_consts.contains(ident));

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -31,6 +31,9 @@ pub(crate) use self::fields_ext::FieldsExt;
 ))]
 pub(crate) use self::spanning::Spanning;
 
+#[cfg(feature = "as_ref")]
+pub(crate) use self::type_search::contains_any_of;
+
 #[derive(Clone, Copy, Default)]
 pub struct DeterministicState;
 
@@ -1709,7 +1712,10 @@ mod type_search {
         }
     }
 
-    pub fn contains_any_of(ty: &syn::Type, search: &HashSet<&syn::Ident>) -> bool {
+    pub(crate) fn contains_any_of(
+        ty: &syn::Type,
+        search: &HashSet<&syn::Ident>,
+    ) -> bool {
         let mut visitor = TypeSearchVisitor {
             search,
             found: false,

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1328,8 +1328,6 @@ pub(crate) mod forward {
         spanned::Spanned as _,
     };
 
-    use super::Spanning;
-
     /// Representation of a `forward` attribute.
     ///
     /// ```rust,ignore
@@ -1343,34 +1341,6 @@ pub(crate) mod forward {
                 p if p.is_ident("forward") => Ok(Self),
                 p => Err(syn::Error::new(p.span(), "only `forward` allowed here")),
             }
-        }
-    }
-
-    impl Attribute {
-        /// Parses an [`Attribute`] from the provided [`syn::Attribute`]s, preserving its [`Span`].
-        ///
-        /// [`Span`]: proc_macro2::Span
-        pub(crate) fn parse_attrs(
-            attrs: impl AsRef<[syn::Attribute]>,
-            attr_ident: &syn::Ident,
-        ) -> syn::Result<Option<Spanning<Self>>> {
-            attrs
-                .as_ref()
-                .iter()
-                .filter(|attr| attr.path().is_ident(attr_ident))
-                .try_fold(None, |mut attrs, attr| {
-                    let parsed = Spanning::new(attr.parse_args::<Self>()?, attr.span());
-                    if attrs.replace(parsed).is_some() {
-                        Err(syn::Error::new(
-                            attr.span(),
-                            format!(
-                                "only single `#[{attr_ident}(forward)]` attribute is allowed here",
-                            ),
-                        ))
-                    } else {
-                        Ok(attrs)
-                    }
-                })
         }
     }
 }

--- a/src/as.rs
+++ b/src/as.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-pub struct Conv<Frm: ?Sized, To: ?Sized>(PhantomData<(Box<Frm>, Box<To>)>);
+pub struct Conv<Frm: ?Sized, To: ?Sized>(PhantomData<(*const Frm, *const To)>);
 
 impl<Frm: ?Sized, To: ?Sized> Default for Conv<Frm, To> {
     fn default() -> Self {

--- a/src/as.rs
+++ b/src/as.rs
@@ -42,7 +42,7 @@ impl<'a, T: ?Sized> ExtractRef for &Conv<&'a mut T, T> {
     }
 }
 
-impl<'a, Frm: ?Sized + AsMut<To>, To: ?Sized + 'a> ExtractRef
+impl<'a, Frm: ?Sized + AsMut<To>, To: 'a + ?Sized> ExtractRef
     for Conv<&'a mut Frm, To>
 {
     type Frm = &'a mut Frm;

--- a/src/as.rs
+++ b/src/as.rs
@@ -1,46 +1,54 @@
 use core::marker::PhantomData;
 
-pub struct Conv<Frm, To>(PhantomData<(Frm, To)>);
+pub struct Conv<Frm: ?Sized, To: ?Sized>(PhantomData<(Box<Frm>, Box<To>)>);
 
-pub trait GetRef {
+impl<Frm: ?Sized, To: ?Sized> Default for Conv<Frm, To> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+pub trait ExtractRef {
     type Frm;
     type To;
 
-    fn get_ref(&self, frm: Self::Frm) -> Self::To;
+    fn __extract_ref(&self, frm: Self::Frm) -> Self::To;
 }
 
-impl<'a, T> GetRef for &Conv<&'a T, T> {
+impl<'a, T: ?Sized> ExtractRef for &Conv<&'a T, T> {
     type Frm = &'a T;
     type To = &'a T;
 
-    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+    fn __extract_ref(&self, frm: Self::Frm) -> Self::To {
         frm
     }
 }
 
-impl<'a, Frm: AsRef<To>, To: 'a> GetRef for Conv<&'a Frm, To> {
+impl<'a, Frm: ?Sized + AsRef<To>, To: 'a + ?Sized> ExtractRef for Conv<&'a Frm, To> {
     type Frm = &'a Frm;
     type To = &'a To;
 
-    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+    fn __extract_ref(&self, frm: Self::Frm) -> Self::To {
         frm.as_ref()
     }
 }
 
-impl<'a, T> GetRef for &Conv<&'a mut T, T> {
+impl<'a, T: ?Sized> ExtractRef for &Conv<&'a mut T, T> {
     type Frm = &'a mut T;
     type To = &'a mut T;
 
-    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+    fn __extract_ref(&self, frm: Self::Frm) -> Self::To {
         frm
     }
 }
 
-impl<'a, Frm: AsMut<To>, To: 'a> GetRef for Conv<&'a mut Frm, To> {
+impl<'a, Frm: ?Sized + AsMut<To>, To: ?Sized + 'a> ExtractRef
+    for Conv<&'a mut Frm, To>
+{
     type Frm = &'a mut Frm;
     type To = &'a mut To;
 
-    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+    fn __extract_ref(&self, frm: Self::Frm) -> Self::To {
         frm.as_mut()
     }
 }

--- a/src/as.rs
+++ b/src/as.rs
@@ -1,0 +1,46 @@
+use core::marker::PhantomData;
+
+pub struct Conv<Frm, To>(PhantomData<(Frm, To)>);
+
+pub trait GetRef {
+    type Frm;
+    type To;
+
+    fn get_ref(&self, frm: Self::Frm) -> Self::To;
+}
+
+impl<'a, T> GetRef for &Conv<&'a T, T> {
+    type Frm = &'a T;
+    type To = &'a T;
+
+    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+        frm
+    }
+}
+
+impl<'a, Frm: AsRef<To>, To: 'a> GetRef for Conv<&'a Frm, To> {
+    type Frm = &'a Frm;
+    type To = &'a To;
+
+    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+        frm.as_ref()
+    }
+}
+
+impl<'a, T> GetRef for &Conv<&'a mut T, T> {
+    type Frm = &'a mut T;
+    type To = &'a mut T;
+
+    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+        frm
+    }
+}
+
+impl<'a, Frm: AsMut<To>, To: 'a> GetRef for Conv<&'a mut Frm, To> {
+    type Frm = &'a mut Frm;
+    type To = &'a mut To;
+
+    fn get_ref(&self, frm: Self::Frm) -> Self::To {
+        frm.as_mut()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub mod __private {
     pub use crate::vendor::thiserror::aserror::AsDynError;
 
     #[cfg(feature = "as_ref")]
-    pub use crate::r#as::{Conv, GetRef};
+    pub use crate::r#as::{Conv, ExtractRef};
 }
 
 /// Module containing macro definitions only, without corresponding traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub mod __private {
 
     #[cfg(feature = "error")]
     pub use crate::vendor::thiserror::aserror::AsDynError;
+
+    #[cfg(feature = "as_ref")]
+    pub use crate::r#as::{Conv, GetRef};
 }
 
 /// Module containing macro definitions only, without corresponding traits.
@@ -76,6 +79,9 @@ pub use crate::add::{BinaryError, WrongVariantError};
 mod ops;
 #[cfg(any(feature = "add", feature = "not"))]
 pub use crate::ops::UnitError;
+
+#[cfg(feature = "as_ref")]
+mod r#as;
 
 #[cfg(feature = "debug")]
 mod fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,14 @@
 // Not public, but exported API. For macro expansion internals only.
 #[doc(hidden)]
 pub mod __private {
+    #[cfg(feature = "as_ref")]
+    pub use crate::r#as::{Conv, ExtractRef};
+
     #[cfg(feature = "debug")]
     pub use crate::fmt::{debug_tuple, DebugTuple};
 
     #[cfg(feature = "error")]
     pub use crate::vendor::thiserror::aserror::AsDynError;
-
-    #[cfg(feature = "as_ref")]
-    pub use crate::r#as::{Conv, ExtractRef};
 }
 
 /// Module containing macro definitions only, without corresponding traits.

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -921,6 +921,16 @@ mod multi_field {
                 let rf: &mut str = item.as_mut();
                 assert!(ptr::eq(rf, item.1.as_mut()));
             }
+
+            #[derive(AsMut)]
+            struct FieldNonGeneric<T>(#[as_mut([T])] Vec<i32>, T);
+
+            #[test]
+            fn field_non_generic() {
+                let mut item = FieldNonGeneric(vec![], 2i32);
+
+                assert!(ptr::eq(item.as_mut(), item.0.as_mut()));
+            }
         }
     }
 
@@ -1178,6 +1188,23 @@ mod multi_field {
 
                 let rf: &mut str = item.as_mut();
                 assert!(ptr::eq(rf, item.second.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldNonGeneric<T> {
+                #[as_mut([T])]
+                first: Vec<i32>,
+                second: T,
+            }
+
+            #[test]
+            fn field_non_generic() {
+                let mut item = FieldNonGeneric {
+                    first: vec![],
+                    second: 2i32,
+                };
+
+                assert!(ptr::eq(item.as_mut(), item.first.as_mut()));
             }
         }
     }

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -109,18 +109,17 @@ mod single_field {
         #[as_mut(i32, f64)]
         struct Types(Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for Types {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsMut<Helper> for Types {
             fn as_mut(&mut self) -> &mut Helper {
                 &mut self.0
@@ -142,9 +141,9 @@ mod single_field {
         #[as_mut(i32, Helper)]
         struct TypesWithInner(Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for TypesWithInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
@@ -168,10 +167,9 @@ mod single_field {
         #[as_mut(i32, RenamedFoo)]
         struct TypesWithRenamedInner(Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
-
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for TypesWithRenamedInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
@@ -192,18 +190,17 @@ mod single_field {
         #[derive(AsMut)]
         struct FieldTypes(#[as_mut(i32, f64)] Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for FieldTypes {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsMut<Helper> for FieldTypes {
             fn as_mut(&mut self) -> &mut Helper {
                 &mut self.0
@@ -224,9 +221,9 @@ mod single_field {
         #[derive(AsMut)]
         struct FieldTypesWithInner(#[as_mut(i32, Helper)] Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for FieldTypesWithInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
@@ -247,9 +244,9 @@ mod single_field {
         #[derive(AsMut)]
         struct FieldTypesWithRenamedInner(#[as_mut(i32, RenamedFoo)] Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for FieldTypesWithRenamedInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
@@ -317,9 +314,9 @@ mod single_field {
             #[as_mut(i32, f64)]
             struct Types<T>(T);
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for Types<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.0.as_mut()
@@ -351,9 +348,9 @@ mod single_field {
             #[derive(AsMut)]
             struct FieldTypes<T>(#[as_mut(i32, f64)] T);
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for FieldTypes<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.0.as_mut()
@@ -497,18 +494,17 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for Types {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsMut<Helper> for Types {
             fn as_mut(&mut self) -> &mut Helper {
                 &mut self.first
@@ -534,9 +530,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for TypesWithInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
@@ -564,9 +560,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for TypesWithRenamedInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
@@ -592,18 +588,17 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for FieldTypes {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsMut<Helper> for FieldTypes {
             fn as_mut(&mut self) -> &mut Helper {
                 &mut self.first
@@ -629,9 +624,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for FieldTypesWithInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
@@ -657,9 +652,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsMut<bool> for FieldTypesWithRenamedInner {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
@@ -749,9 +744,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for Types<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.first.as_mut()
@@ -790,9 +785,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for FieldTypes<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.first.as_mut()

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -14,8 +14,25 @@ use core::ptr;
 
 use derive_more::AsMut;
 
-#[derive(AsMut)]
 struct Foo(i32, f64, bool);
+
+impl AsMut<i32> for Foo {
+    fn as_mut(&mut self) -> &mut i32 {
+        &mut self.0
+    }
+}
+
+impl AsMut<f64> for Foo {
+    fn as_mut(&mut self) -> &mut f64 {
+        &mut self.1
+    }
+}
+
+impl AsMut<bool> for Foo {
+    fn as_mut(&mut self) -> &mut bool {
+        &mut self.2
+    }
+}
 
 mod single_field {
     use super::*;

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -78,6 +78,14 @@ mod single_field {
             }
         }
 
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<Foo> for Types {
+            fn as_mut(&mut self) -> &mut Foo {
+                &mut self.0
+            }
+        }
+
         #[test]
         fn types() {
             let mut item = Types(Foo(1, 2.0, false));
@@ -97,6 +105,14 @@ mod single_field {
         impl AsMut<bool> for FieldTypes {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<Foo> for FieldTypes {
+            fn as_mut(&mut self) -> &mut Foo {
+                &mut self.0
             }
         }
 
@@ -282,6 +298,14 @@ mod single_field {
             }
         }
 
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<Foo> for Types {
+            fn as_mut(&mut self) -> &mut Foo {
+                &mut self.first
+            }
+        }
+
         #[test]
         fn types() {
             let mut item = Types {
@@ -306,6 +330,14 @@ mod single_field {
         impl AsMut<bool> for FieldTypes {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<Foo> for FieldTypes {
+            fn as_mut(&mut self) -> &mut Foo {
+                &mut self.first
             }
         }
 
@@ -512,6 +544,22 @@ mod multi_field {
         #[derive(AsMut)]
         struct Types(#[as_mut(str)] String, #[as_mut([u8])] Vec<u8>);
 
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<String> for Types {
+            fn as_mut(&mut self) -> &mut String {
+                &mut self.0
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<Vec<u8>> for Types {
+            fn as_mut(&mut self) -> &mut Vec<u8> {
+                &mut self.1
+            }
+        }
+
         #[test]
         fn types() {
             let mut item = Types("test".to_owned(), vec![0]);
@@ -687,6 +735,22 @@ mod multi_field {
             first: String,
             #[as_mut([u8])]
             second: Vec<u8>,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<String> for Types {
+            fn as_mut(&mut self) -> &mut String {
+                &mut self.first
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<Vec<u8>> for Types {
+            fn as_mut(&mut self) -> &mut Vec<u8> {
+                &mut self.second
+            }
         }
 
         #[test]

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -70,16 +70,18 @@ mod single_field {
         #[as_mut(i32, f64)]
         struct Types(Foo);
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsMut<bool> for Types {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsMut<Foo> for Types {
             fn as_mut(&mut self) -> &mut Foo {
                 &mut self.0
@@ -100,16 +102,18 @@ mod single_field {
         #[derive(AsMut)]
         struct FieldTypes(#[as_mut(i32, f64)] Foo);
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsMut<bool> for FieldTypes {
             fn as_mut(&mut self) -> &mut bool {
                 self.0.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsMut<Foo> for FieldTypes {
             fn as_mut(&mut self) -> &mut Foo {
                 &mut self.0
@@ -177,8 +181,9 @@ mod single_field {
             #[as_mut(i32, f64)]
             struct Types<T>(T);
 
-            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for Types<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.0.as_mut()
@@ -199,8 +204,9 @@ mod single_field {
             #[derive(AsMut)]
             struct FieldTypes<T>(#[as_mut(i32, f64)] T);
 
-            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for FieldTypes<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.0.as_mut()
@@ -290,16 +296,18 @@ mod single_field {
             first: Foo,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsMut<bool> for Types {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsMut<Foo> for Types {
             fn as_mut(&mut self) -> &mut Foo {
                 &mut self.first
@@ -325,16 +333,18 @@ mod single_field {
             first: Foo,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsMut<bool> for FieldTypes {
             fn as_mut(&mut self) -> &mut bool {
                 self.first.as_mut()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsMut` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsMut<Foo> for FieldTypes {
             fn as_mut(&mut self) -> &mut Foo {
                 &mut self.first
@@ -424,8 +434,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for Types<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.first.as_mut()
@@ -451,8 +462,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsMut<bool>> AsMut<bool> for FieldTypes<T> {
                 fn as_mut(&mut self) -> &mut bool {
                     self.first.as_mut()
@@ -542,17 +554,9 @@ mod multi_field {
         }
 
         #[derive(AsMut)]
-        struct Types(#[as_mut(str)] String, #[as_mut([u8])] Vec<u8>);
+        struct Types(#[as_mut(str, String)] String, #[as_mut([u8])] Vec<u8>);
 
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsMut<String> for Types {
-            fn as_mut(&mut self) -> &mut String {
-                &mut self.0
-            }
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for the field type, by
         // producing trait implementations conflict error during compilation, if it does.
         impl AsMut<Vec<u8>> for Types {
             fn as_mut(&mut self) -> &mut Vec<u8> {
@@ -566,6 +570,9 @@ mod multi_field {
 
             let rf: &mut str = item.as_mut();
             assert!(ptr::eq(rf, item.0.as_mut()));
+
+            let rf: &mut String = item.as_mut();
+            assert!(ptr::eq(rf, &mut item.0));
 
             let rf: &mut [u8] = item.as_mut();
             assert!(ptr::eq(rf, item.1.as_mut()));
@@ -731,18 +738,10 @@ mod multi_field {
 
         #[derive(AsMut)]
         struct Types {
-            #[as_mut(str)]
+            #[as_mut(str, String)]
             first: String,
             #[as_mut([u8])]
             second: Vec<u8>,
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsMut<String> for Types {
-            fn as_mut(&mut self) -> &mut String {
-                &mut self.first
-            }
         }
 
         // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
@@ -762,6 +761,9 @@ mod multi_field {
 
             let rf: &mut str = item.as_mut();
             assert!(ptr::eq(rf, item.first.as_mut()));
+
+            let rf: &mut String = item.as_mut();
+            assert!(ptr::eq(rf, &mut item.first));
 
             let rf: &mut [u8] = item.as_mut();
             assert!(ptr::eq(rf, item.second.as_mut()));

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -42,6 +42,12 @@ impl AsMut<i32> for Bar<&'static mut i32> {
     }
 }
 
+impl AsMut<[i32]> for Bar<[i32; 0]> {
+    fn as_mut(&mut self) -> &mut [i32] {
+        &mut self.0
+    }
+}
+
 impl Default for Bar<&'static mut i32> {
     fn default() -> Self {
         static mut STATIC: i32 = 0;
@@ -391,6 +397,27 @@ mod single_field {
             #[test]
             fn field_lifetime() {
                 let mut item = FieldLifetime(Bar::default());
+
+                assert!(ptr::eq(item.as_mut(), item.0.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            #[as_mut([i32])]
+            struct ConstParam<const N: usize>(Bar<[i32; N]>);
+
+            #[test]
+            fn const_param() {
+                let mut item = ConstParam(Bar([]));
+
+                assert!(ptr::eq(item.as_mut(), item.0.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldConstParam<const N: usize>(#[as_mut([i32])] Bar<[i32; N]>);
+
+            #[test]
+            fn field_const_param() {
+                let mut item = FieldConstParam(Bar([]));
 
                 assert!(ptr::eq(item.as_mut(), item.0.as_mut()));
             }
@@ -821,6 +848,32 @@ mod single_field {
                 let mut item = FieldLifetime {
                     first: Bar::default(),
                 };
+
+                assert!(ptr::eq(item.as_mut(), item.first.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            #[as_mut([i32])]
+            struct ConstParam<const N: usize> {
+                first: Bar<[i32; N]>,
+            }
+
+            #[test]
+            fn const_param() {
+                let mut item = ConstParam { first: Bar([]) };
+
+                assert!(ptr::eq(item.as_mut(), item.first.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldConstParam<const N: usize> {
+                #[as_mut([i32])]
+                first: Bar<[i32; N]>,
+            }
+
+            #[test]
+            fn field_const_param() {
+                let mut item = FieldConstParam { first: Bar([]) };
 
                 assert!(ptr::eq(item.as_mut(), item.first.as_mut()));
             }

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -14,6 +14,9 @@ use core::ptr;
 
 use derive_more::AsMut;
 
+#[derive(AsMut)]
+struct Foo(i32, f64, bool);
+
 mod single_field {
     use super::*;
 
@@ -63,6 +66,51 @@ mod single_field {
             assert!(ptr::eq(rf, item.0.as_mut()));
         }
 
+        #[derive(AsMut)]
+        #[as_mut(i32, f64)]
+        struct Types(Foo);
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<bool> for Types {
+            fn as_mut(&mut self) -> &mut bool {
+                self.0.as_mut()
+            }
+        }
+
+        #[test]
+        fn types() {
+            let mut item = Types(Foo(1, 2.0, false));
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+
+            let rf: &mut f64 = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+        }
+
+        #[derive(AsMut)]
+        struct FieldTypes(#[as_mut(i32, f64)] Foo);
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<bool> for FieldTypes {
+            fn as_mut(&mut self) -> &mut bool {
+                self.0.as_mut()
+            }
+        }
+
+        #[test]
+        fn field_types() {
+            let mut item = FieldTypes(Foo(1, 2.0, false));
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+
+            let rf: &mut f64 = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+        }
+
         mod generic {
             use super::*;
 
@@ -106,6 +154,51 @@ mod single_field {
                 let mut item = FieldForward("test".to_owned());
 
                 let rf: &mut str = item.as_mut();
+                assert!(ptr::eq(rf, item.0.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            #[as_mut(i32, f64)]
+            struct Types<T>(T);
+
+            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsMut<bool>> AsMut<bool> for Types<T> {
+                fn as_mut(&mut self) -> &mut bool {
+                    self.0.as_mut()
+                }
+            }
+
+            #[test]
+            fn types() {
+                let mut item = Types(Foo(1, 2.0, false));
+
+                let rf: &mut i32 = item.as_mut();
+                assert!(ptr::eq(rf, item.0.as_mut()));
+
+                let rf: &mut f64 = item.as_mut();
+                assert!(ptr::eq(rf, item.0.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldTypes<T>(#[as_mut(i32, f64)] T);
+
+            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsMut<bool>> AsMut<bool> for FieldTypes<T> {
+                fn as_mut(&mut self) -> &mut bool {
+                    self.0.as_mut()
+                }
+            }
+
+            #[test]
+            fn field_types() {
+                let mut item = FieldTypes(Foo(1, 2.0, false));
+
+                let rf: &mut i32 = item.as_mut();
+                assert!(ptr::eq(rf, item.0.as_mut()));
+
+                let rf: &mut f64 = item.as_mut();
                 assert!(ptr::eq(rf, item.0.as_mut()));
             }
         }
@@ -175,6 +268,60 @@ mod single_field {
             assert!(ptr::eq(rf, item.first.as_mut()));
         }
 
+        #[derive(AsMut)]
+        #[as_mut(i32, f64)]
+        struct Types {
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<bool> for Types {
+            fn as_mut(&mut self) -> &mut bool {
+                self.first.as_mut()
+            }
+        }
+
+        #[test]
+        fn types() {
+            let mut item = Types {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+
+            let rf: &mut f64 = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+        }
+
+        #[derive(AsMut)]
+        struct FieldTypes {
+            #[as_mut(i32, f64)]
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsMut<bool> for FieldTypes {
+            fn as_mut(&mut self) -> &mut bool {
+                self.first.as_mut()
+            }
+        }
+
+        #[test]
+        fn field_types() {
+            let mut item = FieldTypes {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+
+            let rf: &mut f64 = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+        }
+
         mod generic {
             use super::*;
 
@@ -236,6 +383,60 @@ mod single_field {
                 };
 
                 let rf: &mut str = item.as_mut();
+                assert!(ptr::eq(rf, item.first.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            #[as_mut(i32, f64)]
+            struct Types<T> {
+                first: T,
+            }
+
+            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsMut<bool>> AsMut<bool> for Types<T> {
+                fn as_mut(&mut self) -> &mut bool {
+                    self.first.as_mut()
+                }
+            }
+
+            #[test]
+            fn types() {
+                let mut item = Types {
+                    first: Foo(1, 2.0, false),
+                };
+
+                let rf: &mut i32 = item.as_mut();
+                assert!(ptr::eq(rf, item.first.as_mut()));
+
+                let rf: &mut f64 = item.as_mut();
+                assert!(ptr::eq(rf, item.first.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldTypes<T> {
+                #[as_mut(i32, f64)]
+                first: T,
+            }
+
+            // Asserts that the macro expansion doesn't generate `AsMut` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsMut<bool>> AsMut<bool> for FieldTypes<T> {
+                fn as_mut(&mut self) -> &mut bool {
+                    self.first.as_mut()
+                }
+            }
+
+            #[test]
+            fn field_types() {
+                let mut item = FieldTypes {
+                    first: Foo(1, 2.0, false),
+                };
+
+                let rf: &mut i32 = item.as_mut();
+                assert!(ptr::eq(rf, item.first.as_mut()));
+
+                let rf: &mut f64 = item.as_mut();
                 assert!(ptr::eq(rf, item.first.as_mut()));
             }
         }
@@ -308,6 +509,20 @@ mod multi_field {
             assert!(ptr::eq(rf, item.0.as_mut()));
         }
 
+        #[derive(AsMut)]
+        struct Types(#[as_mut(str)] String, #[as_mut([u8])] Vec<u8>);
+
+        #[test]
+        fn types() {
+            let mut item = Types("test".to_owned(), vec![0]);
+
+            let rf: &mut str = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+
+            let rf: &mut [u8] = item.as_mut();
+            assert!(ptr::eq(rf, item.1.as_mut()));
+        }
+
         mod generic {
             use super::*;
 
@@ -353,6 +568,20 @@ mod multi_field {
 
                 let rf: &mut str = item.as_mut();
                 assert!(ptr::eq(rf, item.0.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct Types<T, U>(#[as_mut(str)] T, #[as_mut([u8])] U);
+
+            #[test]
+            fn types() {
+                let mut item = Types("test".to_owned(), vec![0]);
+
+                let rf: &mut str = item.as_mut();
+                assert!(ptr::eq(rf, item.0.as_mut()));
+
+                let rf: &mut [u8] = item.as_mut();
+                assert!(ptr::eq(rf, item.1.as_mut()));
             }
         }
     }
@@ -452,6 +681,28 @@ mod multi_field {
             assert!(ptr::eq(rf, item.first.as_mut()));
         }
 
+        #[derive(AsMut)]
+        struct Types {
+            #[as_mut(str)]
+            first: String,
+            #[as_mut([u8])]
+            second: Vec<u8>,
+        }
+
+        #[test]
+        fn types() {
+            let mut item = Types {
+                first: "test".to_owned(),
+                second: vec![0],
+            };
+
+            let rf: &mut str = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+
+            let rf: &mut [u8] = item.as_mut();
+            assert!(ptr::eq(rf, item.second.as_mut()));
+        }
+
         mod generic {
             use super::*;
 
@@ -529,6 +780,28 @@ mod multi_field {
 
                 let rf: &mut str = item.as_mut();
                 assert!(ptr::eq(rf, item.first.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct Types<T, U> {
+                #[as_mut(str)]
+                first: T,
+                #[as_mut([u8])]
+                second: U,
+            }
+
+            #[test]
+            fn types() {
+                let mut item = Types {
+                    first: "test".to_owned(),
+                    second: vec![0],
+                };
+
+                let rf: &mut str = item.as_mut();
+                assert!(ptr::eq(rf, item.first.as_mut()));
+
+                let rf: &mut [u8] = item.as_mut();
+                assert!(ptr::eq(rf, item.second.as_mut()));
             }
         }
     }

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -100,6 +100,30 @@ mod single_field {
         }
 
         #[derive(AsMut)]
+        #[as_mut(i32, Foo)]
+        struct TypesWithInner(Foo);
+
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
+        impl AsMut<bool> for TypesWithInner {
+            fn as_mut(&mut self) -> &mut bool {
+                self.0.as_mut()
+            }
+        }
+
+        #[test]
+        fn types_with_inner() {
+            let mut item = TypesWithInner(Foo(1, 2.0, false));
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+
+            let rf: &mut Foo = item.as_mut();
+            assert!(ptr::eq(rf, &mut item.0));
+        }
+
+        #[derive(AsMut)]
         struct FieldTypes(#[as_mut(i32, f64)] Foo);
 
         // Asserts that the macro expansion doesn't generate a blanket `AsMut`
@@ -129,6 +153,29 @@ mod single_field {
 
             let rf: &mut f64 = item.as_mut();
             assert!(ptr::eq(rf, item.0.as_mut()));
+        }
+
+        #[derive(AsMut)]
+        struct FieldTypesWithInner(#[as_mut(i32, Foo)] Foo);
+
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
+        impl AsMut<bool> for FieldTypesWithInner {
+            fn as_mut(&mut self) -> &mut bool {
+                self.0.as_mut()
+            }
+        }
+
+        #[test]
+        fn field_types_with_inner() {
+            let mut item = FieldTypesWithInner(Foo(1, 2.0, false));
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.0.as_mut()));
+
+            let rf: &mut Foo = item.as_mut();
+            assert!(ptr::eq(rf, &mut item.0));
         }
 
         mod generic {
@@ -202,6 +249,17 @@ mod single_field {
             }
 
             #[derive(AsMut)]
+            #[as_mut(Vec<T>)]
+            struct TypesInner<T>(Vec<T>);
+
+            #[test]
+            fn types_inner() {
+                let mut item = TypesInner(vec![1i32]);
+
+                assert!(ptr::eq(item.as_mut(), &mut item.0));
+            }
+
+            #[derive(AsMut)]
             struct FieldTypes<T>(#[as_mut(i32, f64)] T);
 
             // Asserts that the macro expansion doesn't generate a blanket `AsMut`
@@ -222,6 +280,16 @@ mod single_field {
 
                 let rf: &mut f64 = item.as_mut();
                 assert!(ptr::eq(rf, item.0.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldTypesInner<T>(#[as_mut(Vec<T>)] Vec<T>);
+
+            #[test]
+            fn field_types_inner() {
+                let mut item = FieldTypesInner(vec![1i32]);
+
+                assert!(ptr::eq(item.as_mut(), &mut item.0));
             }
         }
     }
@@ -328,6 +396,34 @@ mod single_field {
         }
 
         #[derive(AsMut)]
+        #[as_mut(i32, Foo)]
+        struct TypesWithInner {
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
+        impl AsMut<bool> for TypesWithInner {
+            fn as_mut(&mut self) -> &mut bool {
+                self.first.as_mut()
+            }
+        }
+
+        #[test]
+        fn types_with_inner() {
+            let mut item = TypesWithInner {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+
+            let rf: &mut Foo = item.as_mut();
+            assert!(ptr::eq(rf, &mut item.first));
+        }
+
+        #[derive(AsMut)]
         struct FieldTypes {
             #[as_mut(i32, f64)]
             first: Foo,
@@ -362,6 +458,34 @@ mod single_field {
 
             let rf: &mut f64 = item.as_mut();
             assert!(ptr::eq(rf, item.first.as_mut()));
+        }
+
+        #[derive(AsMut)]
+        struct FieldTypesWithInner {
+            #[as_mut(i32, Foo)]
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate a blanket `AsMut`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
+        impl AsMut<bool> for FieldTypesWithInner {
+            fn as_mut(&mut self) -> &mut bool {
+                self.first.as_mut()
+            }
+        }
+
+        #[test]
+        fn field_types_with_inner() {
+            let mut item = FieldTypesWithInner {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &mut i32 = item.as_mut();
+            assert!(ptr::eq(rf, item.first.as_mut()));
+
+            let rf: &mut Foo = item.as_mut();
+            assert!(ptr::eq(rf, &mut item.first));
         }
 
         mod generic {
@@ -457,6 +581,19 @@ mod single_field {
             }
 
             #[derive(AsMut)]
+            #[as_mut(Vec<T>)]
+            struct TypesInner<T> {
+                first: Vec<T>,
+            }
+
+            #[test]
+            fn types_inner() {
+                let mut item = TypesInner { first: vec![1i32] };
+
+                assert!(ptr::eq(item.as_mut(), &mut item.first));
+            }
+
+            #[derive(AsMut)]
             struct FieldTypes<T> {
                 #[as_mut(i32, f64)]
                 first: T,
@@ -482,6 +619,19 @@ mod single_field {
 
                 let rf: &mut f64 = item.as_mut();
                 assert!(ptr::eq(rf, item.first.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct FieldTypesInner<T> {
+                #[as_mut(Vec<T>)]
+                first: Vec<T>,
+            }
+
+            #[test]
+            fn field_types_inner() {
+                let mut item = FieldTypesInner { first: vec![1i32] };
+
+                assert!(ptr::eq(item.as_mut(), &mut item.first));
             }
         }
     }
@@ -637,6 +787,16 @@ mod multi_field {
 
                 let rf: &mut [u8] = item.as_mut();
                 assert!(ptr::eq(rf, item.1.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct TypesInner<T, U>(#[as_mut(Vec<T>)] Vec<T>, U);
+
+            #[test]
+            fn types_inner() {
+                let mut item = TypesInner(vec![1i32], 2i32);
+
+                assert!(ptr::eq(item.as_mut(), &mut item.0));
             }
         }
     }
@@ -868,6 +1028,23 @@ mod multi_field {
 
                 let rf: &mut [u8] = item.as_mut();
                 assert!(ptr::eq(rf, item.second.as_mut()));
+            }
+
+            #[derive(AsMut)]
+            struct TypesInner<T, U> {
+                #[as_mut(Vec<T>)]
+                first: Vec<T>,
+                second: U,
+            }
+
+            #[test]
+            fn types_inner() {
+                let mut item = TypesInner {
+                    first: vec![1i32],
+                    second: 2i32,
+                };
+
+                assert!(ptr::eq(item.as_mut(), &mut item.first));
             }
         }
     }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -103,18 +103,17 @@ mod single_field {
         #[as_ref(i32, f64)]
         struct Types(Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing  a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing  a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for Types {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsRef<Helper> for Types {
             fn as_ref(&self) -> &Helper {
                 &self.0
@@ -136,9 +135,9 @@ mod single_field {
         #[as_ref(i32, Helper)]
         struct TypesWithInner(Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for TypesWithInner {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
@@ -162,10 +161,9 @@ mod single_field {
         #[as_ref(i32, RenamedFoo)]
         struct TypesWithRenamedInner(Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
-
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for TypesWithRenamedInner {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
@@ -186,18 +184,17 @@ mod single_field {
         #[derive(AsRef)]
         struct FieldTypes(#[as_ref(i32, f64)] Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for FieldTypes {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsRef<Helper> for FieldTypes {
             fn as_ref(&self) -> &Helper {
                 &self.0
@@ -218,9 +215,9 @@ mod single_field {
         #[derive(AsRef)]
         struct FieldTypesWithInner(#[as_ref(i32, Helper)] Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for FieldTypesWithInner {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
@@ -241,9 +238,9 @@ mod single_field {
         #[derive(AsRef)]
         struct FieldTypesWithRenamedInner(#[as_ref(i32, RenamedFoo)] Helper);
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for FieldTypesWithRenamedInner {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
@@ -311,9 +308,9 @@ mod single_field {
             #[as_ref(i32, f64)]
             struct Types<T>(T);
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for Types<T> {
                 fn as_ref(&self) -> &bool {
                     self.0.as_ref()
@@ -345,9 +342,9 @@ mod single_field {
             #[derive(AsRef)]
             struct FieldTypes<T>(#[as_ref(i32, f64)] T);
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for FieldTypes<T> {
                 fn as_ref(&self) -> &bool {
                     self.0.as_ref()
@@ -491,18 +488,17 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for Types {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsRef<Helper> for Types {
             fn as_ref(&self) -> &Helper {
                 &self.first
@@ -528,9 +524,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for TypesWithInner {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
@@ -558,9 +554,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for TypesWithRenamedInner {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
@@ -586,18 +582,17 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for FieldTypes {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
-        // the field type, by producing a trait implementations conflict error
-        // during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for the field type, by
+        // producing a trait implementations conflict error during compilation, if it does.
         impl AsRef<Helper> for FieldTypes {
             fn as_ref(&self) -> &Helper {
                 &self.first
@@ -623,9 +618,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for FieldTypesWithInner {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
@@ -651,9 +646,9 @@ mod single_field {
             first: Helper,
         }
 
-        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing a trait implementations
-        // conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding to
+        // the field type, by producing a trait implementations conflict error during compilation,
+        // if it does.
         impl AsRef<bool> for FieldTypesWithRenamedInner {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
@@ -743,9 +738,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for Types<T> {
                 fn as_ref(&self) -> &bool {
                     self.first.as_ref()
@@ -784,9 +779,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-            // impl forwarding to the field type, by producing a trait implementations
-            // conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef` impl forwarding
+            // to the field type, by producing a trait implementations conflict error during
+            // compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for FieldTypes<T> {
                 fn as_ref(&self) -> &bool {
                     self.first.as_ref()

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -98,6 +98,37 @@ mod single_field {
         }
 
         #[derive(AsRef)]
+        #[as_ref(i32, Foo)]
+        struct TypesWithInner(Foo);
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for TypesWithInner {
+            fn as_ref(&self) -> &bool {
+                self.0.as_ref()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<f64> for TypesWithInner {
+            fn as_ref(&self) -> &f64 {
+                self.0.as_ref()
+            }
+        }
+
+        #[test]
+        fn types_with_inner() {
+            let item = TypesWithInner(Foo(1, 2.0, false));
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+
+            let rf: &Foo = item.as_ref();
+            assert!(ptr::eq(rf, &item.0));
+        }
+
+        #[derive(AsRef)]
         struct FieldTypes(#[as_ref(i32, f64)] Foo);
 
         // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
@@ -125,6 +156,38 @@ mod single_field {
 
             let rf: &f64 = item.as_ref();
             assert!(ptr::eq(rf, item.0.as_ref()));
+        }
+
+        type RenamedFoo = Foo;
+
+        #[derive(AsRef)]
+        struct FieldTypesWithRenamedInner(#[as_ref(i32, RenamedFoo)] Foo);
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for FieldTypesWithRenamedInner {
+            fn as_ref(&self) -> &bool {
+                self.0.as_ref()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<f64> for FieldTypesWithRenamedInner {
+            fn as_ref(&self) -> &f64 {
+                self.0.as_ref()
+            }
+        }
+
+        #[test]
+        fn field_types_with_renamed_inner() {
+            let item = FieldTypesWithRenamedInner(Foo(1, 2.0, false));
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+
+            let rf: &Foo = item.as_ref();
+            assert!(ptr::eq(rf, &item.0));
         }
 
         mod generic {
@@ -320,6 +383,41 @@ mod single_field {
         }
 
         #[derive(AsRef)]
+        #[as_ref(i32, Foo)]
+        struct TypesWithInner {
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for TypesWithInner {
+            fn as_ref(&self) -> &bool {
+                self.first.as_ref()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<f64> for TypesWithInner {
+            fn as_ref(&self) -> &f64 {
+                self.first.as_ref()
+            }
+        }
+
+        #[test]
+        fn types_with_inner() {
+            let item = TypesWithInner {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+
+            let rf: &Foo = item.as_ref();
+            assert!(ptr::eq(rf, &item.first));
+        }
+
+        #[derive(AsRef)]
         struct FieldTypes {
             #[as_ref(i32, f64)]
             first: Foo,
@@ -352,6 +450,43 @@ mod single_field {
 
             let rf: &f64 = item.as_ref();
             assert!(ptr::eq(rf, item.first.as_ref()));
+        }
+
+        type RenamedFoo = Foo;
+
+        #[derive(AsRef)]
+        struct FieldTypesWithRenamedInner {
+            #[as_ref(i32, RenamedFoo)]
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for FieldTypesWithRenamedInner {
+            fn as_ref(&self) -> &bool {
+                self.first.as_ref()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<f64> for FieldTypesWithRenamedInner {
+            fn as_ref(&self) -> &f64 {
+                self.first.as_ref()
+            }
+        }
+
+        #[test]
+        fn field_types_with_renamed_inner() {
+            let item = FieldTypesWithRenamedInner {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+
+            let rf: &Foo = item.as_ref();
+            assert!(ptr::eq(rf, &item.first));
         }
 
         mod generic {
@@ -542,15 +677,7 @@ mod multi_field {
         }
 
         #[derive(AsRef)]
-        struct Types(#[as_ref(str)] String, #[as_ref([u8])] Vec<u8>);
-
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsRef<String> for Types {
-            fn as_ref(&self) -> &String {
-                &self.0
-            }
-        }
+        struct Types(#[as_ref(str, String)] String, #[as_ref([u8])] Vec<u8>);
 
         // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
         // producing trait implementations conflict error during compilation, if it does.
@@ -731,18 +858,10 @@ mod multi_field {
 
         #[derive(AsRef)]
         struct Types {
-            #[as_ref(str)]
+            #[as_ref(str, String)]
             first: String,
             #[as_ref([u8])]
             second: Vec<u8>,
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsRef<String> for Types {
-            fn as_ref(&self) -> &String {
-                &self.first
-            }
         }
 
         // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -42,6 +42,12 @@ impl AsRef<i32> for Bar<&'static i32> {
     }
 }
 
+impl AsRef<[i32]> for Bar<[i32; 0]> {
+    fn as_ref(&self) -> &[i32] {
+        &self.0
+    }
+}
+
 mod single_field {
     use super::*;
 
@@ -384,6 +390,27 @@ mod single_field {
             #[test]
             fn field_lifetime() {
                 let item = FieldLifetime(Bar(&1));
+
+                assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            #[as_ref([i32])]
+            struct ConstParam<const N: usize>(Bar<[i32; N]>);
+
+            #[test]
+            fn const_param() {
+                let item = ConstParam(Bar([]));
+
+                assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldConstParam<const N: usize>(#[as_ref([i32])] Bar<[i32; N]>);
+
+            #[test]
+            fn field_const_param() {
+                let item = FieldConstParam(Bar([]));
 
                 assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
             }
@@ -810,6 +837,32 @@ mod single_field {
             #[test]
             fn field_lifetime() {
                 let item = FieldLifetime { first: Bar(&1) };
+
+                assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            #[as_ref([i32])]
+            struct ConstParam<const N: usize> {
+                first: Bar<[i32; N]>,
+            }
+
+            #[test]
+            fn const_param() {
+                let item = ConstParam { first: Bar([]) };
+
+                assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldConstParam<const N: usize> {
+                #[as_ref([i32])]
+                first: Bar<[i32; N]>,
+            }
+
+            #[test]
+            fn field_const_param() {
+                let item = FieldConstParam { first: Bar([]) };
 
                 assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
             }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -14,6 +14,9 @@ use core::ptr;
 
 use derive_more::AsRef;
 
+#[derive(AsRef)]
+struct Foo(i32, f64, bool);
+
 mod single_field {
     use super::*;
 
@@ -63,6 +66,51 @@ mod single_field {
             assert!(ptr::eq(rf, item.0.as_ref()));
         }
 
+        #[derive(AsRef)]
+        #[as_ref(i32, f64)]
+        struct Types(Foo);
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for Types {
+            fn as_ref(&self) -> &bool {
+                self.0.as_ref()
+            }
+        }
+
+        #[test]
+        fn types() {
+            let item = Types(Foo(1, 2.0, false));
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+
+            let rf: &f64 = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+        }
+
+        #[derive(AsRef)]
+        struct FieldTypes(#[as_ref(i32, f64)] Foo);
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for FieldTypes {
+            fn as_ref(&self) -> &bool {
+                self.0.as_ref()
+            }
+        }
+
+        #[test]
+        fn field_types() {
+            let item = FieldTypes(Foo(1, 2.0, false));
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+
+            let rf: &f64 = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+        }
+
         mod generic {
             use super::*;
 
@@ -106,6 +154,51 @@ mod single_field {
                 let item = FieldForward("test".to_owned());
 
                 let rf: &str = item.as_ref();
+                assert!(ptr::eq(rf, item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            #[as_ref(i32, f64)]
+            struct Types<T>(T);
+
+            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsRef<bool>> AsRef<bool> for Types<T> {
+                fn as_ref(&self) -> &bool {
+                    self.0.as_ref()
+                }
+            }
+
+            #[test]
+            fn types() {
+                let item = Types(Foo(1, 2.0, false));
+
+                let rf: &i32 = item.as_ref();
+                assert!(ptr::eq(rf, item.0.as_ref()));
+
+                let rf: &f64 = item.as_ref();
+                assert!(ptr::eq(rf, item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldTypes<T>(#[as_ref(i32, f64)] T);
+
+            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsRef<bool>> AsRef<bool> for FieldTypes<T> {
+                fn as_ref(&self) -> &bool {
+                    self.0.as_ref()
+                }
+            }
+
+            #[test]
+            fn field_types() {
+                let item = FieldTypes(Foo(1, 2.0, false));
+
+                let rf: &i32 = item.as_ref();
+                assert!(ptr::eq(rf, item.0.as_ref()));
+
+                let rf: &f64 = item.as_ref();
                 assert!(ptr::eq(rf, item.0.as_ref()));
             }
         }
@@ -175,6 +268,60 @@ mod single_field {
             assert!(ptr::eq(rf, item.first.as_ref()));
         }
 
+        #[derive(AsRef)]
+        #[as_ref(i32, f64)]
+        struct Types {
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for Types {
+            fn as_ref(&self) -> &bool {
+                self.first.as_ref()
+            }
+        }
+
+        #[test]
+        fn types() {
+            let item = Types {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+
+            let rf: &f64 = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+        }
+
+        #[derive(AsRef)]
+        struct FieldTypes {
+            #[as_ref(i32, f64)]
+            first: Foo,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<bool> for FieldTypes {
+            fn as_ref(&self) -> &bool {
+                self.first.as_ref()
+            }
+        }
+
+        #[test]
+        fn field_types() {
+            let item = FieldTypes {
+                first: Foo(1, 2.0, false),
+            };
+
+            let rf: &i32 = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+
+            let rf: &f64 = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+        }
+
         mod generic {
             use super::*;
 
@@ -236,6 +383,60 @@ mod single_field {
                 };
 
                 let rf: &str = item.as_ref();
+                assert!(ptr::eq(rf, item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            #[as_ref(i32, f64)]
+            struct Types<T> {
+                first: T,
+            }
+
+            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsRef<bool>> AsRef<bool> for Types<T> {
+                fn as_ref(&self) -> &bool {
+                    self.first.as_ref()
+                }
+            }
+
+            #[test]
+            fn types() {
+                let item = Types {
+                    first: Foo(1, 2.0, false),
+                };
+
+                let rf: &i32 = item.as_ref();
+                assert!(ptr::eq(rf, item.first.as_ref()));
+
+                let rf: &f64 = item.as_ref();
+                assert!(ptr::eq(rf, item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldTypes<T> {
+                #[as_ref(i32, f64)]
+                first: T,
+            }
+
+            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+            // producing trait implementations conflict error during compilation, if it does.
+            impl<T: AsRef<bool>> AsRef<bool> for FieldTypes<T> {
+                fn as_ref(&self) -> &bool {
+                    self.first.as_ref()
+                }
+            }
+
+            #[test]
+            fn field_types() {
+                let item = FieldTypes {
+                    first: Foo(1, 2.0, false),
+                };
+
+                let rf: &i32 = item.as_ref();
+                assert!(ptr::eq(rf, item.first.as_ref()));
+
+                let rf: &f64 = item.as_ref();
                 assert!(ptr::eq(rf, item.first.as_ref()));
             }
         }
@@ -308,6 +509,20 @@ mod multi_field {
             assert!(ptr::eq(rf, item.0.as_ref()));
         }
 
+        #[derive(AsRef)]
+        struct Types(#[as_ref(str)] String, #[as_ref([u8])] Vec<u8>);
+
+        #[test]
+        fn types() {
+            let item = Types("test".to_owned(), vec![0]);
+
+            let rf: &str = item.as_ref();
+            assert!(ptr::eq(rf, item.0.as_ref()));
+
+            let rf: &[u8] = item.as_ref();
+            assert!(ptr::eq(rf, item.1.as_ref()));
+        }
+
         mod generic {
             use super::*;
 
@@ -353,6 +568,20 @@ mod multi_field {
 
                 let rf: &str = item.as_ref();
                 assert!(ptr::eq(rf, item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct Types<T, U>(#[as_ref(str)] T, #[as_ref([u8])] U);
+
+            #[test]
+            fn types() {
+                let item = Types("test".to_owned(), vec![0u8]);
+
+                let rf: &str = item.as_ref();
+                assert!(ptr::eq(rf, item.0.as_ref()));
+
+                let rf: &[u8] = item.as_ref();
+                assert!(ptr::eq(rf, item.1.as_ref()));
             }
         }
     }
@@ -452,6 +681,28 @@ mod multi_field {
             assert!(ptr::eq(rf, item.first.as_ref()));
         }
 
+        #[derive(AsRef)]
+        struct Types {
+            #[as_ref(str)]
+            first: String,
+            #[as_ref([u8])]
+            second: Vec<u8>,
+        }
+
+        #[test]
+        fn types() {
+            let item = Types {
+                first: "test".to_owned(),
+                second: vec![0u8],
+            };
+
+            let rf: &str = item.as_ref();
+            assert!(ptr::eq(rf, item.first.as_ref()));
+
+            let rf: &[u8] = item.as_ref();
+            assert!(ptr::eq(rf, item.second.as_ref()));
+        }
+
         mod generic {
             use super::*;
 
@@ -529,6 +780,28 @@ mod multi_field {
 
                 let rf: &str = item.as_ref();
                 assert!(ptr::eq(rf, item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct Types<T, U> {
+                #[as_ref(str)]
+                first: T,
+                #[as_ref([u8])]
+                second: U,
+            }
+
+            #[test]
+            fn types() {
+                let item = Types {
+                    first: "test".to_owned(),
+                    second: vec![0u8],
+                };
+
+                let rf: &str = item.as_ref();
+                assert!(ptr::eq(rf, item.first.as_ref()));
+
+                let rf: &[u8] = item.as_ref();
+                assert!(ptr::eq(rf, item.second.as_ref()));
             }
         }
     }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -78,6 +78,14 @@ mod single_field {
             }
         }
 
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<Foo> for Types {
+            fn as_ref(&self) -> &Foo {
+                &self.0
+            }
+        }
+
         #[test]
         fn types() {
             let item = Types(Foo(1, 2.0, false));
@@ -97,6 +105,14 @@ mod single_field {
         impl AsRef<bool> for FieldTypes {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<Foo> for FieldTypes {
+            fn as_ref(&self) -> &Foo {
+                &self.0
             }
         }
 
@@ -282,6 +298,14 @@ mod single_field {
             }
         }
 
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<Foo> for Types {
+            fn as_ref(&self) -> &Foo {
+                &self.first
+            }
+        }
+
         #[test]
         fn types() {
             let item = Types {
@@ -306,6 +330,14 @@ mod single_field {
         impl AsRef<bool> for FieldTypes {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<Foo> for FieldTypes {
+            fn as_ref(&self) -> &Foo {
+                &self.first
             }
         }
 
@@ -512,6 +544,22 @@ mod multi_field {
         #[derive(AsRef)]
         struct Types(#[as_ref(str)] String, #[as_ref([u8])] Vec<u8>);
 
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<String> for Types {
+            fn as_ref(&self) -> &String {
+                &self.0
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<Vec<u8>> for Types {
+            fn as_ref(&self) -> &Vec<u8> {
+                &self.1
+            }
+        }
+
         #[test]
         fn types() {
             let item = Types("test".to_owned(), vec![0]);
@@ -687,6 +735,22 @@ mod multi_field {
             first: String,
             #[as_ref([u8])]
             second: Vec<u8>,
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<String> for Types {
+            fn as_ref(&self) -> &String {
+                &self.first
+            }
+        }
+
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
+        // producing trait implementations conflict error during compilation, if it does.
+        impl AsRef<Vec<u8>> for Types {
+            fn as_ref(&self) -> &Vec<u8> {
+                &self.second
+            }
         }
 
         #[test]

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -921,6 +921,16 @@ mod multi_field {
                 let rf: &str = item.as_ref();
                 assert!(ptr::eq(rf, item.1.as_ref()));
             }
+
+            #[derive(AsRef)]
+            struct FieldNonGeneric<T>(#[as_ref([T])] Vec<i32>, T);
+
+            #[test]
+            fn field_non_generic() {
+                let item = FieldNonGeneric(vec![], 2i32);
+
+                assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
+            }
         }
     }
 
@@ -1178,6 +1188,23 @@ mod multi_field {
 
                 let rf: &str = item.as_ref();
                 assert!(ptr::eq(rf, item.second.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldNonGeneric<T> {
+                #[as_ref([T])]
+                first: Vec<i32>,
+                second: T,
+            }
+
+            #[test]
+            fn field_non_generic() {
+                let item = FieldNonGeneric {
+                    first: vec![],
+                    second: 2i32,
+                };
+
+                assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
             }
         }
     }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -34,6 +34,14 @@ impl AsRef<bool> for Foo {
     }
 }
 
+struct Bar<T>(T);
+
+impl AsRef<i32> for Bar<&'static i32> {
+    fn as_ref(&self) -> &i32 {
+        self.0
+    }
+}
+
 mod single_field {
     use super::*;
 
@@ -357,6 +365,27 @@ mod single_field {
                 let item = FieldTypesInner(vec![1i32]);
 
                 assert!(ptr::eq(item.as_ref(), &item.0));
+            }
+
+            #[derive(AsRef)]
+            #[as_ref(i32)]
+            struct Lifetime<'a>(Bar<&'a i32>);
+
+            #[test]
+            fn lifetime() {
+                let item = Lifetime(Bar(&1));
+
+                assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldLifetime<'a>(#[as_ref(i32)] Bar<&'a i32>);
+
+            #[test]
+            fn field_lifetime() {
+                let item = FieldLifetime(Bar(&1));
+
+                assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
             }
         }
     }
@@ -757,6 +786,32 @@ mod single_field {
                 let item = FieldTypesInner { first: vec![1i32] };
 
                 assert!(ptr::eq(item.as_ref(), &item.first));
+            }
+
+            #[derive(AsRef)]
+            #[as_ref(i32)]
+            struct Lifetime<'a> {
+                first: Bar<&'a i32>,
+            }
+
+            #[test]
+            fn lifetime() {
+                let item = Lifetime { first: Bar(&1) };
+
+                assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldLifetime<'a> {
+                #[as_ref(i32)]
+                first: Bar<&'a i32>,
+            }
+
+            #[test]
+            fn field_lifetime() {
+                let item = FieldLifetime { first: Bar(&1) };
+
+                assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
             }
         }
     }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -70,16 +70,18 @@ mod single_field {
         #[as_ref(i32, f64)]
         struct Types(Foo);
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing  atrait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for Types {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsRef<Foo> for Types {
             fn as_ref(&self) -> &Foo {
                 &self.0
@@ -101,18 +103,11 @@ mod single_field {
         #[as_ref(i32, Foo)]
         struct TypesWithInner(Foo);
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for TypesWithInner {
             fn as_ref(&self) -> &bool {
-                self.0.as_ref()
-            }
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsRef<f64> for TypesWithInner {
-            fn as_ref(&self) -> &f64 {
                 self.0.as_ref()
             }
         }
@@ -131,16 +126,18 @@ mod single_field {
         #[derive(AsRef)]
         struct FieldTypes(#[as_ref(i32, f64)] Foo);
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for FieldTypes {
             fn as_ref(&self) -> &bool {
                 self.0.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsRef<Foo> for FieldTypes {
             fn as_ref(&self) -> &Foo {
                 &self.0
@@ -163,18 +160,11 @@ mod single_field {
         #[derive(AsRef)]
         struct FieldTypesWithRenamedInner(#[as_ref(i32, RenamedFoo)] Foo);
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for FieldTypesWithRenamedInner {
             fn as_ref(&self) -> &bool {
-                self.0.as_ref()
-            }
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsRef<f64> for FieldTypesWithRenamedInner {
-            fn as_ref(&self) -> &f64 {
                 self.0.as_ref()
             }
         }
@@ -240,8 +230,9 @@ mod single_field {
             #[as_ref(i32, f64)]
             struct Types<T>(T);
 
-            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for Types<T> {
                 fn as_ref(&self) -> &bool {
                     self.0.as_ref()
@@ -262,8 +253,9 @@ mod single_field {
             #[derive(AsRef)]
             struct FieldTypes<T>(#[as_ref(i32, f64)] T);
 
-            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for FieldTypes<T> {
                 fn as_ref(&self) -> &bool {
                     self.0.as_ref()
@@ -353,16 +345,18 @@ mod single_field {
             first: Foo,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for Types {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsRef<Foo> for Types {
             fn as_ref(&self) -> &Foo {
                 &self.first
@@ -388,18 +382,11 @@ mod single_field {
             first: Foo,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for TypesWithInner {
             fn as_ref(&self) -> &bool {
-                self.first.as_ref()
-            }
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsRef<f64> for TypesWithInner {
-            fn as_ref(&self) -> &f64 {
                 self.first.as_ref()
             }
         }
@@ -423,16 +410,18 @@ mod single_field {
             first: Foo,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for FieldTypes {
             fn as_ref(&self) -> &bool {
                 self.first.as_ref()
             }
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate an `AsRef` impl for
+        // the field type, by producing a trait implementations conflict error
+        // during compilation, if it does.
         impl AsRef<Foo> for FieldTypes {
             fn as_ref(&self) -> &Foo {
                 &self.first
@@ -460,18 +449,11 @@ mod single_field {
             first: Foo,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
+        // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+        // impl forwarding to the field type, by producing a trait implementations
+        // conflict error during compilation, if it does.
         impl AsRef<bool> for FieldTypesWithRenamedInner {
             fn as_ref(&self) -> &bool {
-                self.first.as_ref()
-            }
-        }
-
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-        // producing trait implementations conflict error during compilation, if it does.
-        impl AsRef<f64> for FieldTypesWithRenamedInner {
-            fn as_ref(&self) -> &f64 {
                 self.first.as_ref()
             }
         }
@@ -559,8 +541,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for Types<T> {
                 fn as_ref(&self) -> &bool {
                     self.first.as_ref()
@@ -586,8 +569,9 @@ mod single_field {
                 first: T,
             }
 
-            // Asserts that the macro expansion doesn't generate `AsRef` impl for unmentioned type, by
-            // producing trait implementations conflict error during compilation, if it does.
+            // Asserts that the macro expansion doesn't generate a blanket `AsRef`
+            // impl forwarding to the field type, by producing a trait implementations
+            // conflict error during compilation, if it does.
             impl<T: AsRef<bool>> AsRef<bool> for FieldTypes<T> {
                 fn as_ref(&self) -> &bool {
                     self.first.as_ref()
@@ -679,7 +663,7 @@ mod multi_field {
         #[derive(AsRef)]
         struct Types(#[as_ref(str, String)] String, #[as_ref([u8])] Vec<u8>);
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for the field type, by
         // producing trait implementations conflict error during compilation, if it does.
         impl AsRef<Vec<u8>> for Types {
             fn as_ref(&self) -> &Vec<u8> {
@@ -864,7 +848,7 @@ mod multi_field {
             second: Vec<u8>,
         }
 
-        // Asserts that the macro expansion doesn't generate `AsRef` impl for the third field, by
+        // Asserts that the macro expansion doesn't generate `AsRef` impl for the field type, by
         // producing trait implementations conflict error during compilation, if it does.
         impl AsRef<Vec<u8>> for Types {
             fn as_ref(&self) -> &Vec<u8> {

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -14,8 +14,25 @@ use core::ptr;
 
 use derive_more::AsRef;
 
-#[derive(AsRef)]
 struct Foo(i32, f64, bool);
+
+impl AsRef<i32> for Foo {
+    fn as_ref(&self) -> &i32 {
+        &self.0
+    }
+}
+
+impl AsRef<f64> for Foo {
+    fn as_ref(&self) -> &f64 {
+        &self.1
+    }
+}
+
+impl AsRef<bool> for Foo {
+    fn as_ref(&self) -> &bool {
+        &self.2
+    }
+}
 
 mod single_field {
     use super::*;

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -71,7 +71,7 @@ mod single_field {
         struct Types(Foo);
 
         // Asserts that the macro expansion doesn't generate a blanket `AsRef`
-        // impl forwarding to the field type, by producing  atrait implementations
+        // impl forwarding to the field type, by producing  a trait implementations
         // conflict error during compilation, if it does.
         impl AsRef<bool> for Types {
             fn as_ref(&self) -> &bool {
@@ -251,6 +251,17 @@ mod single_field {
             }
 
             #[derive(AsRef)]
+            #[as_ref(Vec<T>)]
+            struct TypesInner<T>(Vec<T>);
+
+            #[test]
+            fn types_inner() {
+                let item = TypesInner(vec![1i32]);
+
+                assert!(ptr::eq(item.as_ref(), &item.0));
+            }
+
+            #[derive(AsRef)]
             struct FieldTypes<T>(#[as_ref(i32, f64)] T);
 
             // Asserts that the macro expansion doesn't generate a blanket `AsRef`
@@ -271,6 +282,16 @@ mod single_field {
 
                 let rf: &f64 = item.as_ref();
                 assert!(ptr::eq(rf, item.0.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldTypesInner<T>(#[as_ref(Vec<T>)] Vec<T>);
+
+            #[test]
+            fn field_types_inner() {
+                let item = FieldTypesInner(vec![1i32]);
+
+                assert!(ptr::eq(item.as_ref(), &item.0));
             }
         }
     }
@@ -564,6 +585,19 @@ mod single_field {
             }
 
             #[derive(AsRef)]
+            #[as_ref(Vec<T>)]
+            struct TypesInner<T> {
+                first: Vec<T>,
+            }
+
+            #[test]
+            fn types_inner() {
+                let item = TypesInner { first: vec![1i32] };
+
+                assert!(ptr::eq(item.as_ref(), &item.first));
+            }
+
+            #[derive(AsRef)]
             struct FieldTypes<T> {
                 #[as_ref(i32, f64)]
                 first: T,
@@ -589,6 +623,19 @@ mod single_field {
 
                 let rf: &f64 = item.as_ref();
                 assert!(ptr::eq(rf, item.first.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct FieldTypesInner<T> {
+                #[as_ref(Vec<T>)]
+                first: Vec<T>,
+            }
+
+            #[test]
+            fn field_types_inner() {
+                let item = FieldTypesInner { first: vec![1i32] };
+
+                assert!(ptr::eq(item.as_ref(), &item.first));
             }
         }
     }
@@ -678,6 +725,9 @@ mod multi_field {
             let rf: &str = item.as_ref();
             assert!(ptr::eq(rf, item.0.as_ref()));
 
+            let rf: &String = item.as_ref();
+            assert!(ptr::eq(rf, &item.0));
+
             let rf: &[u8] = item.as_ref();
             assert!(ptr::eq(rf, item.1.as_ref()));
         }
@@ -741,6 +791,16 @@ mod multi_field {
 
                 let rf: &[u8] = item.as_ref();
                 assert!(ptr::eq(rf, item.1.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct TypesInner<T, U>(#[as_ref(Vec<T>)] Vec<T>, U);
+
+            #[test]
+            fn types_inner() {
+                let item = TypesInner(vec![1i32], 2i32);
+
+                assert!(ptr::eq(item.as_ref(), &item.0));
             }
         }
     }
@@ -866,6 +926,9 @@ mod multi_field {
             let rf: &str = item.as_ref();
             assert!(ptr::eq(rf, item.first.as_ref()));
 
+            let rf: &String = item.as_ref();
+            assert!(ptr::eq(rf, &item.first));
+
             let rf: &[u8] = item.as_ref();
             assert!(ptr::eq(rf, item.second.as_ref()));
         }
@@ -969,6 +1032,23 @@ mod multi_field {
 
                 let rf: &[u8] = item.as_ref();
                 assert!(ptr::eq(rf, item.second.as_ref()));
+            }
+
+            #[derive(AsRef)]
+            struct TypesInner<T, U> {
+                #[as_ref(Vec<T>)]
+                first: Vec<T>,
+                second: U,
+            }
+
+            #[test]
+            fn types_inner() {
+                let item = TypesInner {
+                    first: vec![1i32],
+                    second: 2i32,
+                };
+
+                assert!(ptr::eq(item.as_ref(), &item.first));
             }
         }
     }

--- a/tests/compile_fail/as_mut/multiple_struct_attrs.stderr
+++ b/tests/compile_fail/as_mut/multiple_struct_attrs.stderr
@@ -1,4 +1,4 @@
-error: only single `#[as_mut(forward)]` attribute is allowed here
+error: only single `#[as_mut(...)]` attribute is allowed here
  --> tests/compile_fail/as_mut/multiple_struct_attrs.rs:3:1
   |
 3 | #[as_mut(forward)]

--- a/tests/compile_fail/as_mut/renamed_generic.rs
+++ b/tests/compile_fail/as_mut/renamed_generic.rs
@@ -1,0 +1,12 @@
+struct Foo<T>(T);
+
+type Bar<T> = Foo<T>;
+
+#[derive(derive_more::AsMut)]
+#[as_mut(Bar<T>)]
+struct Baz<T>(Foo<T>);
+
+fn main() {
+    let mut item = Baz(Foo(1i32));
+    let _: &mut Bar<i32> = item.as_mut();
+}

--- a/tests/compile_fail/as_mut/renamed_generic.stderr
+++ b/tests/compile_fail/as_mut/renamed_generic.stderr
@@ -16,9 +16,6 @@ error[E0599]: the method `as_mut` exists for struct `Baz<i32>`, but its trait bo
    = note: trait bound `Foo<i32>: AsMut<Foo<i32>>` was not satisfied
 note: the trait `AsMut` must be implemented
   --> $RUST/core/src/convert/mod.rs
-   |
-   | pub trait AsMut<T: ?Sized> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `as_mut`, perhaps you need to implement it:
            candidate #1: `AsMut`

--- a/tests/compile_fail/as_mut/renamed_generic.stderr
+++ b/tests/compile_fail/as_mut/renamed_generic.stderr
@@ -1,0 +1,24 @@
+error[E0599]: the method `as_mut` exists for struct `Baz<i32>`, but its trait bounds were not satisfied
+  --> tests/compile_fail/as_mut/renamed_generic.rs:11:33
+   |
+1  | struct Foo<T>(T);
+   | ------------- doesn't satisfy `Foo<i32>: AsMut<Foo<i32>>`
+...
+7  | struct Baz<T>(Foo<T>);
+   | -------------
+   | |
+   | method `as_mut` not found for this struct
+   | doesn't satisfy `Baz<i32>: AsMut<Foo<i32>>`
+...
+11 |     let _: &mut Bar<i32> = item.as_mut();
+   |                                 ^^^^^^ method cannot be called on `Baz<i32>` due to unsatisfied trait bounds
+   |
+   = note: trait bound `Foo<i32>: AsMut<Foo<i32>>` was not satisfied
+note: the trait `AsMut` must be implemented
+  --> $RUST/core/src/convert/mod.rs
+   |
+   | pub trait AsMut<T: ?Sized> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `as_mut`, perhaps you need to implement it:
+           candidate #1: `AsMut`

--- a/tests/compile_fail/as_mut/struct_attr_tuple.rs
+++ b/tests/compile_fail/as_mut/struct_attr_tuple.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::AsMut)]
+#[as_mut((i32, f32))]
+struct Foo {
+    bar: i32,
+    baz: f32,
+}
+
+fn main() {}

--- a/tests/compile_fail/as_mut/struct_attr_tuple.stderr
+++ b/tests/compile_fail/as_mut/struct_attr_tuple.stderr
@@ -1,0 +1,9 @@
+error: `#[as_mut(...)]` attribute can only be placed on structs with exactly one field
+ --> tests/compile_fail/as_mut/struct_attr_tuple.rs:3:12
+  |
+3 |   struct Foo {
+  |  ____________^
+4 | |     bar: i32,
+5 | |     baz: f32,
+6 | | }
+  | |_^

--- a/tests/compile_fail/as_mut/unknown_field_attr_arg.stderr
+++ b/tests/compile_fail/as_mut/unknown_field_attr_arg.stderr
@@ -1,5 +1,16 @@
-error: only `forward` or `skip`/`ignore` allowed here
+error[E0412]: cannot find type `baz` in this scope
  --> tests/compile_fail/as_mut/unknown_field_attr_arg.rs:3:14
   |
 3 |     #[as_mut(baz)]
-  |              ^^^
+  |              ^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+1 | #[derive(derive_more::AsMut<baz>)]
+  |                            +++++
+
+error[E0412]: cannot find type `baz` in this scope
+ --> tests/compile_fail/as_mut/unknown_field_attr_arg.rs:3:14
+  |
+3 |     #[as_mut(baz)]
+  |              ^^^ not found in this scope

--- a/tests/compile_fail/as_mut/unknown_struct_attr_arg.stderr
+++ b/tests/compile_fail/as_mut/unknown_struct_attr_arg.stderr
@@ -1,5 +1,16 @@
-error: only `forward` allowed here
+error[E0412]: cannot find type `baz` in this scope
  --> tests/compile_fail/as_mut/unknown_struct_attr_arg.rs:2:10
   |
 2 | #[as_mut(baz)]
-  |          ^^^
+  |          ^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+1 | #[derive(derive_more::AsMut<baz>)]
+  |                            +++++
+
+error[E0412]: cannot find type `baz` in this scope
+ --> tests/compile_fail/as_mut/unknown_struct_attr_arg.rs:2:10
+  |
+2 | #[as_mut(baz)]
+  |          ^^^ not found in this scope

--- a/tests/compile_fail/as_ref/multiple_struct_attrs.stderr
+++ b/tests/compile_fail/as_ref/multiple_struct_attrs.stderr
@@ -1,4 +1,4 @@
-error: only single `#[as_ref(forward)]` attribute is allowed here
+error: only single `#[as_ref(...)]` attribute is allowed here
  --> tests/compile_fail/as_ref/multiple_struct_attrs.rs:3:1
   |
 3 | #[as_ref(forward)]

--- a/tests/compile_fail/as_ref/renamed_generic.rs
+++ b/tests/compile_fail/as_ref/renamed_generic.rs
@@ -1,0 +1,12 @@
+struct Foo<T>(T);
+
+type Bar<T> = Foo<T>;
+
+#[derive(derive_more::AsRef)]
+#[as_ref(Bar<T>)]
+struct Baz<T>(Foo<T>);
+
+fn main() {
+    let item = Baz(Foo(1i32));
+    let _: &Bar<i32> = item.as_ref();
+}

--- a/tests/compile_fail/as_ref/renamed_generic.stderr
+++ b/tests/compile_fail/as_ref/renamed_generic.stderr
@@ -1,0 +1,24 @@
+error[E0599]: the method `as_ref` exists for struct `Baz<i32>`, but its trait bounds were not satisfied
+  --> tests/compile_fail/as_ref/renamed_generic.rs:11:29
+   |
+1  | struct Foo<T>(T);
+   | ------------- doesn't satisfy `Foo<i32>: AsRef<Foo<i32>>`
+...
+7  | struct Baz<T>(Foo<T>);
+   | -------------
+   | |
+   | method `as_ref` not found for this struct
+   | doesn't satisfy `Baz<i32>: AsRef<Foo<i32>>`
+...
+11 |     let _: &Bar<i32> = item.as_ref();
+   |                             ^^^^^^ method cannot be called on `Baz<i32>` due to unsatisfied trait bounds
+   |
+   = note: trait bound `Foo<i32>: AsRef<Foo<i32>>` was not satisfied
+note: the trait `AsRef` must be implemented
+  --> $RUST/core/src/convert/mod.rs
+   |
+   | pub trait AsRef<T: ?Sized> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `as_ref`, perhaps you need to implement it:
+           candidate #1: `AsRef`

--- a/tests/compile_fail/as_ref/renamed_generic.stderr
+++ b/tests/compile_fail/as_ref/renamed_generic.stderr
@@ -16,9 +16,6 @@ error[E0599]: the method `as_ref` exists for struct `Baz<i32>`, but its trait bo
    = note: trait bound `Foo<i32>: AsRef<Foo<i32>>` was not satisfied
 note: the trait `AsRef` must be implemented
   --> $RUST/core/src/convert/mod.rs
-   |
-   | pub trait AsRef<T: ?Sized> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `as_ref`, perhaps you need to implement it:
            candidate #1: `AsRef`

--- a/tests/compile_fail/as_ref/struct_attr_tuple.rs
+++ b/tests/compile_fail/as_ref/struct_attr_tuple.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::AsRef)]
+#[as_ref((i32, f32))]
+struct Foo {
+    bar: i32,
+    baz: f32,
+}
+
+fn main() {}

--- a/tests/compile_fail/as_ref/struct_attr_tuple.stderr
+++ b/tests/compile_fail/as_ref/struct_attr_tuple.stderr
@@ -1,0 +1,9 @@
+error: `#[as_ref(...)]` attribute can only be placed on structs with exactly one field
+ --> tests/compile_fail/as_ref/struct_attr_tuple.rs:3:12
+  |
+3 |   struct Foo {
+  |  ____________^
+4 | |     bar: i32,
+5 | |     baz: f32,
+6 | | }
+  | |_^

--- a/tests/compile_fail/as_ref/unknown_field_attr_arg.stderr
+++ b/tests/compile_fail/as_ref/unknown_field_attr_arg.stderr
@@ -1,5 +1,16 @@
-error: only `forward` or `skip`/`ignore` allowed here
+error[E0412]: cannot find type `baz` in this scope
  --> tests/compile_fail/as_ref/unknown_field_attr_arg.rs:3:14
   |
 3 |     #[as_ref(baz)]
-  |              ^^^
+  |              ^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+1 | #[derive(derive_more::AsRef<baz>)]
+  |                            +++++
+
+error[E0412]: cannot find type `baz` in this scope
+ --> tests/compile_fail/as_ref/unknown_field_attr_arg.rs:3:14
+  |
+3 |     #[as_ref(baz)]
+  |              ^^^ not found in this scope

--- a/tests/compile_fail/as_ref/unknown_struct_attr_arg.stderr
+++ b/tests/compile_fail/as_ref/unknown_struct_attr_arg.stderr
@@ -1,5 +1,16 @@
-error: only `forward` allowed here
+error[E0412]: cannot find type `baz` in this scope
  --> tests/compile_fail/as_ref/unknown_struct_attr_arg.rs:2:10
   |
 2 | #[as_ref(baz)]
-  |          ^^^
+  |          ^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+1 | #[derive(derive_more::AsRef<baz>)]
+  |                            +++++
+
+error[E0412]: cannot find type `baz` in this scope
+ --> tests/compile_fail/as_ref/unknown_struct_attr_arg.rs:2:10
+  |
+2 | #[as_ref(baz)]
+  |          ^^^ not found in this scope


### PR DESCRIPTION
Resolves #285 

## Synopsis

<!-- Give a brief overview of the problem -->

The `AsRef`/`AsMut` derives are less powerful than `From` and `Into`, because there's no way to specify types into which forwarded implementations should convert.


## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

Keep using the `forward` attribute argument for blanket forwarded impls, and use a list of types for selective ones.


## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
