### PR TITLE
Add `TryFrom` to convert repr to enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.65.0"]
+        msrv: ["1.72.0"]
         os:
           - ubuntu
           - macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
-- The minimum supported Rust version (MSRV) is now Rust 1.65.
+- The minimum supported Rust version (MSRV) is now Rust 1.72.
 - Add the `std` feature which should be disabled in `no_std` environments.
 - All Cargo features, except `std`, are now disabled by default. The `full`
   feature can be used to get the old behavior of supporting all possible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#279](https://github.com/JelteF/derive_more/pull/279))
 - `derive_more::derive` module exporting only macros, without traits.
   ([#290](https://github.com/JelteF/derive_more/pull/290))
+- Add `TryFrom` derive for enums to convert from their discriminant.
+  ([#300](https://github.com/JelteF/derive_more/pull/300))
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive_more"
 version = "1.0.0-beta.3"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.72.0"
 description = "Adds #[derive(x)] macros for more traits"
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ mul_assign = ["derive_more-impl/mul_assign"]
 mul = ["derive_more-impl/mul"]
 not = ["derive_more-impl/not"]
 sum = ["derive_more-impl/sum"]
+try_from = ["derive_more-impl/try_from"]
 try_into = ["derive_more-impl/try_into"]
 is_variant = ["derive_more-impl/is_variant"]
 unwrap = ["derive_more-impl/unwrap"]
@@ -92,6 +93,7 @@ full = [
     "mul_assign",
     "not",
     "sum",
+    "try_from",
     "try_into",
     "try_unwrap",
     "unwrap",
@@ -203,6 +205,11 @@ required-features = ["not"]
 name = "sum"
 path = "tests/sum.rs"
 required-features = ["sum"]
+
+[[test]]
+name = "try_from"
+path = "tests/try_from.rs"
+required-features = ["try_from"]
 
 [[test]]
 name = "try_into"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Version](https://img.shields.io/crates/v/derive_more.svg)](https://crates.io/crates/derive_more)
 [![Rust Documentation](https://docs.rs/derive_more/badge.svg)](https://docs.rs/derive_more)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/JelteF/derive_more/master/LICENSE)
-[![Rust 1.65+](https://img.shields.io/badge/rustc-1.65+-lightgray.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.65.0.html)
+[![Rust 1.72+](https://img.shields.io/badge/rustc-1.72+-lightgray.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.72.0.html)
 [![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance)
 
 Rust has lots of builtin traits that are implemented for its basic types, such
@@ -141,7 +141,7 @@ These don't derive traits, but derive static methods instead.
 
 ## Installation
 
-This library requires Rust 1.65 or higher. To avoid redundant compilation times, by
+This library requires Rust 1.72 or higher. To avoid redundant compilation times, by
 default no derives are supported. You have to enable each type of derive as a feature
 in `Cargo.toml`:
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ These are traits that are used to convert automatically between types.
 1. [`From`]
 2. [`Into`]
 3. [`FromStr`]
-4. [`TryInto`]
-5. [`IntoIterator`]
-6. [`AsRef`], [`AsMut`]
+4. [`TryFrom`]
+5. [`TryInto`]
+6. [`IntoIterator`]
+7. [`AsRef`], [`AsMut`]
 
 
 ### Formatting traits

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Version](https://img.shields.io/crates/v/derive_more.svg)](https://crates.io/crates/derive_more)
 [![Rust Documentation](https://docs.rs/derive_more/badge.svg)](https://docs.rs/derive_more)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/JelteF/derive_more/master/LICENSE)
-[![Rust 1.72+](https://img.shields.io/badge/rustc-1.72+-lightgray.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.72.0.html)
+[![Rust 1.72+](https://img.shields.io/badge/rustc-1.72+-lightgray.svg)](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html)
 [![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance)
 
 Rust has lots of builtin traits that are implemented for its basic types, such

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 # See full lints list at:
 # https://rust-lang.github.io/rust-clippy/master/index.html
 
-msrv = "1.65.0"
+msrv = "1.72.0"
 
 # Ensures consistent bracing for macro calls in the codebase.
 # Extends default settings:

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/JelteF/derive_more"
 documentation = "https://docs.rs/derive_more"
 
 # explicitly no keywords or categories so it cannot be found easily
-
 include = [
     "src/**/*.rs",
     "doc/**/*.md",
@@ -35,6 +34,7 @@ rustc_version = { version = "0.4", optional = true }
 [dev-dependencies]
 derive_more = { path = "..", features = ["full"] }
 itertools = "0.11.0"
+rustversion = "1.0"
 
 [badges]
 github = { repository = "JelteF/derive_more", workflow = "CI" }
@@ -66,6 +66,7 @@ mul = ["syn/extra-traits"]
 mul_assign = ["syn/extra-traits"]
 not = ["syn/extra-traits"]
 sum = []
+try_from = []
 try_into = ["syn/extra-traits"]
 try_unwrap = ["dep:convert_case"]
 unwrap = ["dep:convert_case"]
@@ -91,6 +92,7 @@ full = [
     "mul_assign",
     "not",
     "sum",
+    "try_from",
     "try_into",
     "try_unwrap",
     "unwrap",

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/JelteF/derive_more"
 documentation = "https://docs.rs/derive_more"
 
 # explicitly no keywords or categories so it cannot be found easily
+
 include = [
     "src/**/*.rs",
     "doc/**/*.md",

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -34,7 +34,6 @@ rustc_version = { version = "0.4", optional = true }
 [dev-dependencies]
 derive_more = { path = "..", features = ["full"] }
 itertools = "0.11.0"
-rustversion = "1.0"
 
 [badges]
 github = { repository = "JelteF/derive_more", workflow = "CI" }

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive_more-impl"
 version = "1.0.0-beta.3"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.72.0"
 description = "Internal implementation of `derive_more` crate"
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"

--- a/impl/doc/try_from.md
+++ b/impl/doc/try_from.md
@@ -12,6 +12,7 @@ Only field-less variants can be constructed from their variant, therefor the `Tr
 # mod discriminant_on_non_unit_enum {
 # use derive_more::TryFrom;
 #[derive(TryFrom, Debug, PartialEq)]
+#[try_from(repr)]
 #[repr(u32)]
 enum Enum {
     Implicit,

--- a/impl/doc/try_from.md
+++ b/impl/doc/try_from.md
@@ -1,0 +1,37 @@
+# What `#[derive(TryFrom)]` generates
+
+This derive allows you to convert enum discriminants into their corresponding variants.
+By default a `TryFrom<isize>` is generated, matching the [type of the discriminant](https://doc.rust-lang.org/reference/items/enumerations.html#discriminants).
+The type can be changed with a `#[repr(u/i*)]` attribute, e.g., `#[repr(u8)]` or `#[repr(i32)]`.
+Only field-less variants can be constructed from their variant, therefor the `TryFrom` implementation will return an error for a discriminant representing a variant with fields.
+
+## Example usage
+
+```rust
+# #[rustversion::since(1.66)]
+# mod discriminant_on_non_unit_enum {
+# use derive_more::TryFrom;
+#[derive(TryFrom, Debug, PartialEq)]
+#[repr(u32)]
+enum Enum {
+    Implicit,
+    Explicit = 5,
+    Field(usize),
+    Empty{},
+}
+
+# #[rustversion::since(1.66)]
+# pub fn test(){
+assert_eq!(Enum::Implicit, Enum::try_from(0).unwrap());
+assert_eq!(Enum::Explicit, Enum::try_from(5).unwrap());
+assert_eq!(Enum::Empty{}, Enum::try_from(7).unwrap());
+
+// variants with fields are not supported
+assert!(Enum::try_from(6).is_err());
+# }
+# }
+# // We need to use a `function` declaration, because we cannot put `rustversion` on a statement.
+# #[rustversion::since(1.66)] use discriminant_on_non_unit_enum::test;
+# #[rustversion::before(1.66)] fn test() {}
+# test();
+```

--- a/impl/doc/try_from.md
+++ b/impl/doc/try_from.md
@@ -8,8 +8,6 @@ Only field-less variants can be constructed from their variant, therefor the `Tr
 ## Example usage
 
 ```rust
-# #[rustversion::since(1.66)]
-# mod discriminant_on_non_unit_enum {
 # use derive_more::TryFrom;
 #[derive(TryFrom, Debug, PartialEq)]
 #[try_from(repr)]
@@ -21,18 +19,10 @@ enum Enum {
     Empty{},
 }
 
-# #[rustversion::since(1.66)]
-# pub fn test(){
 assert_eq!(Enum::Implicit, Enum::try_from(0).unwrap());
 assert_eq!(Enum::Explicit, Enum::try_from(5).unwrap());
 assert_eq!(Enum::Empty{}, Enum::try_from(7).unwrap());
 
-// variants with fields are not supported
+// Variants with fields are not supported, as the value for their fields would be undefined.
 assert!(Enum::try_from(6).is_err());
-# }
-# }
-# // We need to use a `function` declaration, because we cannot put `rustversion` on a statement.
-# #[rustversion::since(1.66)] use discriminant_on_non_unit_enum::test;
-# #[rustversion::before(1.66)] fn test() {}
-# test();
 ```

--- a/impl/doc/try_from.md
+++ b/impl/doc/try_from.md
@@ -13,15 +13,15 @@ Only field-less variants can be constructed from their variant, therefor the `Tr
 #[try_from(repr)]
 #[repr(u32)]
 enum Enum {
-    Implicit,
-    Explicit = 5,
-    Field(usize),
-    Empty{},
+    ImplicitZero,
+    ExplicitFive = 5,
+    FieldSix(usize),
+    EmptySeven{},
 }
 
-assert_eq!(Enum::Implicit, Enum::try_from(0).unwrap());
-assert_eq!(Enum::Explicit, Enum::try_from(5).unwrap());
-assert_eq!(Enum::Empty{}, Enum::try_from(7).unwrap());
+assert_eq!(Enum::ImplicitZero, Enum::try_from(0).unwrap());
+assert_eq!(Enum::ExplicitFive, Enum::try_from(5).unwrap());
+assert_eq!(Enum::EmptySeven{}, Enum::try_from(7).unwrap());
 
 // Variants with fields are not supported, as the value for their fields would be undefined.
 assert!(Enum::try_from(6).is_err());

--- a/impl/doc/try_from.md
+++ b/impl/doc/try_from.md
@@ -1,11 +1,15 @@
 # What `#[derive(TryFrom)]` generates
 
-This derive allows you to convert enum discriminants into their corresponding variants.
-By default a `TryFrom<isize>` is generated, matching the [type of the discriminant](https://doc.rust-lang.org/reference/items/enumerations.html#discriminants).
+Derive `TryFrom` allows you to convert enum discriminants into their corresponding variants.
+
+
+
+
+## Enums
+
+By default, a `TryFrom<isize>` is generated, matching the [type of the discriminant](https://doc.rust-lang.org/reference/items/enumerations.html#discriminants).
 The type can be changed with a `#[repr(u/i*)]` attribute, e.g., `#[repr(u8)]` or `#[repr(i32)]`.
 Only field-less variants can be constructed from their variant, therefor the `TryFrom` implementation will return an error for a discriminant representing a variant with fields.
-
-## Example usage
 
 ```rust
 # use derive_more::TryFrom;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -64,6 +64,8 @@ mod not_like;
 pub(crate) mod parsing;
 #[cfg(feature = "sum")]
 mod sum_like;
+#[cfg(feature = "try_from")]
+mod try_from;
 #[cfg(feature = "try_into")]
 mod try_into;
 #[cfg(feature = "try_unwrap")]
@@ -264,6 +266,8 @@ create_derive!("not", not_like, Neg, neg_derive);
 
 create_derive!("sum", sum_like, Sum, sum_derive);
 create_derive!("sum", sum_like, Product, product_derive);
+
+create_derive!("try_from", try_from, TryFrom, try_from_derive, try_from);
 
 create_derive!("try_into", try_into, TryInto, try_into_derive, try_into);
 

--- a/impl/src/parsing.rs
+++ b/impl/src/parsing.rs
@@ -245,8 +245,8 @@ pub fn seq<const N: usize>(
     move |c| {
         parsers
             .iter_mut()
-            .fold(Some((TokenStream::new(), c)), |out, parser| {
-                let (mut out, mut c) = out?;
+            .try_fold((TokenStream::new(), c), |out, parser| {
+                let (mut out, mut c) = out;
                 let (stream, cursor) = parser(c)?;
                 out.extend(stream);
                 c = cursor;

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -165,14 +165,14 @@ impl ToTokens for Expansion {
                  ::core::convert::TryFrom<#repr #ty_generics> for #ident
                  #where_clause
             {
-                type Error = ::derive_more::TryFromError<#repr>;
+                type Error = ::derive_more::TryFromReprError<#repr>;
 
                 #[inline]
                 fn try_from(value: #repr) -> ::core::result::Result<Self, Self::Error> {
                     #(#[allow(non_upper_case_globals)] const #consts: #repr = #discriminants;)*
                     match value {
                         #(#consts => ::core::result::Result::Ok(#ident::#variants),)*
-                        _ => ::core::result::Result::Err(::derive_more::TryFromError::new(value)),
+                        _ => ::core::result::Result::Err(::derive_more::TryFromReprError::new(value)),
                     }
                 }
             }

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -1,0 +1,141 @@
+//! Implementation of a [`TryFrom`] derive macro.
+
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::{format_ident, quote, ToTokens as _};
+use syn::{spanned::Spanned as _, Ident, Variant};
+
+/// Expands a [`TryFrom`] derive macro.
+pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStream> {
+    match &input.data {
+        syn::Data::Struct(data) => Err(syn::Error::new(
+            data.struct_token.span(),
+            "`TryFrom` cannot be derived for structs",
+        )),
+        syn::Data::Enum(data) => Expansion {
+            repr: ReprAttribute::parse_attrs(&input.attrs)?,
+            ident: &input.ident,
+            variants: data.variants.iter().collect(),
+            generics: &input.generics,
+        }
+        .expand(),
+        syn::Data::Union(data) => Err(syn::Error::new(
+            data.union_token.span(),
+            "`TryFrom` cannot be derived for unions",
+        )),
+    }
+}
+
+/// Representation of a [`Repr`] derive macro struct container attribute.
+///
+/// ```rust,ignore
+/// #[repr(<type>)]
+/// ```
+struct ReprAttribute(Ident);
+
+impl ReprAttribute {
+    /// Parses a [`StructAttribute`] from the provided [`syn::Attribute`]s.
+    fn parse_attrs(attrs: impl AsRef<[syn::Attribute]>) -> syn::Result<Self> {
+        attrs
+            .as_ref()
+            .iter()
+            .filter(|attr| attr.path().is_ident("repr"))
+            .try_fold(None, |mut repr, attr| {
+                attr.parse_nested_meta(|meta| {
+                    if let Some(ident) = meta.path.get_ident() {
+                        if let "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8"
+                        | "i16" | "i32" | "i64" | "i128" | "isize" =
+                            ident.to_string().as_str()
+                        {
+                            repr = Some(ident.clone());
+                            return Ok(());
+                        }
+                    }
+                    // ignore all other attributes that could have a body e.g. `align`
+                    _ = meta.input.parse::<proc_macro2::Group>();
+                    Ok(())
+                })
+                .map(|_| repr)
+            })
+            // Default discriminant is interpreted as `isize` (https://doc.rust-lang.org/reference/items/enumerations.html#discriminants)
+            .map(|repr| repr.unwrap_or_else(|| Ident::new("isize", Span::call_site())))
+            .map(Self)
+    }
+}
+
+/// Expansion of a macro for generating [`TryFrom`] implementation of an enum
+struct Expansion<'a> {
+    /// Enum `#[repr(u/i*)]`
+    repr: ReprAttribute,
+    /// Enum [`Ident`].
+    ident: &'a Ident,
+
+    /// Variant [`Ident`] in case of enum expansion.
+    variants: Vec<&'a syn::Variant>,
+
+    /// Struct or enum [`syn::Generics`].
+    generics: &'a syn::Generics,
+}
+
+impl<'a> Expansion<'a> {
+    /// Expands [`TryFrom`] implementations for a struct.
+    fn expand(&self) -> syn::Result<TokenStream> {
+        let ident = self.ident;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+
+        let repr = &self.repr.0;
+
+        let mut last_discriminant = quote! {0};
+        let mut inc = 0usize;
+        let (consts, (discriminants, variants)): (
+            Vec<Ident>,
+            (Vec<TokenStream>, Vec<TokenStream>),
+        ) = self
+            .variants
+            .iter()
+            .filter_map(
+                |Variant {
+                     ident,
+                     fields,
+                     discriminant,
+                     ..
+                 }| {
+                    if let Some(discriminant) = discriminant {
+                        last_discriminant = discriminant.1.to_token_stream();
+                        inc = 0;
+                    }
+                    let ret = {
+                        let inc = Literal::usize_unsuffixed(inc);
+                        fields.is_empty().then_some((
+                            format_ident!("__DISCRIMINANT_{ident}"),
+                            (
+                                quote! {#last_discriminant + #inc},
+                                quote! {#ident #fields},
+                            ),
+                        ))
+                    };
+                    inc += 1;
+                    ret
+                },
+            )
+            .unzip();
+
+        Ok(quote! {
+            #[automatically_derived]
+            impl #impl_generics
+                 ::core::convert::TryFrom<#repr #ty_generics> for #ident
+                 #where_clause
+            {
+                type Error = ::derive_more::TryFromError<#repr>;
+
+                #[inline]
+                fn try_from(value: #repr) -> ::core::result::Result<Self, Self::Error> {
+                    #(#[allow(non_upper_case_globals)] const #consts: #repr = #discriminants;)*
+                    match value {
+                        #(#consts => ::core::result::Result::Ok(#ident::#variants),)*
+                        _ => ::core::result::Result::Err(::derive_more::TryFromError::new(value)),
+                    }
+                }
+            }
+        })
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -68,10 +68,10 @@ impl<T> TryFromReprError<T> {
     }
 }
 
-// `T` should only be an integer type and therefor be debug
+// `T` should only be an integer type and therefore be debug
 impl<T: fmt::Debug> fmt::Display for TryFromReprError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "`{:?}` does not respond to a unit variant", self.input)
+        write!(f, "`{:?}` does not corespond to a unit variant", self.input)
     }
 }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -45,3 +45,35 @@ impl<T> fmt::Display for TryIntoError<T> {
 
 #[cfg(feature = "std")]
 impl<T: fmt::Debug> std::error::Error for TryIntoError<T> {}
+
+/// Error returned by the derived [`TryFrom`] implementation.
+///
+/// [`TryFrom`]: macro@crate::TryFrom
+#[derive(Clone, Copy, Debug)]
+pub struct TryFromError<T> {
+    /// Original input value which failed to convert via the derived
+    /// [`TryFrom`] implementation.
+    ///
+    /// [`TryFrom`]: macro@crate::TryFrom
+    pub input: T,
+}
+
+impl<T> TryFromError<T> {
+    #[doc(hidden)]
+    #[must_use]
+    #[inline]
+    pub const fn new(input: T) -> Self {
+        Self { input }
+    }
+}
+
+// `T` should only be an integer type and therefor display
+impl<T: fmt::Display> fmt::Display for TryFromError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "`{}` does not respond to a unit variant", self.input)
+    }
+}
+
+#[cfg(feature = "std")]
+// `T` should only be an integer type and therefor display and debug
+impl<T: fmt::Debug + fmt::Display> std::error::Error for TryFromError<T> {}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,80 +1,97 @@
 //! Definitions used in derived implementations of [`core::convert`] traits.
 
-use core::fmt;
+#[cfg(feature = "try_from")]
+pub use self::try_from::TryFromReprError;
+#[cfg(feature = "try_into")]
+pub use self::try_into::TryIntoError;
 
-/// Error returned by the derived [`TryInto`] implementation.
-///
-/// [`TryInto`]: macro@crate::TryInto
-#[derive(Clone, Copy, Debug)]
-pub struct TryIntoError<T> {
-    /// Original input value which failed to convert via the derived
-    /// [`TryInto`] implementation.
-    ///
-    /// [`TryInto`]: macro@crate::TryInto
-    pub input: T,
-    variant_names: &'static str,
-    output_type: &'static str,
-}
+#[cfg(feature = "try_from")]
+mod try_from {
+    use core::fmt;
 
-impl<T> TryIntoError<T> {
-    #[doc(hidden)]
-    #[must_use]
-    #[inline]
-    pub const fn new(
-        input: T,
-        variant_names: &'static str,
-        output_type: &'static str,
-    ) -> Self {
-        Self {
-            input,
-            variant_names,
-            output_type,
-        }
-    }
-}
-
-impl<T> fmt::Display for TryIntoError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Only {} can be converted to {}",
-            self.variant_names, self.output_type,
-        )
-    }
-}
-
-#[cfg(feature = "std")]
-impl<T: fmt::Debug> std::error::Error for TryIntoError<T> {}
-
-/// Error returned by the derived [`TryFrom`] implementation on enums to
-/// convert from their repr.
-///
-/// [`TryFrom`]: macro@crate::TryFrom
-#[derive(Clone, Copy, Debug)]
-pub struct TryFromReprError<T> {
-    /// Original input value which failed to convert via the derived
-    /// [`TryFrom`] implementation.
+    /// Error returned by the derived [`TryFrom`] implementation on enums to
+    /// convert from their repr.
     ///
     /// [`TryFrom`]: macro@crate::TryFrom
-    pub input: T,
-}
-
-impl<T> TryFromReprError<T> {
-    #[doc(hidden)]
-    #[must_use]
-    #[inline]
-    pub const fn new(input: T) -> Self {
-        Self { input }
+    #[derive(Clone, Copy, Debug)]
+    pub struct TryFromReprError<T> {
+        /// Original input value which failed to convert via the derived
+        /// [`TryFrom`] implementation.
+        ///
+        /// [`TryFrom`]: macro@crate::TryFrom
+        pub input: T,
     }
-}
 
-// `T` should only be an integer type and therefore be debug
-impl<T: fmt::Debug> fmt::Display for TryFromReprError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "`{:?}` does not corespond to a unit variant", self.input)
+    impl<T> TryFromReprError<T> {
+        #[doc(hidden)]
+        #[must_use]
+        #[inline]
+        pub const fn new(input: T) -> Self {
+            Self { input }
+        }
     }
+
+    // `T`, as a discriminant, should only be an integer type, and therefore be `Debug`.
+    impl<T: fmt::Debug> fmt::Display for TryFromReprError<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "`{:?}` does not correspond to a unit variant",
+                self.input
+            )
+        }
+    }
+
+    #[cfg(feature = "std")]
+    // `T` should only be an integer type and therefor be debug
+    impl<T: fmt::Debug> std::error::Error for TryFromReprError<T> {}
 }
 
-#[cfg(feature = "std")]
-// `T` should only be an integer type and therefor be debug
-impl<T: fmt::Debug> std::error::Error for TryFromReprError<T> {}
+#[cfg(feature = "try_into")]
+mod try_into {
+    use core::fmt;
+
+    /// Error returned by the derived [`TryInto`] implementation.
+    ///
+    /// [`TryInto`]: macro@crate::TryInto
+    #[derive(Clone, Copy, Debug)]
+    pub struct TryIntoError<T> {
+        /// Original input value which failed to convert via the derived
+        /// [`TryInto`] implementation.
+        ///
+        /// [`TryInto`]: macro@crate::TryInto
+        pub input: T,
+        variant_names: &'static str,
+        output_type: &'static str,
+    }
+
+    impl<T> TryIntoError<T> {
+        #[doc(hidden)]
+        #[must_use]
+        #[inline]
+        pub const fn new(
+            input: T,
+            variant_names: &'static str,
+            output_type: &'static str,
+        ) -> Self {
+            Self {
+                input,
+                variant_names,
+                output_type,
+            }
+        }
+    }
+
+    impl<T> fmt::Display for TryIntoError<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "Only {} can be converted to {}",
+                self.variant_names, self.output_type,
+            )
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: fmt::Debug> std::error::Error for TryIntoError<T> {}
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -46,11 +46,12 @@ impl<T> fmt::Display for TryIntoError<T> {
 #[cfg(feature = "std")]
 impl<T: fmt::Debug> std::error::Error for TryIntoError<T> {}
 
-/// Error returned by the derived [`TryFrom`] implementation.
+/// Error returned by the derived [`TryFrom`] implementation on enums to
+/// convert from their repr.
 ///
 /// [`TryFrom`]: macro@crate::TryFrom
 #[derive(Clone, Copy, Debug)]
-pub struct TryFromError<T> {
+pub struct TryFromReprError<T> {
     /// Original input value which failed to convert via the derived
     /// [`TryFrom`] implementation.
     ///
@@ -58,7 +59,7 @@ pub struct TryFromError<T> {
     pub input: T,
 }
 
-impl<T> TryFromError<T> {
+impl<T> TryFromReprError<T> {
     #[doc(hidden)]
     #[must_use]
     #[inline]
@@ -67,13 +68,13 @@ impl<T> TryFromError<T> {
     }
 }
 
-// `T` should only be an integer type and therefor display
-impl<T: fmt::Display> fmt::Display for TryFromError<T> {
+// `T` should only be an integer type and therefor be debug
+impl<T: fmt::Debug> fmt::Display for TryFromReprError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "`{}` does not respond to a unit variant", self.input)
+        write!(f, "`{:?}` does not respond to a unit variant", self.input)
     }
 }
 
 #[cfg(feature = "std")]
-// `T` should only be an integer type and therefor display and debug
-impl<T: fmt::Debug + fmt::Display> std::error::Error for TryFromError<T> {}
+// `T` should only be an integer type and therefor be debug
+impl<T: fmt::Debug> std::error::Error for TryFromReprError<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! [`From`]: macro@crate::From
 //! [`Into`]: macro@crate::Into
 //! [`FromStr`]: macro@crate::FromStr
+//! [`TryFrom`]: macro@crate::TryInto
 //! [`TryInto`]: macro@crate::TryInto
 //! [`IntoIterator`]: macro@crate::IntoIterator
 //! [`AsRef`]: macro@crate::AsRef
@@ -89,8 +90,11 @@ mod r#str;
 #[doc(inline)]
 pub use crate::r#str::FromStrError;
 
-#[cfg(feature = "try_into")]
+#[cfg(any(feature = "try_into", feature = "try_from"))]
 mod convert;
+#[cfg(feature = "try_from")]
+#[doc(inline)]
+pub use crate::convert::TryFromError;
 #[cfg(feature = "try_into")]
 #[doc(inline)]
 pub use crate::convert::TryIntoError;
@@ -203,6 +207,8 @@ re_export_traits!("not", not_traits, core::ops, Neg, Not);
 
 re_export_traits!("sum", sum_traits, core::iter, Product, Sum);
 
+re_export_traits!("try_from", try_from_traits, core::convert, TryFrom);
+
 re_export_traits!("try_into", try_into_traits, core::convert, TryInto);
 
 // Now re-export our own derives by their exact name to overwrite any derives that the trait
@@ -271,6 +277,9 @@ pub use derive_more_impl::{Neg, Not};
 #[cfg(feature = "sum")]
 pub use derive_more_impl::{Product, Sum};
 
+#[cfg(feature = "try_from")]
+pub use derive_more_impl::TryFrom;
+
 #[cfg(feature = "try_into")]
 pub use derive_more_impl::TryInto;
 
@@ -303,6 +312,7 @@ pub use derive_more_impl::Unwrap;
     feature = "mul_assign",
     feature = "not",
     feature = "sum",
+    feature = "try_from",
     feature = "try_into",
     feature = "try_unwrap",
     feature = "unwrap",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use crate::r#str::FromStrError;
 mod convert;
 #[cfg(feature = "try_from")]
 #[doc(inline)]
-pub use crate::convert::TryFromError;
+pub use crate::convert::TryFromReprError;
 #[cfg(feature = "try_into")]
 #[doc(inline)]
 pub use crate::convert::TryIntoError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! [`From`]: macro@crate::From
 //! [`Into`]: macro@crate::Into
 //! [`FromStr`]: macro@crate::FromStr
-//! [`TryFrom`]: macro@crate::TryInto
+//! [`TryFrom`]: macro@crate::TryFrom
 //! [`TryInto`]: macro@crate::TryInto
 //! [`IntoIterator`]: macro@crate::IntoIterator
 //! [`AsRef`]: macro@crate::AsRef

--- a/tests/compile_fail/try_from/invalid_repr.rs
+++ b/tests/compile_fail/try_from/invalid_repr.rs
@@ -1,0 +1,7 @@
+#[derive(derive_more::TryFrom)]
+#[repr(a + b)]
+enum Enum {
+    Variant
+}
+
+fn main() {}

--- a/tests/compile_fail/try_from/invalid_repr.stderr
+++ b/tests/compile_fail/try_from/invalid_repr.stderr
@@ -1,0 +1,11 @@
+error: expected `,`
+ --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+  |
+2 | #[repr(a + b)]
+  |          ^
+
+error: expected one of `(`, `,`, `::`, or `=`, found `+`
+ --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+  |
+2 | #[repr(a + b)]
+  |          ^ expected one of `(`, `,`, `::`, or `=`

--- a/tests/compile_fail/try_from/struct.rs
+++ b/tests/compile_fail/try_from/struct.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::TryFrom)]
+struct Struct;
+
+fn main() {}

--- a/tests/compile_fail/try_from/struct.stderr
+++ b/tests/compile_fail/try_from/struct.stderr
@@ -1,0 +1,5 @@
+error: `TryFrom` cannot be derived for structs
+ --> tests/compile_fail/try_from/struct.rs:2:1
+  |
+2 | struct Struct;
+  | ^^^^^^

--- a/tests/compile_fail/try_from/union.rs
+++ b/tests/compile_fail/try_from/union.rs
@@ -1,0 +1,6 @@
+#[derive(derive_more::TryFrom)]
+union Union {
+    field: i32,
+}
+
+fn main() {}

--- a/tests/compile_fail/try_from/union.stderr
+++ b/tests/compile_fail/try_from/union.stderr
@@ -1,0 +1,5 @@
+error: `TryFrom` cannot be derived for unions
+ --> tests/compile_fail/try_from/union.rs:2:1
+  |
+2 | union Union {
+  | ^^^^^

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -1,0 +1,80 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(dead_code)]
+
+use derive_more::TryFrom;
+
+#[test]
+fn test_with_repr() {
+    #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(i16)]
+    enum Enum {
+        A,
+        B = -21,
+        C,
+        D,
+    }
+    assert_eq!(Enum::A, Enum::try_from(0i16).unwrap());
+    assert_eq!(Enum::B, Enum::try_from(-21).unwrap());
+    assert_eq!(Enum::C, Enum::try_from(-20).unwrap());
+    assert_eq!(Enum::D, Enum::try_from(-19).unwrap());
+    assert!(Enum::try_from(-1).is_err());
+}
+
+#[test]
+fn enum_without_repr() {
+    #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    enum Enum {
+        A,
+        B = -21,
+        C,
+        D,
+    }
+    assert_eq!(Enum::A, Enum::try_from(0isize).unwrap());
+    assert_eq!(Enum::B, Enum::try_from(-21).unwrap());
+    assert_eq!(Enum::C, Enum::try_from(-20).unwrap());
+    assert_eq!(Enum::D, Enum::try_from(-19).unwrap());
+    assert!(Enum::try_from(-1).is_err());
+}
+
+#[test]
+fn enum_with_complex_repr() {
+    #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(align(16), i32)]
+    enum Enum {
+        A,
+        B = -21,
+        C,
+        D,
+    }
+    assert_eq!(Enum::A, Enum::try_from(0i32).unwrap());
+    assert_eq!(Enum::B, Enum::try_from(-21).unwrap());
+    assert_eq!(Enum::C, Enum::try_from(-20).unwrap());
+    assert_eq!(Enum::D, Enum::try_from(-19).unwrap());
+    assert!(Enum::try_from(-1).is_err());
+}
+
+#[rustversion::since(1.66)]
+mod discriminants_on_enum_with_fields {
+    use super::*;
+
+    #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(i16)]
+    enum Enum {
+        A,
+        Discriminant = 5,
+        Field(usize),
+        Empty {},
+        FieldWithDiscriminant(u8, i64) = -14,
+        EmptyTuple(),
+    }
+
+    #[test]
+    fn test_discriminants_on_enum_with_fields() {
+        assert_eq!(Enum::A, Enum::try_from(0).unwrap());
+        assert_eq!(Enum::Discriminant, Enum::try_from(5).unwrap());
+        assert!(Enum::try_from(6).is_err());
+        assert_eq!(Enum::Empty {}, Enum::try_from(7).unwrap());
+        assert!(Enum::try_from(-14).is_err());
+        assert_eq!(Enum::EmptyTuple(), Enum::try_from(-13).unwrap());
+    }
+}

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -7,6 +7,7 @@ use derive_more::TryFrom;
 fn test_with_repr() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i16)]
+    #[try_from(repr)]
     enum Enum {
         A,
         B = -21,
@@ -23,6 +24,7 @@ fn test_with_repr() {
 #[test]
 fn enum_without_repr() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    #[try_from(repr)]
     enum Enum {
         A,
         B = -21,
@@ -39,6 +41,7 @@ fn enum_without_repr() {
 #[test]
 fn enum_with_complex_repr() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    #[try_from(repr)]
     #[repr(align(16), i32)]
     enum Enum {
         A,
@@ -58,6 +61,7 @@ mod discriminants_on_enum_with_fields {
     use super::*;
 
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
+    #[try_from(repr)]
     #[repr(i16)]
     enum Enum {
         A,

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -56,10 +56,8 @@ fn enum_with_complex_repr() {
     assert!(Enum::try_from(-1).is_err());
 }
 
-#[rustversion::since(1.66)]
-mod discriminants_on_enum_with_fields {
-    use super::*;
-
+#[test]
+fn test_discriminants_on_enum_with_fields() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]
     #[try_from(repr)]
     #[repr(i16)]
@@ -72,13 +70,10 @@ mod discriminants_on_enum_with_fields {
         EmptyTuple(),
     }
 
-    #[test]
-    fn test_discriminants_on_enum_with_fields() {
-        assert_eq!(Enum::A, Enum::try_from(0).unwrap());
-        assert_eq!(Enum::Discriminant, Enum::try_from(5).unwrap());
-        assert!(Enum::try_from(6).is_err());
-        assert_eq!(Enum::Empty {}, Enum::try_from(7).unwrap());
-        assert!(Enum::try_from(-14).is_err());
-        assert_eq!(Enum::EmptyTuple(), Enum::try_from(-13).unwrap());
-    }
+    assert_eq!(Enum::A, Enum::try_from(0).unwrap());
+    assert_eq!(Enum::Discriminant, Enum::try_from(5).unwrap());
+    assert!(Enum::try_from(6).is_err());
+    assert_eq!(Enum::Empty {}, Enum::try_from(7).unwrap());
+    assert!(Enum::try_from(-14).is_err());
+    assert_eq!(Enum::EmptyTuple(), Enum::try_from(-13).unwrap());
 }


### PR DESCRIPTION
Resolves #146

## Synopsis

Conversion from the repr integer to an enum.




## Solution

A `TryFrom` derive macro implementing `TryFrom<integertype> for Enum`.


## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
    - [x] basic tests
    - [x] compile fail
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
