### PR TITLE
Fix order sensitivity of `Display` attributes (#319)

### DIFF
--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -8,8 +8,6 @@ pub(crate) mod debug;
 pub(crate) mod display;
 mod parsing;
 
-use std::mem;
-
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -391,7 +391,7 @@ impl attr::ParseMultiple for ContainerAttributes {
             item: new,
         } = new;
 
-        if mem::replace(&mut prev.fmt, new.fmt).is_some() {
+        if new.fmt.and_then(|n| prev.fmt.replace(n)).is_some() {
             return Err(syn::Error::new(
                 new_span,
                 format!("multiple `#[{name}(\"...\", ...)]` attributes aren't allowed"),

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -786,8 +786,8 @@ mod generic {
             }
 
             #[derive(Display)]
-            #[display(bound(T1: Trait1 + Trait2, T2: Trait1))]
             #[display("{} {} {} {} {:?}", _0.function1(), _0, _0.function2(), _1.function1(), _1)]
+            #[display(bound(T1: Trait1 + Trait2, T2: Trait1))]
             struct Struct<T1, T2>(T1, T2);
 
             let s = Struct(10, DebugOnly);
@@ -849,8 +849,8 @@ mod generic {
             }
 
             #[derive(Display)]
-            #[display(bound(T: Trait))]
             #[display("{}", _0.function())]
+            #[display(bound(T: Trait))]
             struct Struct<T>(T);
 
             let s = Struct(NoDisplay);


### PR DESCRIPTION
Resolves #319




## Synopsis

See https://github.com/JelteF/derive_more/issues/319#issue-2004684216:

> The following code used to work in 1.0.0-beta.3:
> 
> ```rust
> #[derive(Display)]
> #[display("{name}@{tag}")]
> #[display(bound(Tag: std::fmt::Display))]
> struct Specifier<Tag> {
>     name: String,
>     tag: Tag,
> }
> ```
> 
> However, in 1.0.0-beta.6, it emits the following error message:
> 
> ```
> error: multiple `#[display("...", ...)]` attributes aren't allowed
> ```
> 
> It took me a long time to figure out that the fix was to swap place between the 2 display attributes.

The regression lies [here](https://github.com/JelteF/derive_more/blob/v1.0.0-beta.6/impl/src/fmt/mod.rs#L394-L399), where `mem::replace` doesn't provide the implied and expected "and" logic for merging two `Option`s.



## Solution

- [x] Merge those two `Option`s correctly.
- [x] Recheck similar places over the code.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated (if required)
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
