### PR TITLE
Delegation for `fmt` traits (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `#[display(fmt = "...", ("<expr>"),*)]`, and `#[display(bound(<bound>))]`
   instead of `#[display(bound = "<bound>")]`. So without the double quotes
   around the expressions and bounds.
+- The `Display` derive (and other `fmt`-like ones) now delegates to the inner type
+  when `#[display("...", (<expr>),*)]` attribute is trivially substitutable with such
+  call. ([#322](https://github.com/JelteF/derive_more/pull/322))
 - The `DebugCustom` derive is renamed to just `Debug` (gated now under a separate
   `debug` feature), and its semantics were changed to be a superset of `std` variant
   of `Debug`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   instead of `#[display(bound = "<bound>")]`. So without the double quotes
   around the expressions and bounds.
 - The `Debug` and `Display` derives (and other `fmt`-like ones) now transparently
-  delegates to the inner type when `#[display("...", (<expr>),*)]` attribute is
+  delegate to the inner type when `#[display("...", (<expr>),*)]` attribute is
   trivially substitutable with a transparent call.
   ([#322](https://github.com/JelteF/derive_more/pull/322))
 - The `DebugCustom` derive is renamed to just `Debug` (gated now under a separate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `#[display(fmt = "...", ("<expr>"),*)]`, and `#[display(bound(<bound>))]`
   instead of `#[display(bound = "<bound>")]`. So without the double quotes
   around the expressions and bounds.
-- The `Display` derive (and other `fmt`-like ones) now delegates to the inner type
-  when `#[display("...", (<expr>),*)]` attribute is trivially substitutable with such
-  call. ([#322](https://github.com/JelteF/derive_more/pull/322))
+- The `Debug` and `Display` derives (and other `fmt`-like ones) now transparently
+  delegates to the inner type when `#[display("...", (<expr>),*)]` attribute is
+  trivially substitutable with a transparent call.
+  ([#322](https://github.com/JelteF/derive_more/pull/322))
 - The `DebugCustom` derive is renamed to just `Debug` (gated now under a separate
   `debug` feature), and its semantics were changed to be a superset of `std` variant
   of `Debug`.

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -97,7 +97,7 @@ and can be trivially substituted with a delegation call to the inner type, then 
 struct MyOctalInt(i32);
 
 // so, additional formatting parameters do work transparently
-assert_eq!(format!("{:03?}", MyInt(9)), "011");
+assert_eq!(format!("{:03?}", MyOctalInt(9)), "011");
 
 #[derive(Debug)]
 #[debug("{_0:02b}")] // cannot be trivially substituted with `Binary::fmt()`
@@ -116,7 +116,7 @@ If, for some reason, delegation in trivial cases is not desired, it may be suppr
 struct MyOctalInt(i32);
 
 // so, additional formatting parameters have no effect
-assert_eq!(format!("{:07}", MyInt(9)), "11");
+assert_eq!(format!("{:07}", MyOctalInt(9)), "11");
 ```
 
 

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -116,7 +116,7 @@ If, for some reason, delegation in trivial cases is not desired, it may be suppr
 struct MyOctalInt(i32);
 
 // so, additional formatting parameters have no effect
-assert_eq!(format!("{:07}", MyOctalInt(9)), "11");
+assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
 ```
 
 

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -18,8 +18,6 @@ The variables available in the arguments is `self` and each member of the struct
 structs being named with a leading underscore and their index, i.e. `_0`, `_1`, `_2`, etc.
 
 
-
-
 ### Generic data types
 
 When deriving `Debug` for a generic struct/enum, all generic type arguments _used_ during formatting
@@ -53,8 +51,6 @@ The following where clauses would be generated:
 - `&'a T1: Pointer`
 
 
-
-
 ### Custom trait bounds
 
 Sometimes you may want to specify additional trait bounds on your generic type parameters, so that they could be used
@@ -85,6 +81,42 @@ struct MyStruct<T, U, V, F> {
 }
 
 trait MyTrait { fn my_function(&self) -> i32; }
+```
+
+
+### Delegation
+
+If the top-level `#[debug("...", args...)]` attribute (the one for a whole struct or variant) is specified
+and can be trivially substituted with a delegation call to the inner type, then all the additional
+[formatting parameters][1] do work as expected:
+```rust
+# use derive_more::Debug;
+#
+#[derive(Debug)]
+#[debug("{_0:o}")] // the same as calling `Octal::fmt()`
+struct MyOctalInt(i32);
+
+// so, additional formatting parameters do work transparently
+assert_eq!(format!("{:03?}", MyInt(9)), "011");
+
+#[derive(Debug)]
+#[debug("{_0:02b}")] // cannot be trivially substituted with `Binary::fmt()`
+struct MyBinaryInt(i32);
+
+// so, additional formatting parameters have no effect
+assert_eq!(format!("{:07?}", MyBinaryInt(2)), "10");
+```
+
+If, for some reason, delegation in trivial cases is not desired, it may be suppressed explicitly:
+```rust
+# use derive_more::Debug;
+#
+#[derive(Debug)]
+#[debug("{}", format_args!("{_0:o}"))] // `format_args!()` opaques the inner type
+struct MyOctalInt(i32);
+
+// so, additional formatting parameters have no effect
+assert_eq!(format!("{:07}", MyInt(9)), "11");
 ```
 
 
@@ -133,3 +165,5 @@ assert_eq!(format!("{:?}", E::EnumFormat(true)), "true");
 
 [`format!()`]: https://doc.rust-lang.org/stable/std/macro.format.html
 [`format_args!()`]: https://doc.rust-lang.org/stable/std/macro.format_args.html
+
+[1]: https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-parameters

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -84,10 +84,10 @@ trait MyTrait { fn my_function(&self) -> i32; }
 ```
 
 
-### Delegation
+### Transparency
 
 If the top-level `#[debug("...", args...)]` attribute (the one for a whole struct or variant) is specified
-and can be trivially substituted with a delegation call to the inner type, then all the additional
+and can be trivially substituted with a transparent delegation call to the inner type, then all the additional
 [formatting parameters][1] do work as expected:
 ```rust
 # use derive_more::Debug;
@@ -100,22 +100,34 @@ struct MyOctalInt(i32);
 assert_eq!(format!("{:03?}", MyOctalInt(9)), "011");
 
 #[derive(Debug)]
-#[debug("{_0:02b}")] // cannot be trivially substituted with `Binary::fmt()`
-struct MyBinaryInt(i32);
+#[debug("{_0:02b}")]     // cannot be trivially substituted with `Binary::fmt()`,
+struct MyBinaryInt(i32); // because of specified formatting parameters
 
 // so, additional formatting parameters have no effect
 assert_eq!(format!("{:07?}", MyBinaryInt(2)), "10");
 ```
 
-If, for some reason, delegation in trivial cases is not desired, it may be suppressed explicitly:
+If, for some reason, transparency in trivial cases is not desired, it may be suppressed explicitly
+either with the [`format_args!()`] macro usage:
 ```rust
 # use derive_more::Debug;
 #
 #[derive(Debug)]
-#[debug("{}", format_args!("{_0:o}"))] // `format_args!()` opaques the inner type
+#[debug("{}", format_args!("{_0:o}"))] // `format_args!()` obscures the inner type
 struct MyOctalInt(i32);
 
 // so, additional formatting parameters have no effect
+assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
+```
+Or by adding [formatting parameters][1] which cause no visual effects:
+```rust
+# use derive_more::Debug;
+#
+#[derive(Debug)]
+#[debug("{_0:^o}")] // `^` is centering, but in absence of additional width has no effect
+struct MyOctalInt(i32);
+
+// and so, additional formatting parameters have no effect
 assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
 ```
 

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -151,7 +151,7 @@ Or by adding [formatting parameters][1] which cause no visual effects:
 struct MyOctalInt(i32);
 
 // and so, additional formatting parameters have no effect
-assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
+assert_eq!(format!("{:07}", MyOctalInt(9)), "11");
 ```
 
 

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -120,7 +120,7 @@ call to the inner type, then delegation will work too:
 struct MyOctalInt(i32);
 
 // so, additional formatting parameters do work transparently
-assert_eq!(format!("{:03}", MyInt(9)), "011");
+assert_eq!(format!("{:03}", MyOctalInt(9)), "011");
 
 #[derive(Display)]
 #[display("{_0:02b}")] // cannot be trivially substituted with `Binary::fmt()`
@@ -139,7 +139,7 @@ If, for some reason, delegation in trivial cases is not desired, it may be suppr
 struct MyOctalInt(i32);
 
 // so, additional formatting parameters have no effect
-assert_eq!(format!("{:07}", MyInt(9)), "11");
+assert_eq!(format!("{:07}", MyOctalInt(9)), "11");
 ```
 
 

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -330,9 +330,11 @@ impl<'a> Expansion<'a> {
         let mut out = self.attr.bounds.0.clone().into_iter().collect::<Vec<_>>();
 
         if let Some(fmt) = self.attr.fmt.as_ref() {
-            out.extend(fmt.bounded_types(self.fields).map(|(ty, trait_name)| {
-                let trait_name = format_ident!("{trait_name}");
-                parse_quote! { #ty: ::core::fmt::#trait_name }
+            out.extend(fmt.bindings(self.fields).map(|b| {
+                let ty = b.ty;
+                let trait_ident = format_ident!("{}", b.trait_name);
+
+                parse_quote! { #ty: ::core::fmt::#trait_ident }
             }));
             Ok(out)
         } else {
@@ -342,12 +344,12 @@ impl<'a> Expansion<'a> {
                     .map(Spanning::into_inner)
                 {
                     Some(FieldAttribute::Right(fmt_attr)) => {
-                        out.extend(fmt_attr.bounded_types(self.fields).map(
-                            |(ty, trait_name)| {
-                                let trait_name = format_ident!("{trait_name}");
-                                parse_quote! { #ty: ::core::fmt::#trait_name }
-                            },
-                        ));
+                        out.extend(fmt_attr.bindings(self.fields).map(|b| {
+                            let ty = b.ty;
+                            let trait_ident = format_ident!("{}", b.trait_name);
+
+                            parse_quote! { #ty: ::core::fmt::#trait_ident }
+                        }));
                     }
                     Some(FieldAttribute::Left(_skip)) => {}
                     None => out.extend([parse_quote! { #ty: ::core::fmt::Debug }]),

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -228,7 +228,7 @@ impl<'a> Expansion<'a> {
     /// [`Debug::fmt()`]: std::fmt::Debug::fmt()
     fn generate_body(&self) -> syn::Result<TokenStream> {
         if let Some(fmt) = &self.attr.fmt {
-            return Ok(if let Some((expr, trait_ident)) = fmt.delegatable() {
+            return Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
                 quote! { ::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
             } else {
                 quote! { ::core::write!(__derive_more_f, #fmt) }

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -334,9 +334,8 @@ impl<'a> Expansion<'a> {
         let mut out = self.attr.bounds.0.clone().into_iter().collect::<Vec<_>>();
 
         if let Some(fmt) = self.attr.fmt.as_ref() {
-            out.extend(fmt.bindings(self.fields).map(|b| {
-                let ty = b.ty;
-                let trait_ident = format_ident!("{}", b.trait_name);
+            out.extend(fmt.bounded_types(self.fields).map(|(ty, trait_name)| {
+                let trait_ident = format_ident!("{trait_name}");
 
                 parse_quote! { #ty: ::core::fmt::#trait_ident }
             }));
@@ -348,12 +347,13 @@ impl<'a> Expansion<'a> {
                     .map(Spanning::into_inner)
                 {
                     Some(FieldAttribute::Right(fmt_attr)) => {
-                        out.extend(fmt_attr.bindings(self.fields).map(|b| {
-                            let ty = b.ty;
-                            let trait_ident = format_ident!("{}", b.trait_name);
+                        out.extend(fmt_attr.bounded_types(self.fields).map(
+                            |(ty, trait_name)| {
+                                let trait_ident = format_ident!("{trait_name}");
 
-                            parse_quote! { #ty: ::core::fmt::#trait_ident }
-                        }));
+                                parse_quote! { #ty: ::core::fmt::#trait_ident }
+                            },
+                        ));
                     }
                     Some(FieldAttribute::Left(_skip)) => {}
                     None => out.extend([parse_quote! { #ty: ::core::fmt::Debug }]),

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -222,11 +222,13 @@ impl<'a> Expansion<'a> {
     /// [`Display::fmt()`]: fmt::Display::fmt()
     fn generate_body(&self) -> syn::Result<TokenStream> {
         match &self.attrs.fmt {
-            Some(fmt) => Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                quote! { ::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
-            } else {
-                quote! { ::core::write!(__derive_more_f, #fmt) }
-            }),
+            Some(fmt) => {
+                Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
+                    quote! { ::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
+                } else {
+                    quote! { ::core::write!(__derive_more_f, #fmt) }
+                })
+            }
             None if self.fields.is_empty() => {
                 let ident_str = self.ident.to_string();
 

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -222,7 +222,7 @@ impl<'a> Expansion<'a> {
     /// [`Display::fmt()`]: fmt::Display::fmt()
     fn generate_body(&self) -> syn::Result<TokenStream> {
         match &self.attrs.fmt {
-            Some(fmt) => Ok(if let Some((expr, trait_ident)) = fmt.delegatable() {
+            Some(fmt) => Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
                 quote! { ::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
             } else {
                 quote! { ::core::write!(__derive_more_f, #fmt) }

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -273,10 +273,9 @@ impl<'a> Expansion<'a> {
                 .unwrap_or_default();
         };
 
-        fmt.bindings(self.fields)
-            .map(|b| {
-                let ty = b.ty;
-                let trait_ident = format_ident!("{}", b.trait_name);
+        fmt.bounded_types(self.fields)
+            .map(|(ty, trait_name)| {
+                let trait_ident = format_ident!("{trait_name}");
 
                 parse_quote! { #ty: ::core::fmt::#trait_ident }
             })

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -222,10 +222,35 @@ impl<'a> Expansion<'a> {
     /// [`Display::fmt()`]: fmt::Display::fmt()
     fn generate_body(&self) -> syn::Result<TokenStream> {
         match &self.attrs.fmt {
-            Some(fmt) => Ok(quote! { ::core::write!(__derive_more_f, #fmt) }),
+            Some(fmt) => Ok(fmt
+                .delegatable()
+                .then(|| {
+                    let mut bindings = fmt.bindings(self.fields);
+                    let binding = bindings.next()?;
+                    bindings.next().is_none().then_some(binding)
+                })
+                .flatten()
+                .map_or_else(
+                    || {
+                        quote! {
+                            ::core::write!(__derive_more_f, #fmt)
+                        }
+                    },
+                    |b| {
+                        let ident = &b.ident;
+                        let trait_ident = format_ident!("{}", b.trait_name);
+
+                        quote! {
+                            ::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)
+                        }
+                    },
+                )),
             None if self.fields.is_empty() => {
                 let ident_str = self.ident.to_string();
-                Ok(quote! { ::core::write!(__derive_more_f, #ident_str) })
+
+                Ok(quote! {
+                    ::core::write!(__derive_more_f, #ident_str)
+                })
             }
             None if self.fields.len() == 1 => {
                 let field = self
@@ -235,6 +260,7 @@ impl<'a> Expansion<'a> {
                     .unwrap_or_else(|| unreachable!("count() == 1"));
                 let ident = field.ident.clone().unwrap_or_else(|| format_ident!("_0"));
                 let trait_ident = self.trait_ident;
+
                 Ok(quote! {
                     ::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)
                 })
@@ -265,10 +291,12 @@ impl<'a> Expansion<'a> {
                 .unwrap_or_default();
         };
 
-        fmt.bounded_types(self.fields)
-            .map(|(ty, trait_name)| {
-                let tr = format_ident!("{}", trait_name);
-                parse_quote! { #ty: ::core::fmt::#tr }
+        fmt.bindings(self.fields)
+            .map(|b| {
+                let ty = b.ty;
+                let trait_ident = format_ident!("{}", b.trait_name);
+
+                parse_quote! { #ty: ::core::fmt::#trait_ident }
             })
             .chain(self.attrs.bounds.0.clone())
             .collect()

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -133,15 +133,15 @@ impl ToTokens for FmtAttribute {
 }
 
 impl FmtAttribute {
-    /// Checks whether this [`FmtAttribute`] can be replaced with a trivial delegation (calling a formatting trait
-    /// directly instead of interpolation syntax).
+    /// Checks whether this [`FmtAttribute`] can be replaced with a transparent delegation (calling
+    /// a formatting trait directly instead of interpolation syntax).
     ///
-    /// If delegation is possible, returns an [`Ident`] of the delegated trait and an [`Expr`] to pass into the
-    /// delegation call.
+    /// If such transparent call is possible, the returns an [`Ident`] of the delegated trait and
+    /// the [`Expr`] to pass into the call, otherwise [`None`].
     ///
     /// [`Ident`]: struct@syn::Ident
-    fn delegatable(&self) -> Option<(Expr, syn::Ident)> {
-        // `FmtAttribute` is delegatable when:
+    fn transparent_call(&self) -> Option<(Expr, syn::Ident)> {
+        // `FmtAttribute` is transparent when:
 
         // (1) There is exactly one formatting parameter.
         let lit = self.lit.value();

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -148,7 +148,13 @@ impl FmtAttribute {
                 // (2) And the formatting parameter doesn't contain any modifiers.
                 p.spec
                     .map(|s| {
-                        s.width.is_none() && s.precision.is_none() && s.ty.is_trivial()
+                        s.align.is_none()
+                            && s.sign.is_none()
+                            && s.alternate.is_none()
+                            && s.zero_padding.is_none()
+                            && s.width.is_none()
+                            && s.precision.is_none()
+                            && s.ty.is_trivial()
                     })
                     .unwrap_or(true)
             })

--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -7,7 +7,7 @@ use std::{convert::identity, iter};
 use unicode_xid::UnicodeXID as XID;
 
 /// Output of the [`format_string`] parser.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct FormatString<'a> {
     pub(crate) formats: Vec<Format<'a>>,
 }
@@ -22,7 +22,7 @@ pub(crate) struct Format<'a> {
 }
 
 /// Output of the [`format_spec`] parser.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct FormatSpec<'a> {
     pub(crate) width: Option<Width<'a>>,
     pub(crate) precision: Option<Precision<'a>>,
@@ -30,21 +30,21 @@ pub(crate) struct FormatSpec<'a> {
 }
 
 /// Output of the [`argument`] parser.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Argument<'a> {
     Integer(usize),
     Identifier(&'a str),
 }
 
 /// Output of the [`precision`] parser.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Precision<'a> {
     Count(Count<'a>),
     Star,
 }
 
 /// Output of the [`count`] parser.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Count<'a> {
     Integer(usize),
     Parameter(Parameter<'a>),
@@ -53,7 +53,7 @@ pub(crate) enum Count<'a> {
 /// Output of the [`type_`] parser. See [formatting traits][1] for more info.
 ///
 /// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-traits
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Type {
     Display,
     Debug,
@@ -72,15 +72,31 @@ impl Type {
     /// Returns trait name of this [`Type`].
     pub(crate) fn trait_name(&self) -> &'static str {
         match self {
-            Type::Display => "Display",
-            Type::Debug | Type::LowerDebug | Type::UpperDebug => "Debug",
-            Type::Octal => "Octal",
-            Type::LowerHex => "LowerHex",
-            Type::UpperHex => "UpperHex",
-            Type::Pointer => "Pointer",
-            Type::Binary => "Binary",
-            Type::LowerExp => "LowerExp",
-            Type::UpperExp => "UpperExp",
+            Self::Display => "Display",
+            Self::Debug | Self::LowerDebug | Self::UpperDebug => "Debug",
+            Self::Octal => "Octal",
+            Self::LowerHex => "LowerHex",
+            Self::UpperHex => "UpperHex",
+            Self::Pointer => "Pointer",
+            Self::Binary => "Binary",
+            Self::LowerExp => "LowerExp",
+            Self::UpperExp => "UpperExp",
+        }
+    }
+
+    /// Indicates whether this [`Type`] represents a trivial trait call without any modifications.
+    pub(crate) fn is_trivial(&self) -> bool {
+        match self {
+            Self::Display
+            | Self::Debug
+            | Self::Octal
+            | Self::LowerHex
+            | Self::UpperHex
+            | Self::Pointer
+            | Self::Binary
+            | Self::LowerExp
+            | Self::UpperExp => true,
+            Self::LowerDebug | Self::UpperDebug => false,
         }
     }
 }
@@ -188,7 +204,7 @@ fn maybe_format(input: &str) -> Option<(LeftToParse<'_>, MaybeFormat<'_>)> {
 ///
 /// [`format`]: fn@format
 /// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
-fn format(input: &str) -> Option<(LeftToParse<'_>, Format<'_>)> {
+pub(crate) fn format(input: &str) -> Option<(LeftToParse<'_>, Format<'_>)> {
     let input = char('{')(input)?;
 
     let (input, arg) = optional_result(argument)(input);

--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -24,10 +24,24 @@ pub(crate) struct Format<'a> {
 /// Output of the [`format_spec`] parser.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct FormatSpec<'a> {
+    /// Parsed `[`[`sign`]`]`.
     pub(crate) sign: Option<Sign>,
+
+    /// Parsed `['#']` (alternation).
     pub(crate) alternate: Option<Alternate>,
+
+    /// Parsed `['0']` (padding with zeros).
+    pub(crate) zero_padding: Option<ZeroPadding>,
+
+    /// Parsed `[width]`.
     pub(crate) width: Option<Width<'a>>,
+
+    /// Parsed `['.' `[`precision`]`]`.
     pub(crate) precision: Option<Precision<'a>>,
+
+    /// Parsed [`type`].
+    ///
+    /// [`type`]: type_
     pub(crate) ty: Type,
 }
 
@@ -48,6 +62,10 @@ pub(crate) enum Sign {
 /// Type for the [`FormatSpec::alternate`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Alternate;
+
+/// Type for the [`FormatSpec::zero_padding`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ZeroPadding;
 
 /// Output of the [`precision`] parser.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -285,10 +303,13 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
 
     let (input, alternate) = optional_result(map(char('#'), |i| (i, Alternate)))(input);
 
-    let input = seq(&mut [&mut optional(try_seq(&mut [
-        &mut char('0'),
-        &mut lookahead(check_char(|c| !matches!(c, '$'))),
-    ]))])(input);
+    let (input, zero_padding) = optional_result(map(
+        try_seq(&mut [
+            &mut char('0'),
+            &mut lookahead(check_char(|c| !matches!(c, '$'))),
+        ]),
+        |i| (i, ZeroPadding),
+    ))(input);
 
     let (input, width) = optional_result(count)(input);
 
@@ -305,6 +326,7 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
         FormatSpec {
             sign,
             alternate,
+            zero_padding,
             width,
             precision,
             ty,
@@ -739,6 +761,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -754,6 +777,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -769,6 +793,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -784,6 +809,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -799,6 +825,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -814,6 +841,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -829,6 +857,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -844,6 +873,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: Some(Alternate),
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -859,6 +889,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
                         alternate: Some(Alternate),
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -874,6 +905,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: Some(Alternate),
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -889,6 +921,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
                         alternate: Some(Alternate),
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -904,6 +937,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: Some(ZeroPadding),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -919,6 +953,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: Some(Alternate),
+                        zero_padding: Some(ZeroPadding),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -934,6 +969,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
                         alternate: None,
+                        zero_padding: Some(ZeroPadding),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -949,6 +985,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: Some(ZeroPadding),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -964,6 +1001,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
                         alternate: Some(Alternate),
+                        zero_padding: Some(ZeroPadding),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -979,6 +1017,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: Some(Count::Integer(1)),
                         precision: None,
                         ty: Type::Display,
@@ -994,6 +1033,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: Some(Count::Parameter(Argument::Integer(1))),
                         precision: None,
                         ty: Type::Display,
@@ -1009,6 +1049,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: Some(Count::Parameter(Argument::Identifier("par"))),
                         precision: None,
                         ty: Type::Display,
@@ -1024,6 +1065,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
                         alternate: Some(Alternate),
+                        zero_padding: Some(ZeroPadding),
                         width: Some(Count::Parameter(Argument::Identifier("Минск"))),
                         precision: None,
                         ty: Type::Display,
@@ -1039,6 +1081,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: Some(Precision::Star),
                         ty: Type::Display,
@@ -1054,6 +1097,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Integer(0))),
                         ty: Type::Display,
@@ -1069,6 +1113,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Integer(0),
@@ -1086,6 +1131,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1103,6 +1149,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
                         alternate: Some(Alternate),
+                        zero_padding: None,
                         width: Some(Count::Parameter(Argument::Integer(2))),
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1120,6 +1167,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::LowerDebug,
@@ -1135,6 +1183,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: None,
                         alternate: None,
+                        zero_padding: None,
                         width: None,
                         precision: None,
                         ty: Type::UpperExp,
@@ -1150,6 +1199,7 @@ mod tests {
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
                         alternate: Some(Alternate),
+                        zero_padding: None,
                         width: Some(Count::Parameter(Argument::Identifier("par"))),
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1172,6 +1222,7 @@ mod tests {
                         spec: Some(FormatSpec {
                             sign: None,
                             alternate: Some(Alternate),
+                            zero_padding: None,
                             width: None,
                             precision: None,
                             ty: Type::Debug,
@@ -1182,6 +1233,7 @@ mod tests {
                         spec: Some(FormatSpec {
                             sign: None,
                             alternate: None,
+                            zero_padding: None,
                             width: Some(Count::Parameter(Argument::Identifier("par"))),
                             precision: Some(Precision::Count(Count::Parameter(
                                 Argument::Identifier("a"),

--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -25,6 +25,7 @@ pub(crate) struct Format<'a> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct FormatSpec<'a> {
     pub(crate) sign: Option<Sign>,
+    pub(crate) alternate: Option<Alternate>,
     pub(crate) width: Option<Width<'a>>,
     pub(crate) precision: Option<Precision<'a>>,
     pub(crate) ty: Type,
@@ -43,6 +44,10 @@ pub(crate) enum Sign {
     Plus,
     Minus,
 }
+
+/// Type for the [`FormatSpec::alternate`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Alternate;
 
 /// Output of the [`precision`] parser.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -278,13 +283,12 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
 
     let (input, sign) = optional_result(sign)(input);
 
-    let input = seq(&mut [
-        &mut optional(char('#')),
-        &mut optional(try_seq(&mut [
-            &mut char('0'),
-            &mut lookahead(check_char(|c| !matches!(c, '$'))),
-        ])),
-    ])(input);
+    let (input, alternate) = optional_result(map(char('#'), |i| (i, Alternate)))(input);
+
+    let input = seq(&mut [&mut optional(try_seq(&mut [
+        &mut char('0'),
+        &mut lookahead(check_char(|c| !matches!(c, '$'))),
+    ]))])(input);
 
     let (input, width) = optional_result(count)(input);
 
@@ -300,6 +304,7 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
         input,
         FormatSpec {
             sign,
+            alternate,
             width,
             precision,
             ty,
@@ -733,6 +738,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -747,6 +753,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -761,6 +768,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -775,6 +783,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -789,6 +798,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -803,6 +813,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -817,6 +828,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -831,6 +843,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: Some(Alternate),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -845,6 +858,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
+                        alternate: Some(Alternate),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -859,6 +873,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: Some(Alternate),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -873,6 +888,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
+                        alternate: Some(Alternate),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -887,6 +903,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -901,6 +918,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: Some(Alternate),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -915,6 +933,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -929,6 +948,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -943,6 +963,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
+                        alternate: Some(Alternate),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -957,6 +978,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: Some(Count::Integer(1)),
                         precision: None,
                         ty: Type::Display,
@@ -971,6 +993,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: Some(Count::Parameter(Argument::Integer(1))),
                         precision: None,
                         ty: Type::Display,
@@ -985,6 +1008,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: Some(Count::Parameter(Argument::Identifier("par"))),
                         precision: None,
                         ty: Type::Display,
@@ -999,6 +1023,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Minus),
+                        alternate: Some(Alternate),
                         width: Some(Count::Parameter(Argument::Identifier("Минск"))),
                         precision: None,
                         ty: Type::Display,
@@ -1013,6 +1038,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: Some(Precision::Star),
                         ty: Type::Display,
@@ -1027,6 +1053,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Integer(0))),
                         ty: Type::Display,
@@ -1041,6 +1068,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Integer(0),
@@ -1057,6 +1085,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1073,6 +1102,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
+                        alternate: Some(Alternate),
                         width: Some(Count::Parameter(Argument::Integer(2))),
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1089,6 +1119,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::LowerDebug,
@@ -1103,6 +1134,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: None,
+                        alternate: None,
                         width: None,
                         precision: None,
                         ty: Type::UpperExp,
@@ -1117,6 +1149,7 @@ mod tests {
                     arg: None,
                     spec: Some(FormatSpec {
                         sign: Some(Sign::Plus),
+                        alternate: Some(Alternate),
                         width: Some(Count::Parameter(Argument::Identifier("par"))),
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1138,6 +1171,7 @@ mod tests {
                         arg: Some(Argument::Integer(0)),
                         spec: Some(FormatSpec {
                             sign: None,
+                            alternate: Some(Alternate),
                             width: None,
                             precision: None,
                             ty: Type::Debug,
@@ -1147,6 +1181,7 @@ mod tests {
                         arg: Some(Argument::Identifier("par")),
                         spec: Some(FormatSpec {
                             sign: None,
+                            alternate: None,
                             width: Some(Count::Parameter(Argument::Identifier("par"))),
                             precision: Some(Precision::Count(Count::Parameter(
                                 Argument::Identifier("a"),

--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -92,9 +92,9 @@ pub(crate) enum Count<'a> {
     Parameter(Parameter<'a>),
 }
 
-/// Output of the [`type_`] parser. See [formatting traits][1] for more info.
+/// Output of the [`type_`] parser. See [formatting traits][0] for more info.
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-traits
+/// [0]: std::fmt#formatting-traits
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Type {
     Display,
@@ -163,7 +163,7 @@ type Parameter<'a> = Argument<'a>;
 /// [`str`]: prim@str
 type LeftToParse<'a> = &'a str;
 
-/// Parses a `format_string` as defined in the [grammar spec][1].
+/// Parses a `format_string` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -187,7 +187,7 @@ type LeftToParse<'a> = &'a str;
 /// - [`None`] otherwise (not all characters are consumed by underlying
 ///   parsers).
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 pub(crate) fn format_string(input: &str) -> Option<FormatString<'_>> {
     let (mut input, _) = optional_result(text)(input);
 
@@ -207,7 +207,7 @@ pub(crate) fn format_string(input: &str) -> Option<FormatString<'_>> {
     input.is_empty().then_some(FormatString { formats })
 }
 
-/// Parses a `maybe_format` as defined in the [grammar spec][1].
+/// Parses a `maybe_format` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -224,7 +224,7 @@ pub(crate) fn format_string(input: &str) -> Option<FormatString<'_>> {
 /// ```
 ///
 /// [`format`]: fn@format
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn maybe_format(input: &str) -> Option<(LeftToParse<'_>, MaybeFormat<'_>)> {
     alt(&mut [
         &mut map(str("{{"), |i| (i, None)),
@@ -233,7 +233,7 @@ fn maybe_format(input: &str) -> Option<(LeftToParse<'_>, MaybeFormat<'_>)> {
     ])(input)
 }
 
-/// Parses a `format` as defined in the [grammar spec][1].
+/// Parses a `format` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -248,7 +248,7 @@ fn maybe_format(input: &str) -> Option<(LeftToParse<'_>, MaybeFormat<'_>)> {
 /// ```
 ///
 /// [`format`]: fn@format
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 pub(crate) fn format(input: &str) -> Option<(LeftToParse<'_>, Format<'_>)> {
     let input = char('{')(input)?;
 
@@ -265,7 +265,7 @@ pub(crate) fn format(input: &str) -> Option<(LeftToParse<'_>, Format<'_>)> {
     Some((input, Format { arg, spec }))
 }
 
-/// Parses an `argument` as defined in the [grammar spec][1].
+/// Parses an `argument` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -279,7 +279,7 @@ pub(crate) fn format(input: &str) -> Option<(LeftToParse<'_>, Format<'_>)> {
 /// Минск
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn argument(input: &str) -> Option<(LeftToParse<'_>, Argument)> {
     alt(&mut [
         &mut map(identifier, |(i, ident)| (i, Argument::Identifier(ident))),
@@ -287,7 +287,7 @@ fn argument(input: &str) -> Option<(LeftToParse<'_>, Argument)> {
     ])(input)
 }
 
-/// Parses a `format_spec` as defined in the [grammar spec][1].
+/// Parses a `format_spec` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -303,7 +303,7 @@ fn argument(input: &str) -> Option<(LeftToParse<'_>, Argument)> {
 /// ```
 ///
 /// [`type`]: type_
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
     let (input, align) = optional_result(alt(&mut [
         &mut and_then(take_any_char, |(i, fill)| {
@@ -348,7 +348,7 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
     ))
 }
 
-/// Parses an `align` as defined in the [grammar spec][1].
+/// Parses an `align` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -362,7 +362,7 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
 /// >
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn align(input: &str) -> Option<(LeftToParse<'_>, Align)> {
     alt(&mut [
         &mut map(char('<'), |i| (i, Align::Left)),
@@ -371,7 +371,7 @@ fn align(input: &str) -> Option<(LeftToParse<'_>, Align)> {
     ])(input)
 }
 
-/// Parses a `sign` as defined in the [grammar spec][1].
+/// Parses a `sign` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -384,7 +384,7 @@ fn align(input: &str) -> Option<(LeftToParse<'_>, Align)> {
 /// -
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn sign(input: &str) -> Option<(LeftToParse<'_>, Sign)> {
     alt(&mut [
         &mut map(char('+'), |i| (i, Sign::Plus)),
@@ -392,7 +392,7 @@ fn sign(input: &str) -> Option<(LeftToParse<'_>, Sign)> {
     ])(input)
 }
 
-/// Parses a `precision` as defined in the [grammar spec][1].
+/// Parses a `precision` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -407,7 +407,7 @@ fn sign(input: &str) -> Option<(LeftToParse<'_>, Sign)> {
 /// *
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn precision(input: &str) -> Option<(LeftToParse<'_>, Precision<'_>)> {
     alt(&mut [
         &mut map(count, |(i, c)| (i, Precision::Count(c))),
@@ -415,7 +415,7 @@ fn precision(input: &str) -> Option<(LeftToParse<'_>, Precision<'_>)> {
     ])(input)
 }
 
-/// Parses a `type` as defined in the [grammar spec][1].
+/// Parses a `type` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -439,7 +439,7 @@ fn precision(input: &str) -> Option<(LeftToParse<'_>, Precision<'_>)> {
 /// ```
 ///
 /// [`type`]: type_
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn type_(input: &str) -> Option<(&str, Type)> {
     alt(&mut [
         &mut map(str("x?"), |i| (i, Type::LowerDebug)),
@@ -456,7 +456,7 @@ fn type_(input: &str) -> Option<(&str, Type)> {
     ])(input)
 }
 
-/// Parses a `count` as defined in the [grammar spec][1].
+/// Parses a `count` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -470,7 +470,7 @@ fn type_(input: &str) -> Option<(&str, Type)> {
 /// par$
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn count(input: &str) -> Option<(LeftToParse<'_>, Count<'_>)> {
     alt(&mut [
         &mut map(parameter, |(i, p)| (i, Count::Parameter(p))),
@@ -478,7 +478,7 @@ fn count(input: &str) -> Option<(LeftToParse<'_>, Count<'_>)> {
     ])(input)
 }
 
-/// Parses a `parameter` as defined in the [grammar spec][1].
+/// Parses a `parameter` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -491,12 +491,12 @@ fn count(input: &str) -> Option<(LeftToParse<'_>, Count<'_>)> {
 /// par$
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn parameter(input: &str) -> Option<(LeftToParse<'_>, Parameter<'_>)> {
     and_then(argument, |(i, arg)| map(char('$'), |i| (i, arg))(i))(input)
 }
 
-/// Parses an `identifier` as defined in the [grammar spec][1].
+/// Parses an `identifier` as defined in the [grammar spec][0].
 ///
 /// # Grammar
 ///
@@ -511,7 +511,7 @@ fn parameter(input: &str) -> Option<(LeftToParse<'_>, Parameter<'_>)> {
 /// Минск
 /// ```
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 /// [2]: https://doc.rust-lang.org/reference/identifiers.html
 fn identifier(input: &str) -> Option<(LeftToParse<'_>, Identifier<'_>)> {
     map(
@@ -526,9 +526,9 @@ fn identifier(input: &str) -> Option<(LeftToParse<'_>, Identifier<'_>)> {
     )(input)
 }
 
-/// Parses an `integer` as defined in the [grammar spec][1].
+/// Parses an `integer` as defined in the [grammar spec][0].
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn integer(input: &str) -> Option<(LeftToParse<'_>, usize)> {
     and_then(
         take_while1(check_char(|c| c.is_ascii_digit())),
@@ -536,9 +536,9 @@ fn integer(input: &str) -> Option<(LeftToParse<'_>, usize)> {
     )(input)
 }
 
-/// Parses a `text` as defined in the [grammar spec][1].
+/// Parses a `text` as defined in the [grammar spec][0].
 ///
-/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+/// [0]: std::fmt#syntax
 fn text(input: &str) -> Option<(LeftToParse<'_>, &str)> {
     take_until1(any_char, one_of("{}"))(input)
 }

--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -24,6 +24,7 @@ pub(crate) struct Format<'a> {
 /// Output of the [`format_spec`] parser.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct FormatSpec<'a> {
+    pub(crate) sign: Option<Sign>,
     pub(crate) width: Option<Width<'a>>,
     pub(crate) precision: Option<Precision<'a>>,
     pub(crate) ty: Type,
@@ -34,6 +35,13 @@ pub(crate) struct FormatSpec<'a> {
 pub(crate) enum Argument<'a> {
     Integer(usize),
     Identifier(&'a str),
+}
+
+/// Output of the [`sign`] parser.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Sign {
+    Plus,
+    Minus,
 }
 
 /// Output of the [`precision`] parser.
@@ -246,7 +254,7 @@ fn argument(input: &str) -> Option<(LeftToParse<'_>, Argument)> {
 ///
 /// # Grammar
 ///
-/// [`format_spec`]` := [[fill]align][sign]['#']['0'][width]`
+/// [`format_spec`]` := [[fill]align][`[`sign`]`]['#']['0'][width]`
 ///                     `['.' `[`precision`]`]`[`type`]
 ///
 /// # Example
@@ -268,8 +276,9 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
         identity,
     )(input);
 
+    let (input, sign) = optional_result(sign)(input);
+
     let input = seq(&mut [
-        &mut optional(one_of("+-")),
         &mut optional(char('#')),
         &mut optional(try_seq(&mut [
             &mut char('0'),
@@ -290,11 +299,33 @@ fn format_spec(input: &str) -> Option<(LeftToParse<'_>, FormatSpec<'_>)> {
     Some((
         input,
         FormatSpec {
+            sign,
             width,
             precision,
             ty,
         },
     ))
+}
+
+/// Parses a `sign` as defined in the [grammar spec][1].
+///
+/// # Grammar
+///
+/// [`sign`]` := '+' | '-'`
+///
+/// # Example
+///
+/// ```text
+/// +
+/// -
+/// ```
+///
+/// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#syntax
+fn sign(input: &str) -> Option<(LeftToParse<'_>, Sign)> {
+    alt(&mut [
+        &mut map(char('+'), |i| (i, Sign::Plus)),
+        &mut map(char('-'), |i| (i, Sign::Minus)),
+    ])(input)
 }
 
 /// Parses a `precision` as defined in the [grammar spec][1].
@@ -701,6 +732,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -714,6 +746,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -727,6 +760,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -740,6 +774,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -753,6 +788,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -766,6 +802,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Plus),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -779,6 +816,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Minus),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -792,6 +830,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -805,6 +844,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Plus),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -818,6 +858,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -831,6 +872,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Minus),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -844,6 +886,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -857,6 +900,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -870,6 +914,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Minus),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -883,6 +928,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -896,6 +942,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Plus),
                         width: None,
                         precision: None,
                         ty: Type::Display,
@@ -909,6 +956,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: Some(Count::Integer(1)),
                         precision: None,
                         ty: Type::Display,
@@ -922,6 +970,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: Some(Count::Parameter(Argument::Integer(1))),
                         precision: None,
                         ty: Type::Display,
@@ -935,6 +984,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: Some(Count::Parameter(Argument::Identifier("par"))),
                         precision: None,
                         ty: Type::Display,
@@ -948,6 +998,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Minus),
                         width: Some(Count::Parameter(Argument::Identifier("Минск"))),
                         precision: None,
                         ty: Type::Display,
@@ -961,6 +1012,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: Some(Precision::Star),
                         ty: Type::Display,
@@ -974,6 +1026,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Integer(0))),
                         ty: Type::Display,
@@ -987,6 +1040,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Integer(0),
@@ -1002,6 +1056,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1017,6 +1072,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Plus),
                         width: Some(Count::Parameter(Argument::Integer(2))),
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1032,6 +1088,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::LowerDebug,
@@ -1045,6 +1102,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: None,
                         width: None,
                         precision: None,
                         ty: Type::UpperExp,
@@ -1058,6 +1116,7 @@ mod tests {
                 formats: vec![Format {
                     arg: None,
                     spec: Some(FormatSpec {
+                        sign: Some(Sign::Plus),
                         width: Some(Count::Parameter(Argument::Identifier("par"))),
                         precision: Some(Precision::Count(Count::Parameter(
                             Argument::Identifier("par"),
@@ -1078,6 +1137,7 @@ mod tests {
                     Format {
                         arg: Some(Argument::Integer(0)),
                         spec: Some(FormatSpec {
+                            sign: None,
                             width: None,
                             precision: None,
                             ty: Type::Debug,
@@ -1086,6 +1146,7 @@ mod tests {
                     Format {
                         arg: Some(Argument::Identifier("par")),
                         spec: Some(FormatSpec {
+                            sign: None,
                             width: Some(Count::Parameter(Argument::Identifier("par"))),
                             precision: Some(Precision::Count(Count::Parameter(
                                 Argument::Identifier("a"),

--- a/impl/src/parsing.rs
+++ b/impl/src/parsing.rs
@@ -12,7 +12,7 @@ use syn::{
 };
 
 /// [`syn::Expr`] [`Parse`]ing polyfill.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Expr {
     /// [`syn::Expr::Path`] of length 1 [`Parse`]ing polyfill.
     Ident(syn::Ident),
@@ -28,6 +28,12 @@ impl Expr {
             Self::Ident(ident) => Some(ident),
             Self::Other(_) => None,
         }
+    }
+}
+
+impl From<syn::Ident> for Expr {
+    fn from(ident: syn::Ident) -> Self {
+        Self::Ident(ident)
     }
 }
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1520,7 +1520,6 @@ pub(crate) mod attr {
     #[cfg(any(
         feature = "as_ref",
         feature = "debug",
-        feature = "display",
         feature = "from",
         feature = "into",
     ))]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -155,6 +155,85 @@ mod structs {
                 assert_eq!(format!("{:#?}", Struct { field: 0 }), "Struct { .. }");
             }
         }
+
+        mod delegation {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            #[debug("{_0:?}")]
+            struct TupleDebug(i32);
+
+            #[derive(Debug)]
+            #[debug("{}", field)]
+            struct StructDisplay {
+                field: i32,
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03?}", TupleDebug(7)), "007");
+                assert_eq!(format!("{:03?}", StructDisplay { field: 7 }), "007");
+            }
+
+            mod suppressed {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                #[debug("{}", format_args!("{_0:?}"))]
+                struct TupleDebug(i32);
+
+                #[derive(Debug)]
+                #[debug("{}", format_args!("{}", field))]
+                struct StructDisplay {
+                    field: i32,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03?}", TupleDebug(7)), "7");
+                    assert_eq!(format!("{:03?}", StructDisplay { field: 7 }), "7");
+                }
+            }
+
+            mod untriggered {
+                mod on_modifiers {
+                    #[cfg(not(feature = "std"))]
+                    use alloc::format;
+
+                    use derive_more::Debug;
+
+                    #[derive(Debug)]
+                    #[debug("{_0:x?}")]
+                    struct LowerDebug(i32);
+
+                    #[derive(Debug)]
+                    #[debug("{_0:X?}")]
+                    struct UpperDebug(i32);
+
+                    #[derive(Debug)]
+                    #[debug("{:07}", _0)]
+                    struct Width(i32);
+
+                    #[derive(Debug)]
+                    #[debug("{:.5}", _0)]
+                    struct Precision(f64);
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03?}", LowerDebug(7)), "7");
+                        assert_eq!(format!("{:03?}", UpperDebug(8)), "8");
+                        assert_eq!(format!("{:03?}", Width(5)), "0000005");
+                        assert_eq!(format!("{:.3?}", Precision(1.23456789)), "1.23457");
+                    }
+                }
+            }
+        }
     }
 
     mod multi_field {
@@ -356,6 +435,33 @@ mod structs {
                 );
             }
         }
+
+        mod delegation {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            #[debug("{0:o}", _0)]
+            struct TupleOctal(i32, i64);
+
+            #[derive(Debug)]
+            #[debug("{named:e}", named = b)]
+            struct StructLowerExp {
+                a: i32,
+                b: f64,
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03?}", TupleOctal(9, 4)), "011");
+                assert_eq!(
+                    format!("{:.1?}", StructLowerExp { a: 7, b: 3.14 }),
+                    "3.1e0",
+                );
+            }
+        }
     }
 }
 
@@ -480,6 +586,80 @@ mod enums {
                 format!("{:#?}", Enum::SkippedNamed { field: 1 }),
                 "SkippedNamed { .. }",
             );
+        }
+
+        mod delegation {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            enum Enum {
+                #[debug("{_0:?}")]
+                Debug(i32),
+                #[debug("{}", field)]
+                Display { field: i32 },
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03?}", Enum::Debug(7)), "007");
+                assert_eq!(format!("{:03?}", Enum::Display { field: 7 }), "007");
+            }
+
+            mod suppressed {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                enum Enum {
+                    #[debug("{}", format_args!("{_0:?}"))]
+                    Debug(i32),
+                    #[debug("{}", format_args!("{}", field))]
+                    Display { field: i32 },
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03?}", Enum::Debug(7)), "7");
+                    assert_eq!(format!("{:03?}", Enum::Display { field: 7 }), "7");
+                }
+            }
+
+            mod untriggered {
+                mod on_modifiers {
+                    #[cfg(not(feature = "std"))]
+                    use alloc::format;
+
+                    use derive_more::Debug;
+
+                    #[derive(Debug)]
+                    enum Enum {
+                        #[debug("{_0:x?}")]
+                        LowerDebug(i32),
+                        #[debug("{_0:X?}")]
+                        UpperDebug(i32),
+                        #[debug("{:07}", _0)]
+                        Width(i32),
+                        #[debug("{:.5}", _0)]
+                        Precision(f64),
+                    }
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03?}", Enum::LowerDebug(7)), "7");
+                        assert_eq!(format!("{:03?}", Enum::UpperDebug(8)), "8");
+                        assert_eq!(format!("{:03?}", Enum::Width(5)), "0000005");
+                        assert_eq!(
+                            format!("{:.3?}", Enum::Precision(1.23456789)),
+                            "1.23457"
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -629,6 +809,30 @@ mod enums {
                 assert_eq!(
                     format!("{:?}", Enum::Fields { a: 1, b: 2 }),
                     "Format 1 String 2",
+                );
+            }
+        }
+
+        mod delegation {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            enum Enum {
+                #[debug("{0:o}", _0)]
+                TupleOctal(i32, i64),
+                #[debug("{named:e}", named = b)]
+                StructLowerExp { a: i32, b: f64 },
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03?}", Enum::TupleOctal(9, 4)), "011");
+                assert_eq!(
+                    format!("{:.1?}", Enum::StructLowerExp { a: 7, b: 3.14 }),
+                    "3.1e0",
                 );
             }
         }
@@ -1367,6 +1571,84 @@ mod generic {
                 format!("{s:#?}"),
                 "Struct(\n    WHAT_10_EVER_20,\n    20,\n)",
             );
+        }
+    }
+
+    mod delegation {
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        use derive_more::Debug;
+
+        #[derive(Debug)]
+        #[debug("{0:o}", _0)]
+        struct Tuple<T>(T);
+
+        #[derive(Debug)]
+        #[debug("{named:e}", named = b)]
+        struct Struct<A, B> {
+            a: A,
+            b: B,
+        }
+
+        #[derive(Debug)]
+        enum Enum<A, B, C> {
+            #[debug("{_0:?}")]
+            Debug(A),
+            #[debug("{}", c)]
+            Display { b: B, c: C },
+        }
+
+        #[test]
+        fn assert() {
+            assert_eq!(format!("{:03?}", Tuple(9)), "011");
+            assert_eq!(format!("{:.1?}", Struct { a: 9, b: 3.14 }), "3.1e0");
+            assert_eq!(format!("{:03?}", Enum::<_, u8, u8>::Debug(7)), "007");
+            assert_eq!(
+                format!("{:03?}", Enum::<u8, _, _>::Display { b: 7, c: 8 }),
+                "008",
+            );
+        }
+
+        mod untriggered {
+            mod on_modifiers {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                enum Enum<A, B, C, D> {
+                    #[debug("{_0:x?}")]
+                    LowerDebug(A),
+                    #[debug("{_0:X?}")]
+                    UpperDebug(B),
+                    #[debug("{:07}", _0)]
+                    Width(C),
+                    #[debug("{:.5}", _0)]
+                    Precision(D),
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(
+                        format!("{:03?}", Enum::<_, u8, u8, f64>::LowerDebug(7)),
+                        "7",
+                    );
+                    assert_eq!(
+                        format!("{:03?}", Enum::<u8, _, u8, f64>::UpperDebug(8)),
+                        "8",
+                    );
+                    assert_eq!(
+                        format!("{:03?}", Enum::<u8, u8, _, f64>::Width(5)),
+                        "0000005",
+                    );
+                    assert_eq!(
+                        format!("{:.3?}", Enum::<u8, u8, u8, _>::Precision(1.23456789)),
+                        "1.23457",
+                    );
+                }
+            }
         }
     }
 }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -97,7 +97,7 @@ mod structs {
                 assert_eq!(format!("{:03?}", Display), "011");
                 assert_eq!(format!("{:03?}", StructDebug), "011");
                 assert_eq!(format!("{:07?}", Binary), "0001011");
-                assert_eq!(format!("{:07?}", Octal), "0000111");
+                assert_eq!(format!("{:07?}", Octal), "0000013");
                 assert_eq!(format!("{:03?}", LowerHex), "00b");
                 assert_eq!(format!("{:03?}", UpperHex), "00B");
                 assert_eq!(format!("{:07?}", LowerExp), "03.14e0");
@@ -672,7 +672,7 @@ mod enums {
                 assert_eq!(format!("{:03?}", Unit::Display), "011");
                 assert_eq!(format!("{:03?}", Unit::Debug), "011");
                 assert_eq!(format!("{:07?}", Unit::Binary), "0001011");
-                assert_eq!(format!("{:07?}", Unit::Octal), "0000111");
+                assert_eq!(format!("{:07?}", Unit::Octal), "0000013");
                 assert_eq!(format!("{:03?}", Unit::LowerHex), "00b");
                 assert_eq!(format!("{:03?}", Unit::UpperHex), "00B");
                 assert_eq!(format!("{:07?}", Unit::LowerExp), "03.14e0");

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -217,6 +217,22 @@ mod structs {
                     struct UpperDebug(i32);
 
                     #[derive(Debug)]
+                    #[debug("{:^}", _0)]
+                    struct Align(i32);
+
+                    #[derive(Debug)]
+                    #[debug("{:+}", _0)]
+                    struct Sign(i32);
+
+                    #[derive(Debug)]
+                    #[debug("{:#b}", _0)]
+                    struct Alternate(i32);
+
+                    #[derive(Debug)]
+                    #[debug("{:0}", _0)]
+                    struct ZeroPadded(i32);
+
+                    #[derive(Debug)]
                     #[debug("{:07}", _0)]
                     struct Width(i32);
 
@@ -228,6 +244,10 @@ mod structs {
                     fn assert() {
                         assert_eq!(format!("{:03?}", LowerDebug(7)), "7");
                         assert_eq!(format!("{:03?}", UpperDebug(8)), "8");
+                        assert_eq!(format!("{:03?}", Align(5)), "5");
+                        assert_eq!(format!("{:03?}", Sign(5)), "+5");
+                        assert_eq!(format!("{:07?}", Alternate(5)), "0b101");
+                        assert_eq!(format!("{:07?}", ZeroPadded(-5)), "-5");
                         assert_eq!(format!("{:03?}", Width(5)), "0000005");
                         assert_eq!(format!("{:.3?}", Precision(1.23456789)), "1.23457");
                     }
@@ -642,6 +662,14 @@ mod enums {
                         LowerDebug(i32),
                         #[debug("{_0:X?}")]
                         UpperDebug(i32),
+                        #[debug("{:^}", _0)]
+                        Align(i32),
+                        #[debug("{:+}", _0)]
+                        Sign(i32),
+                        #[debug("{:#b}", _0)]
+                        Alternate(i32),
+                        #[debug("{:0}", _0)]
+                        ZeroPadded(i32),
                         #[debug("{:07}", _0)]
                         Width(i32),
                         #[debug("{:.5}", _0)]
@@ -652,10 +680,14 @@ mod enums {
                     fn assert() {
                         assert_eq!(format!("{:03?}", Enum::LowerDebug(7)), "7");
                         assert_eq!(format!("{:03?}", Enum::UpperDebug(8)), "8");
+                        assert_eq!(format!("{:03?}", Enum::Align(5)), "5");
+                        assert_eq!(format!("{:03?}", Enum::Sign(5)), "+5");
+                        assert_eq!(format!("{:07?}", Enum::Alternate(5)), "0b101");
+                        assert_eq!(format!("{:07?}", Enum::ZeroPadded(-5)), "-5");
                         assert_eq!(format!("{:03?}", Enum::Width(5)), "0000005");
                         assert_eq!(
                             format!("{:.3?}", Enum::Precision(1.23456789)),
-                            "1.23457"
+                            "1.23457",
                         );
                     }
                 }
@@ -1623,6 +1655,14 @@ mod generic {
                     LowerDebug(A),
                     #[debug("{_0:X?}")]
                     UpperDebug(B),
+                    #[debug("{:^}", _0)]
+                    Align(C),
+                    #[debug("{:+}", _0)]
+                    Sign(C),
+                    #[debug("{:#b}", _0)]
+                    Alternate(C),
+                    #[debug("{:0}", _0)]
+                    ZeroPadded(C),
                     #[debug("{:07}", _0)]
                     Width(C),
                     #[debug("{:.5}", _0)]
@@ -1638,6 +1678,22 @@ mod generic {
                     assert_eq!(
                         format!("{:03?}", Enum::<u8, _, u8, f64>::UpperDebug(8)),
                         "8",
+                    );
+                    assert_eq!(
+                        format!("{:03?}", Enum::<u8, u8, _, f64>::Align(5)),
+                        "5",
+                    );
+                    assert_eq!(
+                        format!("{:03?}", Enum::<u8, u8, _, f64>::Sign(5)),
+                        "+5",
+                    );
+                    assert_eq!(
+                        format!("{:07?}", Enum::<u8, u8, _, f64>::Alternate(5)),
+                        "0b101",
+                    );
+                    assert_eq!(
+                        format!("{:07?}", Enum::<u8, u8, _, f64>::ZeroPadded(-5)),
+                        "-5",
                     );
                     assert_eq!(
                         format!("{:03?}", Enum::<u8, u8, _, f64>::Width(5)),

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -46,7 +46,7 @@ mod structs {
             }
         }
 
-        mod delegation {
+        mod transparency {
             #[cfg(not(feature = "std"))]
             use alloc::format;
 
@@ -105,7 +105,7 @@ mod structs {
                 assert_eq!(format!("{:018?}", Pointer).len(), 18);
             }
 
-            mod untriggered {
+            mod omitted {
                 mod on_modifiers {
                     #[cfg(not(feature = "std"))]
                     use alloc::format;
@@ -272,7 +272,7 @@ mod structs {
             }
         }
 
-        mod delegation {
+        mod transparency {
             #[cfg(not(feature = "std"))]
             use alloc::format;
 
@@ -317,7 +317,7 @@ mod structs {
                 }
             }
 
-            mod untriggered {
+            mod omitted {
                 mod on_modifiers {
                     #[cfg(not(feature = "std"))]
                     use alloc::format;
@@ -572,7 +572,7 @@ mod structs {
             }
         }
 
-        mod delegation {
+        mod transparency {
             #[cfg(not(feature = "std"))]
             use alloc::format;
 
@@ -635,7 +635,7 @@ mod enums {
             assert_eq!(format!("{:#?}", Enum::Named {}), "Named");
         }
 
-        mod delegation {
+        mod transparency {
             #[cfg(not(feature = "std"))]
             use alloc::format;
 
@@ -680,7 +680,7 @@ mod enums {
                 assert_eq!(format!("{:018?}", Unit::Pointer).len(), 18);
             }
 
-            mod untriggered {
+            mod omitted {
                 mod on_modifiers {
                     #[cfg(not(feature = "std"))]
                     use alloc::format;
@@ -814,7 +814,7 @@ mod enums {
             );
         }
 
-        mod delegation {
+        mod transparency {
             #[cfg(not(feature = "std"))]
             use alloc::format;
 
@@ -855,7 +855,7 @@ mod enums {
                 }
             }
 
-            mod untriggered {
+            mod omitted {
                 mod on_modifiers {
                     #[cfg(not(feature = "std"))]
                     use alloc::format;
@@ -1051,7 +1051,7 @@ mod enums {
             }
         }
 
-        mod delegation {
+        mod transparency {
             #[cfg(not(feature = "std"))]
             use alloc::format;
 
@@ -1812,7 +1812,7 @@ mod generic {
         }
     }
 
-    mod delegation {
+    mod transparency {
         #[cfg(not(feature = "std"))]
         use alloc::format;
 
@@ -1848,7 +1848,7 @@ mod generic {
             );
         }
 
-        mod untriggered {
+        mod omitted {
             mod on_modifiers {
                 #[cfg(not(feature = "std"))]
                 use alloc::format;

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -45,6 +45,122 @@ mod structs {
                 assert_eq!(format!("{Unit:?}"), "Format String");
             }
         }
+
+        mod delegation {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
+
+            const I32: i32 = 11;
+            const F64: f64 = 3.14;
+            const POINTER: &f64 = &3.14;
+
+            #[derive(Debug)]
+            #[debug("{I32}")]
+            struct Display;
+
+            #[derive(Debug)]
+            #[debug("{I32:?}")]
+            struct StructDebug;
+
+            #[derive(Debug)]
+            #[debug("{:b}", I32)]
+            struct Binary;
+
+            #[derive(Debug)]
+            #[debug("{0:o}", I32)]
+            struct Octal;
+
+            #[derive(Debug)]
+            #[debug("{I32:x}")]
+            struct LowerHex;
+
+            #[derive(Debug)]
+            #[debug("{:X}", I32)]
+            struct UpperHex;
+
+            #[derive(Debug)]
+            #[debug("{F64:e}")]
+            struct LowerExp;
+
+            #[derive(Debug)]
+            #[debug("{named:E}", named = F64)]
+            struct UpperExp;
+
+            #[derive(Debug)]
+            #[debug("{POINTER:p}")]
+            struct Pointer;
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03?}", Display), "011");
+                assert_eq!(format!("{:03?}", StructDebug), "011");
+                assert_eq!(format!("{:07?}", Binary), "0001011");
+                assert_eq!(format!("{:07?}", Octal), "0000111");
+                assert_eq!(format!("{:03?}", LowerHex), "00b");
+                assert_eq!(format!("{:03?}", UpperHex), "00B");
+                assert_eq!(format!("{:07?}", LowerExp), "03.14e0");
+                assert_eq!(format!("{:07?}", UpperExp), "03.14E0");
+                assert_eq!(format!("{:018?}", Pointer).len(), 18);
+            }
+
+            mod untriggered {
+                mod on_modifiers {
+                    #[cfg(not(feature = "std"))]
+                    use alloc::format;
+
+                    use derive_more::Debug;
+
+                    const I32: i32 = 11;
+                    const F64: f64 = 3.14;
+
+                    #[derive(Debug)]
+                    #[debug("{I32:x?}")]
+                    struct LowerDebug;
+
+                    #[derive(Debug)]
+                    #[debug("{I32:X?}")]
+                    struct UpperDebug;
+
+                    #[derive(Debug)]
+                    #[debug("{:^}", I32)]
+                    struct Align;
+
+                    #[derive(Debug)]
+                    #[debug("{:+}", I32)]
+                    struct Sign;
+
+                    #[derive(Debug)]
+                    #[debug("{:#b}", I32)]
+                    struct Alternate;
+
+                    #[derive(Debug)]
+                    #[debug("{:0}", I32)]
+                    struct ZeroPadded;
+
+                    #[derive(Debug)]
+                    #[debug("{:07}", I32)]
+                    struct Width;
+
+                    #[derive(Debug)]
+                    #[debug("{:.1}", F64)]
+                    struct Precision;
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03?}", LowerDebug), "b");
+                        assert_eq!(format!("{:03?}", UpperDebug), "B");
+                        assert_eq!(format!("{:03?}", Align), "11");
+                        assert_eq!(format!("{:04?}", Sign), "+11");
+                        assert_eq!(format!("{:07?}", Alternate), "0b1011");
+                        assert_eq!(format!("{:07?}", ZeroPadded), "11");
+                        assert_eq!(format!("{:03?}", Width), "0000011");
+                        assert_eq!(format!("{:.3?}", Precision), "3.1");
+                    }
+                }
+            }
+        }
     }
 
     mod single_field {
@@ -517,6 +633,96 @@ mod enums {
             assert_eq!(format!("{:#?}", Enum::Unnamed()), "Unnamed");
             assert_eq!(format!("{:?}", Enum::Named {}), "Named");
             assert_eq!(format!("{:#?}", Enum::Named {}), "Named");
+        }
+
+        mod delegation {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
+            use derive_more::Debug;
+
+            const I32: i32 = 11;
+            const F64: f64 = 3.14;
+            const POINTER: &f64 = &3.14;
+
+            #[derive(Debug)]
+            enum Unit {
+                #[debug("{I32}")]
+                Display,
+                #[debug("{I32:?}")]
+                Debug,
+                #[debug("{:b}", I32)]
+                Binary,
+                #[debug("{0:o}", I32)]
+                Octal,
+                #[debug("{I32:x}")]
+                LowerHex,
+                #[debug("{:X}", I32)]
+                UpperHex,
+                #[debug("{F64:e}")]
+                LowerExp,
+                #[debug("{named:E}", named = F64)]
+                UpperExp,
+                #[debug("{POINTER:p}")]
+                Pointer,
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03?}", Unit::Display), "011");
+                assert_eq!(format!("{:03?}", Unit::Debug), "011");
+                assert_eq!(format!("{:07?}", Unit::Binary), "0001011");
+                assert_eq!(format!("{:07?}", Unit::Octal), "0000111");
+                assert_eq!(format!("{:03?}", Unit::LowerHex), "00b");
+                assert_eq!(format!("{:03?}", Unit::UpperHex), "00B");
+                assert_eq!(format!("{:07?}", Unit::LowerExp), "03.14e0");
+                assert_eq!(format!("{:07?}", Unit::UpperExp), "03.14E0");
+                assert_eq!(format!("{:018?}", Unit::Pointer).len(), 18);
+            }
+
+            mod untriggered {
+                mod on_modifiers {
+                    #[cfg(not(feature = "std"))]
+                    use alloc::format;
+
+                    use derive_more::Debug;
+
+                    const I32: i32 = 11;
+                    const F64: f64 = 3.14;
+
+                    #[derive(Debug)]
+                    enum Unit {
+                        #[debug("{I32:x?}")]
+                        LowerDebug,
+                        #[debug("{I32:X?}")]
+                        UpperDebug,
+                        #[debug("{:^}", I32)]
+                        Align,
+                        #[debug("{:+}", I32)]
+                        Sign,
+                        #[debug("{:#b}", I32)]
+                        Alternate,
+                        #[debug("{:0}", I32)]
+                        ZeroPadded,
+                        #[debug("{:07}", I32)]
+                        Width,
+                        #[debug("{:.1}", F64)]
+                        Precision,
+                    }
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03?}", Unit::LowerDebug), "b");
+                        assert_eq!(format!("{:03?}", Unit::UpperDebug), "B");
+                        assert_eq!(format!("{:03?}", Unit::Align), "11");
+                        assert_eq!(format!("{:04?}", Unit::Sign), "+11");
+                        assert_eq!(format!("{:07?}", Unit::Alternate), "0b1011");
+                        assert_eq!(format!("{:07?}", Unit::ZeroPadded), "11");
+                        assert_eq!(format!("{:03?}", Unit::Width), "0000011");
+                        assert_eq!(format!("{:.3?}", Unit::Precision), "3.1");
+                    }
+                }
+            }
         }
     }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -135,7 +135,7 @@ mod structs {
                     assert_eq!(format!("{:03}", Display), "011");
                     assert_eq!(format!("{:03}", Debug), "011");
                     assert_eq!(format!("{:07}", Binary), "0001011");
-                    assert_eq!(format!("{:07}", Octal), "0000111");
+                    assert_eq!(format!("{:07}", Octal), "0000013");
                     assert_eq!(format!("{:03}", LowerHex), "00b");
                     assert_eq!(format!("{:03}", UpperHex), "00B");
                     assert_eq!(format!("{:07}", LowerExp), "03.14e0");
@@ -758,7 +758,7 @@ mod enums {
                     assert_eq!(format!("{:03}", Unit::Display), "011");
                     assert_eq!(format!("{:03}", Unit::Debug), "011");
                     assert_eq!(format!("{:07}", Unit::Binary), "0001011");
-                    assert_eq!(format!("{:07}", Unit::Octal), "0000111");
+                    assert_eq!(format!("{:07}", Unit::Octal), "0000013");
                     assert_eq!(format!("{:03}", Unit::LowerHex), "00b");
                     assert_eq!(format!("{:03}", Unit::UpperHex), "00B");
                     assert_eq!(format!("{:07}", Unit::LowerExp), "03.14e0");

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -226,11 +226,11 @@ mod structs {
                 struct TupleDebug(i32);
 
                 #[derive(Display)]
-                #[display("{_0:b}")]
+                #[display("{:b}", _0)]
                 struct TupleBinary(i32);
 
                 #[derive(Display)]
-                #[display("{:o}", _0)]
+                #[display("{0:o}", _0)]
                 struct TupleOctal(i32);
 
                 #[derive(Display)]
@@ -252,7 +252,7 @@ mod structs {
                 }
 
                 #[derive(Display)]
-                #[display("{:E}", field)]
+                #[display("{named:E}", named = field)]
                 struct StructUpperExp {
                     field: f64,
                 }
@@ -357,6 +357,38 @@ mod structs {
                     );
                 }
             }
+
+            mod untriggered {
+                use super::*;
+
+                mod on_modifiers {
+                    use super::*;
+
+                    #[derive(Display)]
+                    #[display("{_0:x?}")]
+                    struct LowerDebug(i32);
+
+                    #[derive(Display)]
+                    #[display("{_0:X?}")]
+                    struct UpperDebug(i32);
+
+                    #[derive(Display)]
+                    #[display("{:07}", _0)]
+                    struct Width(i32);
+
+                    #[derive(Display)]
+                    #[display("{:.5}", _0)]
+                    struct Precision(f64);
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03}", LowerDebug(7)), "7");
+                        assert_eq!(format!("{:03}", UpperDebug(8)), "8");
+                        assert_eq!(format!("{:03}", Width(5)), "0000005");
+                        assert_eq!(format!("{:.3}", Precision(1.23456789)), "1.23457");
+                    }
+                }
+            }
         }
     }
 
@@ -436,15 +468,15 @@ mod structs {
                 struct TupleDisplay(i32, u64);
 
                 #[derive(Display)]
-                #[display("{_1:?}")]
+                #[display("{:?}", _1)]
                 struct TupleDebug(i32, u64);
 
                 #[derive(Display)]
-                #[display("{_1:b}")]
+                #[display("{0:b}", _1)]
                 struct TupleBinary(i32, u64);
 
                 #[derive(Display)]
-                #[display("{:o}", _0)]
+                #[display("{named:o}", named = _0)]
                 struct TupleOctal(i32, u64);
 
                 #[derive(Display)]
@@ -681,9 +713,9 @@ mod enums {
 
                 #[derive(Display)]
                 enum Debug {
-                    #[display("{_0:?}")]
+                    #[display("{0:?}", _0)]
                     A(i32),
-                    #[display("{:?}", field)]
+                    #[display("{named:?}", named = field)]
                     B { field: u8 },
                 }
 
@@ -931,9 +963,9 @@ mod enums {
 
                 #[derive(Display)]
                 enum Debug {
-                    #[display("{_1:?}")]
+                    #[display("{0:?}", _1)]
                     A(i32, i64),
-                    #[display("{:?}", a)]
+                    #[display("{named:?}", named = a)]
                     B { a: u8, b: i32 },
                 }
 
@@ -1629,7 +1661,7 @@ mod generic {
             struct TupleDisplay<T>(T);
 
             #[derive(Display)]
-            #[display("{_0:?}")]
+            #[display("{0:?}", _0)]
             struct TupleDebug<T>(T);
 
             #[derive(Display)]
@@ -1641,7 +1673,7 @@ mod generic {
             struct TupleOctal<Y, T>(Y, T);
 
             #[derive(Display)]
-            #[display("{_0:x}")]
+            #[display("{0:x}", _0)]
             struct TupleLowerHex<T>(T);
 
             #[derive(Display)]
@@ -1674,7 +1706,7 @@ mod generic {
             }
 
             #[derive(Display)]
-            #[display("{b:o}")]
+            #[display("{named:o}", named = b)]
             struct StructOctal<Y, T> {
                 a: Y,
                 b: T,

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -351,9 +351,9 @@ mod structs {
                         format!("{:07}", StructUpperExp { field: 42.0 }),
                         "4.2E1",
                     );
-                    assert_eq!(
+                    assert_ne!(
                         format!("{:018}", StructPointer { field: &42 }).len(),
-                        11,
+                        18,
                     );
                 }
             }
@@ -897,8 +897,8 @@ mod enums {
                     assert_eq!(format!("{:07}", LowerExp::B { field: 43.0 }), "4.3e1");
                     assert_eq!(format!("{:07}", UpperExp::A(42.0)), "4.2E1");
                     assert_eq!(format!("{:07}", UpperExp::B { field: 43.0 }), "4.3E1");
-                    assert_eq!(format!("{:018}", Pointer::A(&7)).len(), 11);
-                    assert_eq!(format!("{:018}", Pointer::B { field: &42 }).len(), 11);
+                    assert_ne!(format!("{:018}", Pointer::A(&7)).len(), 18);
+                    assert_ne!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
                 }
             }
         }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -222,6 +222,10 @@ mod structs {
                 struct TupleDisplay(i32);
 
                 #[derive(Display)]
+                #[display("{_0:?}")]
+                struct TupleDebug(i32);
+
+                #[derive(Display)]
                 #[display("{_0:b}")]
                 struct TupleBinary(i32);
 
@@ -262,6 +266,7 @@ mod structs {
                 #[test]
                 fn assert() {
                     assert_eq!(format!("{:03}", TupleDisplay(7)), "007");
+                    assert_eq!(format!("{:03}", TupleDebug(8)), "008");
                     assert_eq!(format!("{:07}", TupleBinary(7)), "0000111");
                     assert_eq!(format!("{:03}", TupleOctal(9)), "011");
                     assert_eq!(format!("{:03}", StructLowerHex { field: 42 }), "02a");
@@ -359,6 +364,10 @@ mod structs {
                 struct TupleDisplay(i32, u64);
 
                 #[derive(Display)]
+                #[display("{_1:?}")]
+                struct TupleDebug(i32, u64);
+
+                #[derive(Display)]
                 #[display("{_1:b}")]
                 struct TupleBinary(i32, u64);
 
@@ -404,6 +413,7 @@ mod structs {
                 #[test]
                 fn assert() {
                     assert_eq!(format!("{:03}", TupleDisplay(7, 8)), "007");
+                    assert_eq!(format!("{:03}", TupleDebug(7, 8)), "008");
                     assert_eq!(format!("{:07}", TupleBinary(6, 7)), "0000111");
                     assert_eq!(format!("{:03}", TupleOctal(9, 10)), "011");
                     assert_eq!(
@@ -598,6 +608,14 @@ mod enums {
                 }
 
                 #[derive(Display)]
+                enum Debug {
+                    #[display("{_0:?}")]
+                    A(i32),
+                    #[display("{:?}", field)]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
                 enum Binary {
                     #[display("{_0:b}")]
                     A(i32),
@@ -657,6 +675,8 @@ mod enums {
                 fn assert() {
                     assert_eq!(format!("{:03}", Display::A(7)), "007");
                     assert_eq!(format!("{:03}", Display::B { field: 8 }), "008");
+                    assert_eq!(format!("{:03}", Debug::A(8)), "008");
+                    assert_eq!(format!("{:03}", Debug::B { field: 9 }), "009");
                     assert_eq!(format!("{:07}", Binary::A(7)), "0000111");
                     assert_eq!(format!("{:07}", Binary::B { field: 8 }), "0001000");
                     assert_eq!(format!("{:03}", Octal::A(9)), "011");
@@ -740,6 +760,14 @@ mod enums {
                 }
 
                 #[derive(Display)]
+                enum Debug {
+                    #[display("{_1:?}")]
+                    A(i32, i64),
+                    #[display("{:?}", a)]
+                    B { a: u8, b: i32 },
+                }
+
+                #[derive(Display)]
                 enum Binary {
                     #[display("{_0:b}")]
                     A(i32, i64),
@@ -799,6 +827,8 @@ mod enums {
                 fn assert() {
                     assert_eq!(format!("{:03}", Display::A(7, 8)), "007");
                     assert_eq!(format!("{:03}", Display::B { a: 7, b: 8 }), "008");
+                    assert_eq!(format!("{:03}", Debug::A(7, 8)), "008");
+                    assert_eq!(format!("{:03}", Debug::B { a: 7, b: 8 }), "007");
                     assert_eq!(format!("{:07}", Binary::A(7, 8)), "0000111");
                     assert_eq!(format!("{:07}", Binary::B { a: 7, b: 8 }), "0001000");
                     assert_eq!(format!("{:03}", Octal::A(9, 10)), "011");
@@ -1429,6 +1459,10 @@ mod generic {
             struct TupleDisplay<T>(T);
 
             #[derive(Display)]
+            #[display("{_0:?}")]
+            struct TupleDebug<T>(T);
+
+            #[derive(Display)]
             #[display("{_0:b}")]
             struct TupleBinary<T, Y>(T, Y);
 
@@ -1573,6 +1607,7 @@ mod generic {
             #[test]
             fn assert() {
                 assert_eq!(format!("{:03}", TupleDisplay(7)), "007");
+                assert_eq!(format!("{:03}", TupleDebug(8)), "008");
                 assert_eq!(format!("{:03}", StructDisplay { field: 7 }), "007");
                 assert_eq!(format!("{:03}", EnumDisplay::<_, i8>::A(7)), "007");
                 assert_eq!(

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -84,7 +84,7 @@ mod structs {
             }
         }
 
-        mod delegation {
+        mod transparency {
             use super::*;
 
             mod interpolated {
@@ -144,7 +144,7 @@ mod structs {
                 }
             }
 
-            mod untriggered {
+            mod omitted {
                 use super::*;
 
                 mod on_modifiers {
@@ -268,7 +268,7 @@ mod structs {
             }
         }
 
-        mod delegation {
+        mod transparency {
             use super::*;
 
             mod direct {
@@ -474,7 +474,7 @@ mod structs {
                 }
             }
 
-            mod untriggered {
+            mod omitted {
                 use super::*;
 
                 mod on_modifiers {
@@ -593,7 +593,7 @@ mod structs {
             }
         }
 
-        mod delegation {
+        mod transparency {
             use super::*;
 
             mod interpolated {
@@ -721,7 +721,7 @@ mod enums {
             assert_eq!(Enum::StrNamed {}.to_string(), "STR_NAMED");
         }
 
-        mod delegation {
+        mod transparency {
             use super::*;
 
             mod interpolated {
@@ -767,7 +767,7 @@ mod enums {
                 }
             }
 
-            mod untriggered {
+            mod omitted {
                 use super::*;
 
                 mod on_modifiers {
@@ -845,7 +845,7 @@ mod enums {
             assert_eq!(Enum::InterpolatedNamed { field: 1 }.to_string(), "1 1");
         }
 
-        mod delegation {
+        mod transparency {
             use super::*;
 
             mod direct {
@@ -1173,7 +1173,7 @@ mod enums {
             );
         }
 
-        mod delegation {
+        mod transparency {
             use super::*;
 
             mod interpolated {
@@ -1807,7 +1807,7 @@ mod generic {
         }
     }
 
-    mod delegation {
+    mod transparency {
         use super::*;
 
         mod direct {
@@ -2100,7 +2100,7 @@ mod generic {
             }
         }
 
-        mod untriggered {
+        mod omitted {
             use super::*;
 
             mod on_modifiers {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -12,7 +12,9 @@ use alloc::{
     vec::Vec,
 };
 
-use derive_more::{Binary, Display, Octal, UpperHex};
+use derive_more::{
+    Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+};
 
 mod structs {
     use super::*;
@@ -149,6 +151,69 @@ mod structs {
                 assert_eq!(Struct { field: 0 }.to_string(), "struct: 0 0");
             }
         }
+
+        mod delegation {
+            use super::*;
+
+            mod direct {
+                use super::*;
+
+                #[derive(Display)]
+                struct TupleDisplay(i32);
+
+                #[derive(Binary)]
+                struct TupleBinary(i32);
+
+                #[derive(Octal)]
+                struct TupleOctal(i32);
+
+                #[derive(LowerHex)]
+                struct StructLowerHex {
+                    field: i32,
+                }
+
+                #[derive(UpperHex)]
+                struct StructUpperHex {
+                    field: i32,
+                }
+
+                #[derive(LowerExp)]
+                struct StructLowerExp {
+                    field: f64,
+                }
+
+                #[derive(UpperExp)]
+                struct StructUpperExp {
+                    field: f64,
+                }
+
+                #[derive(Pointer)]
+                struct StructPointer<'a> {
+                    field: &'a i32,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", TupleDisplay(7)), "007");
+                    assert_eq!(format!("{:07b}", TupleBinary(7)), "0000111");
+                    assert_eq!(format!("{:03o}", TupleOctal(9)), "011");
+                    assert_eq!(format!("{:03x}", StructLowerHex { field: 42 }), "02a");
+                    assert_eq!(format!("{:03X}", StructUpperHex { field: 42 }), "02A");
+                    assert_eq!(
+                        format!("{:07e}", StructLowerExp { field: 42.0 }),
+                        "004.2e1",
+                    );
+                    assert_eq!(
+                        format!("{:07E}", StructUpperExp { field: 42.0 }),
+                        "004.2E1",
+                    );
+                    assert_eq!(
+                        format!("{:018p}", StructPointer { field: &42 }).len(),
+                        18,
+                    );
+                }
+            }
+        }
     }
 
     mod multi_field {
@@ -187,15 +252,15 @@ mod structs {
 
             #[derive(Display)]
             #[display(
-            "{_0} {ident} {_1} {} {}",
-            _1, _0 + _1, ident = 123, _1 = _0,
+                "{_0} {ident} {_1} {} {}",
+                _1, _0 + _1, ident = 123, _1 = _0,
             )]
             struct Tuple(i32, i32);
 
             #[derive(Display)]
             #[display(
-            "{field1} {ident} {field2} {} {}",
-            field2, field1 + field2, ident = 123, field2 = field1,
+                "{field1} {ident} {field2} {} {}",
+                field2, field1 + field2, ident = 123, field2 = field1,
             )]
             struct Struct {
                 field1: i32,
@@ -289,6 +354,88 @@ mod enums {
             assert_eq!(Enum::StrNamed { field: 1 }.to_string(), "named");
             assert_eq!(Enum::InterpolatedUnnamed(1).to_string(), "1 1");
             assert_eq!(Enum::InterpolatedNamed { field: 1 }.to_string(), "1 1");
+        }
+
+        mod delegation {
+            use super::*;
+
+            mod direct {
+                use super::*;
+
+                #[derive(Display)]
+                enum Display {
+                    A(i32),
+                    B { field: u8 },
+                }
+
+                #[derive(Binary)]
+                enum Binary {
+                    A(i32),
+                    B { field: u8 },
+                }
+
+                #[derive(Octal)]
+                enum Octal {
+                    A(i32),
+                    B { field: u8 },
+                }
+
+                #[derive(LowerHex)]
+                enum LowerHex {
+                    A(i32),
+                    B { field: u8 },
+                }
+
+                #[derive(UpperHex)]
+                enum UpperHex {
+                    A(i32),
+                    B { field: u8 },
+                }
+
+                #[derive(LowerExp)]
+                enum LowerExp {
+                    A(f64),
+                    B { field: f32 },
+                }
+
+                #[derive(UpperExp)]
+                enum UpperExp {
+                    A(f64),
+                    B { field: f32 },
+                }
+
+                #[derive(Pointer)]
+                enum Pointer<'a> {
+                    A(&'a i32),
+                    B { field: &'a u8 },
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", Display::A(7)), "007");
+                    assert_eq!(format!("{:03}", Display::B { field: 8 }), "008");
+                    assert_eq!(format!("{:07b}", Binary::A(7)), "0000111");
+                    assert_eq!(format!("{:07b}", Binary::B { field: 8 }), "0001000");
+                    assert_eq!(format!("{:03o}", Octal::A(9)), "011");
+                    assert_eq!(format!("{:03o}", Octal::B { field: 10 }), "012");
+                    assert_eq!(format!("{:03x}", LowerHex::A(42)), "02a");
+                    assert_eq!(format!("{:03x}", LowerHex::B { field: 43 }), "02b");
+                    assert_eq!(format!("{:03X}", UpperHex::A(42)), "02A");
+                    assert_eq!(format!("{:03X}", UpperHex::B { field: 43 }), "02B");
+                    assert_eq!(format!("{:07e}", LowerExp::A(42.0)), "004.2e1");
+                    assert_eq!(
+                        format!("{:07e}", LowerExp::B { field: 43.0 }),
+                        "004.3e1",
+                    );
+                    assert_eq!(format!("{:07E}", UpperExp::A(42.0)), "004.2E1");
+                    assert_eq!(
+                        format!("{:07E}", UpperExp::B { field: 43.0 }),
+                        "004.3E1",
+                    );
+                    assert_eq!(format!("{:018p}", Pointer::A(&7)).len(), 18);
+                    assert_eq!(format!("{:018p}", Pointer::B { field: &42 }).len(), 18);
+                }
+            }
         }
     }
 
@@ -855,6 +1002,79 @@ mod generic {
 
             let s = Struct(NoDisplay);
             assert_eq!(s.to_string(), "no display");
+        }
+    }
+
+    mod delegation {
+        use super::*;
+
+        mod direct {
+            use super::*;
+
+            #[derive(
+                Display, Binary, Octal, LowerHex, UpperHex, LowerExp, UpperExp, Pointer
+            )]
+            struct Tuple<T>(T);
+
+            #[derive(
+                Display, Binary, Octal, LowerHex, UpperHex, LowerExp, UpperExp, Pointer
+            )]
+            struct Struct<T> {
+                field: T,
+            }
+
+            #[derive(
+                Display, Binary, Octal, LowerHex, UpperHex, LowerExp, UpperExp, Pointer
+            )]
+            enum Enum<A, B> {
+                A(A),
+                B { field: B },
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03}", Tuple(7)), "007");
+                assert_eq!(format!("{:03}", Struct { field: 7 }), "007");
+                assert_eq!(format!("{:03}", Enum::<_, i8>::A(7)), "007");
+                assert_eq!(format!("{:03}", Enum::<i8, _>::B { field: 8 }), "008");
+                assert_eq!(format!("{:07b}", Tuple(7)), "0000111");
+                assert_eq!(format!("{:07b}", Struct { field: 7 }), "0000111");
+                assert_eq!(format!("{:07b}", Enum::<_, i8>::A(7)), "0000111");
+                assert_eq!(format!("{:07b}", Enum::<i8, _>::B { field: 8 }), "0001000");
+                assert_eq!(format!("{:03o}", Tuple(9)), "011");
+                assert_eq!(format!("{:03o}", Struct { field: 9 }), "011");
+                assert_eq!(format!("{:03o}", Enum::<_, i8>::A(9)), "011");
+                assert_eq!(format!("{:03o}", Enum::<i8, _>::B { field: 10 }), "012");
+                assert_eq!(format!("{:03x}", Tuple(42)), "02a");
+                assert_eq!(format!("{:03x}", Struct { field: 42 }), "02a");
+                assert_eq!(format!("{:03x}", Enum::<_, i8>::A(42)), "02a");
+                assert_eq!(format!("{:03x}", Enum::<i8, _>::B { field: 43 }), "02b");
+                assert_eq!(format!("{:03X}", Tuple(42)), "02A");
+                assert_eq!(format!("{:03X}", Struct { field: 42 }), "02A");
+                assert_eq!(format!("{:03X}", Enum::<_, i8>::A(42)), "02A");
+                assert_eq!(format!("{:03X}", Enum::<i8, _>::B { field: 43 }), "02B");
+                assert_eq!(format!("{:07e}", Tuple(42.0)), "004.2e1");
+                assert_eq!(format!("{:07e}", Struct { field: 42.0 }), "004.2e1");
+                assert_eq!(format!("{:07e}", Enum::<_, i8>::A(42.0)), "004.2e1");
+                assert_eq!(
+                    format!("{:07e}", Enum::<i8, _>::B { field: 43.0 }),
+                    "004.3e1",
+                );
+                assert_eq!(format!("{:07E}", Tuple(42.0)), "004.2E1");
+                assert_eq!(format!("{:07E}", Struct { field: 42.0 }), "004.2E1");
+                assert_eq!(format!("{:07E}", Enum::<_, i8>::A(42.0)), "004.2E1");
+                assert_eq!(
+                    format!("{:07E}", Enum::<i8, _>::B { field: 43.0 }),
+                    "004.3E1",
+                );
+                assert_eq!(format!("{:018p}", Tuple(&42)).len(), 18);
+                assert_eq!(format!("{:018p}", Struct { field: &42 }).len(), 18);
+                assert_eq!(format!("{:018p}", Enum::<_, &i8>::A(&7)).len(), 18);
+                assert_eq!(
+                    format!("{:018p}", Enum::<&i8, _>::B { field: &42 }).len(),
+                    18,
+                );
+            }
         }
     }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -213,6 +213,73 @@ mod structs {
                     );
                 }
             }
+
+            mod interpolated {
+                use super::*;
+
+                #[derive(Display)]
+                #[display("{_0}")]
+                struct TupleDisplay(i32);
+
+                #[derive(Display)]
+                #[display("{_0:b}")]
+                struct TupleBinary(i32);
+
+                #[derive(Display)]
+                #[display("{:o}", _0)]
+                struct TupleOctal(i32);
+
+                #[derive(Display)]
+                #[display("{field:x}")]
+                struct StructLowerHex {
+                    field: i32,
+                }
+
+                #[derive(Display)]
+                #[display("{:X}", field)]
+                struct StructUpperHex {
+                    field: i32,
+                }
+
+                #[derive(Display)]
+                #[display("{field:e}")]
+                struct StructLowerExp {
+                    field: f64,
+                }
+
+                #[derive(Display)]
+                #[display("{:E}", field)]
+                struct StructUpperExp {
+                    field: f64,
+                }
+
+                #[derive(Display)]
+                #[display("{field:p}")]
+                struct StructPointer<'a> {
+                    field: &'a i32,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", TupleDisplay(7)), "007");
+                    assert_eq!(format!("{:07}", TupleBinary(7)), "0000111");
+                    assert_eq!(format!("{:03}", TupleOctal(9)), "011");
+                    assert_eq!(format!("{:03}", StructLowerHex { field: 42 }), "02a");
+                    assert_eq!(format!("{:03}", StructUpperHex { field: 42 }), "02A");
+                    assert_eq!(
+                        format!("{:07}", StructLowerExp { field: 42.0 }),
+                        "004.2e1",
+                    );
+                    assert_eq!(
+                        format!("{:07}", StructUpperExp { field: 42.0 }),
+                        "004.2E1",
+                    );
+                    assert_eq!(
+                        format!("{:018}", StructPointer { field: &42 }).len(),
+                        18,
+                    );
+                }
+            }
         }
     }
 
@@ -434,6 +501,100 @@ mod enums {
                     );
                     assert_eq!(format!("{:018p}", Pointer::A(&7)).len(), 18);
                     assert_eq!(format!("{:018p}", Pointer::B { field: &42 }).len(), 18);
+                }
+            }
+
+            mod interpolated {
+                use super::*;
+
+                #[derive(Display)]
+                enum Display {
+                    #[display("{_0}")]
+                    A(i32),
+                    #[display("{}", field)]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum Binary {
+                    #[display("{_0:b}")]
+                    A(i32),
+                    #[display("{:b}", field)]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum Octal {
+                    #[display("{_0:o}")]
+                    A(i32),
+                    #[display("{:o}", field)]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum LowerHex {
+                    #[display("{_0:x}")]
+                    A(i32),
+                    #[display("{:x}", field)]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum UpperHex {
+                    #[display("{_0:X}")]
+                    A(i32),
+                    #[display("{:X}", field)]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum LowerExp {
+                    #[display("{:e}", _0)]
+                    A(f64),
+                    #[display("{field:e}")]
+                    B { field: f32 },
+                }
+
+                #[derive(Display)]
+                enum UpperExp {
+                    #[display("{:E}", _0)]
+                    A(f64),
+                    #[display("{field:E}")]
+                    B { field: f32 },
+                }
+
+                #[derive(Display)]
+                enum Pointer<'a> {
+                    #[display("{:p}", _0)]
+                    A(&'a i32),
+                    #[display("{field:p}")]
+                    B { field: &'a u8 },
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", Display::A(7)), "007");
+                    assert_eq!(format!("{:03}", Display::B { field: 8 }), "008");
+                    assert_eq!(format!("{:07}", Binary::A(7)), "0000111");
+                    assert_eq!(format!("{:07}", Binary::B { field: 8 }), "0001000");
+                    assert_eq!(format!("{:03}", Octal::A(9)), "011");
+                    assert_eq!(format!("{:03}", Octal::B { field: 10 }), "012");
+                    assert_eq!(format!("{:03}", LowerHex::A(42)), "02a");
+                    assert_eq!(format!("{:03}", LowerHex::B { field: 43 }), "02b");
+                    assert_eq!(format!("{:03}", UpperHex::A(42)), "02A");
+                    assert_eq!(format!("{:03}", UpperHex::B { field: 43 }), "02B");
+                    assert_eq!(format!("{:07}", LowerExp::A(42.0)), "004.2e1");
+                    assert_eq!(
+                        format!("{:07}", LowerExp::B { field: 43.0 }),
+                        "004.3e1",
+                    );
+                    assert_eq!(format!("{:07}", UpperExp::A(42.0)), "004.2E1");
+                    assert_eq!(
+                        format!("{:07}", UpperExp::B { field: 43.0 }),
+                        "004.3E1",
+                    );
+                    assert_eq!(format!("{:018}", Pointer::A(&7)).len(), 18);
+                    assert_eq!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
                 }
             }
         }
@@ -1072,6 +1233,214 @@ mod generic {
                 assert_eq!(format!("{:018p}", Enum::<_, &i8>::A(&7)).len(), 18);
                 assert_eq!(
                     format!("{:018p}", Enum::<&i8, _>::B { field: &42 }).len(),
+                    18,
+                );
+            }
+        }
+
+        mod interpolated {
+            use super::*;
+
+            #[derive(Display)]
+            #[display("{_0}")]
+            struct TupleDisplay<T>(T);
+
+            #[derive(Display)]
+            #[display("{_0:b}")]
+            struct TupleBinary<T>(T);
+
+            #[derive(Display)]
+            #[display("{_0:o}")]
+            struct TupleOctal<T>(T);
+
+            #[derive(Display)]
+            #[display("{_0:x}")]
+            struct TupleLowerHex<T>(T);
+
+            #[derive(Display)]
+            #[display("{_0:X}")]
+            struct TupleUpperHex<T>(T);
+
+            #[derive(Display)]
+            #[display("{:e}", _0)]
+            struct TupleLowerExp<T>(T);
+
+            #[derive(Display)]
+            #[display("{:E}", _0)]
+            struct TupleUpperExp<T>(T);
+
+            #[derive(Display)]
+            #[display("{:p}", _0)]
+            struct TuplePointer<T>(T);
+
+            #[derive(Display)]
+            #[display("{field}")]
+            struct StructDisplay<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{field:b}")]
+            struct StructBinary<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{field:o}")]
+            struct StructOctal<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{field:x}")]
+            struct StructLowerHex<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{field:X}")]
+            struct StructUpperHex<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{:e}", field)]
+            struct StructLowerExp<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{:E}", field)]
+            struct StructUpperExp<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            #[display("{:p}", field)]
+            struct StructPointer<T> {
+                field: T,
+            }
+
+            #[derive(Display)]
+            enum EnumDisplay<A, B> {
+                #[display("{_0}")]
+                A(A),
+                #[display("{}", field)]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumBinary<A, B> {
+                #[display("{_0:b}")]
+                A(A),
+                #[display("{:b}", field)]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumOctal<A, B> {
+                #[display("{_0:o}")]
+                A(A),
+                #[display("{:o}", field)]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumLowerHex<A, B> {
+                #[display("{_0:x}")]
+                A(A),
+                #[display("{:x}", field)]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumUpperHex<A, B> {
+                #[display("{_0:X}")]
+                A(A),
+                #[display("{:X}", field)]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumLowerExp<A, B> {
+                #[display("{:e}", _0)]
+                A(A),
+                #[display("{field:e}")]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumUpperExp<A, B> {
+                #[display("{:E}", _0)]
+                A(A),
+                #[display("{field:E}")]
+                B { field: B },
+            }
+
+            #[derive(Display)]
+            enum EnumPointer<A, B> {
+                #[display("{:p}", _0)]
+                A(A),
+                #[display("{field:p}")]
+                B { field: B },
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:03}", TupleDisplay(7)), "007");
+                assert_eq!(format!("{:03}", StructDisplay { field: 7 }), "007");
+                assert_eq!(format!("{:03}", EnumDisplay::<_, i8>::A(7)), "007");
+                assert_eq!(
+                    format!("{:03}", EnumDisplay::<i8, _>::B { field: 8 }),
+                    "008"
+                );
+                assert_eq!(format!("{:07}", TupleBinary(7)), "0000111");
+                assert_eq!(format!("{:07}", StructBinary { field: 7 }), "0000111");
+                assert_eq!(format!("{:07}", EnumBinary::<_, i8>::A(7)), "0000111");
+                assert_eq!(
+                    format!("{:07}", EnumBinary::<i8, _>::B { field: 8 }),
+                    "0001000"
+                );
+                assert_eq!(format!("{:03}", TupleOctal(9)), "011");
+                assert_eq!(format!("{:03}", StructOctal { field: 9 }), "011");
+                assert_eq!(format!("{:03}", EnumOctal::<_, i8>::A(9)), "011");
+                assert_eq!(
+                    format!("{:03}", EnumOctal::<i8, _>::B { field: 10 }),
+                    "012"
+                );
+                assert_eq!(format!("{:03}", TupleLowerHex(42)), "02a");
+                assert_eq!(format!("{:03}", StructLowerHex { field: 42 }), "02a");
+                assert_eq!(format!("{:03}", EnumLowerHex::<_, i8>::A(42)), "02a");
+                assert_eq!(
+                    format!("{:03}", EnumLowerHex::<i8, _>::B { field: 43 }),
+                    "02b"
+                );
+                assert_eq!(format!("{:03}", TupleUpperHex(42)), "02A");
+                assert_eq!(format!("{:03}", StructUpperHex { field: 42 }), "02A");
+                assert_eq!(format!("{:03}", EnumUpperHex::<_, i8>::A(42)), "02A");
+                assert_eq!(
+                    format!("{:03}", EnumUpperHex::<i8, _>::B { field: 43 }),
+                    "02B"
+                );
+                assert_eq!(format!("{:07}", TupleLowerExp(42.0)), "004.2e1");
+                assert_eq!(format!("{:07}", StructLowerExp { field: 42.0 }), "004.2e1");
+                assert_eq!(format!("{:07}", EnumLowerExp::<_, i8>::A(42.0)), "004.2e1");
+                assert_eq!(
+                    format!("{:07}", EnumLowerExp::<i8, _>::B { field: 43.0 }),
+                    "004.3e1",
+                );
+                assert_eq!(format!("{:07}", TupleUpperExp(42.0)), "004.2E1");
+                assert_eq!(format!("{:07}", StructUpperExp { field: 42.0 }), "004.2E1");
+                assert_eq!(format!("{:07}", EnumUpperExp::<_, i8>::A(42.0)), "004.2E1");
+                assert_eq!(
+                    format!("{:07}", EnumUpperExp::<i8, _>::B { field: 43.0 }),
+                    "004.3E1",
+                );
+                assert_eq!(format!("{:018}", TuplePointer(&42)).len(), 18);
+                assert_eq!(format!("{:018}", StructPointer { field: &42 }).len(), 18);
+                assert_eq!(format!("{:018}", EnumPointer::<_, &i8>::A(&7)).len(), 18);
+                assert_eq!(
+                    format!("{:018}", EnumPointer::<&i8, _>::B { field: &42 }).len(),
                     18,
                 );
             }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -373,6 +373,22 @@ mod structs {
                     struct UpperDebug(i32);
 
                     #[derive(Display)]
+                    #[display("{:^}", _0)]
+                    struct Align(i32);
+
+                    #[derive(Display)]
+                    #[display("{:+}", _0)]
+                    struct Sign(i32);
+
+                    #[derive(Display)]
+                    #[display("{:#b}", _0)]
+                    struct Alternate(i32);
+
+                    #[derive(Display)]
+                    #[display("{:0}", _0)]
+                    struct ZeroPadded(i32);
+
+                    #[derive(Display)]
                     #[display("{:07}", _0)]
                     struct Width(i32);
 
@@ -384,6 +400,10 @@ mod structs {
                     fn assert() {
                         assert_eq!(format!("{:03}", LowerDebug(7)), "7");
                         assert_eq!(format!("{:03}", UpperDebug(8)), "8");
+                        assert_eq!(format!("{:03}", Align(5)), "5");
+                        assert_eq!(format!("{:03}", Sign(5)), "+5");
+                        assert_eq!(format!("{:07}", Alternate(5)), "0b101");
+                        assert_eq!(format!("{:07}", ZeroPadded(-5)), "-5");
                         assert_eq!(format!("{:03}", Width(5)), "0000005");
                         assert_eq!(format!("{:.3}", Precision(1.23456789)), "1.23457");
                     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -83,6 +83,122 @@ mod structs {
                 assert_eq!(Struct {}.to_string(), "struct: 0");
             }
         }
+
+        mod delegation {
+            use super::*;
+
+            mod interpolated {
+                use super::*;
+
+                const I32: i32 = 11;
+                const F64: f64 = 3.14;
+                const POINTER: &f64 = &3.14;
+
+                #[derive(Display)]
+                #[display("{I32}")]
+                struct Display;
+
+                #[derive(Display)]
+                #[display("{I32:?}")]
+                struct Debug;
+
+                #[derive(Display)]
+                #[display("{:b}", I32)]
+                struct Binary;
+
+                #[derive(Display)]
+                #[display("{0:o}", I32)]
+                struct Octal;
+
+                #[derive(Display)]
+                #[display("{I32:x}")]
+                struct LowerHex;
+
+                #[derive(Display)]
+                #[display("{:X}", I32)]
+                struct UpperHex;
+
+                #[derive(Display)]
+                #[display("{F64:e}")]
+                struct LowerExp;
+
+                #[derive(Display)]
+                #[display("{named:E}", named = F64)]
+                struct UpperExp;
+
+                #[derive(Display)]
+                #[display("{POINTER:p}")]
+                struct Pointer;
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", Display), "011");
+                    assert_eq!(format!("{:03}", Debug), "011");
+                    assert_eq!(format!("{:07}", Binary), "0001011");
+                    assert_eq!(format!("{:07}", Octal), "0000111");
+                    assert_eq!(format!("{:03}", LowerHex), "00b");
+                    assert_eq!(format!("{:03}", UpperHex), "00B");
+                    assert_eq!(format!("{:07}", LowerExp), "03.14e0");
+                    assert_eq!(format!("{:07}", UpperExp), "03.14E0");
+                    assert_eq!(format!("{:018}", Pointer).len(), 18);
+                }
+            }
+
+            mod untriggered {
+                use super::*;
+
+                mod on_modifiers {
+                    use super::*;
+
+                    const I32: i32 = 11;
+                    const F64: f64 = 3.14;
+
+                    #[derive(Display)]
+                    #[display("{I32:x?}")]
+                    struct LowerDebug;
+
+                    #[derive(Display)]
+                    #[display("{I32:X?}")]
+                    struct UpperDebug;
+
+                    #[derive(Display)]
+                    #[display("{:^}", I32)]
+                    struct Align;
+
+                    #[derive(Display)]
+                    #[display("{:+}", I32)]
+                    struct Sign;
+
+                    #[derive(Display)]
+                    #[display("{:#b}", I32)]
+                    struct Alternate;
+
+                    #[derive(Display)]
+                    #[display("{:0}", I32)]
+                    struct ZeroPadded;
+
+                    #[derive(Display)]
+                    #[display("{:07}", I32)]
+                    struct Width;
+
+                    #[derive(Display)]
+                    #[display("{:.1}", F64)]
+                    struct Precision;
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03}", LowerDebug), "b");
+                        assert_eq!(format!("{:03}", UpperDebug), "B");
+                        assert_eq!(format!("{:03}", Align), "11");
+                        assert_eq!(format!("{:04}", Sign), "+11");
+                        assert_eq!(format!("{:07}", Alternate), "0b1011");
+                        assert_eq!(format!("{:07}", ZeroPadded), "11");
+                        assert_eq!(format!("{:03}", Width), "0000011");
+                        assert_eq!(format!("{:.3}", Precision), "3.1");
+                    }
+                }
+            }
+        }
     }
 
     mod single_field {
@@ -603,6 +719,96 @@ mod enums {
             assert_eq!(Enum::StrUnit.to_string(), "STR_UNIT");
             assert_eq!(Enum::StrUnnamed().to_string(), "STR_UNNAMED");
             assert_eq!(Enum::StrNamed {}.to_string(), "STR_NAMED");
+        }
+
+        mod delegation {
+            use super::*;
+
+            mod interpolated {
+                use super::*;
+
+                const I32: i32 = 11;
+                const F64: f64 = 3.14;
+                const POINTER: &f64 = &3.14;
+
+                #[derive(Display)]
+                enum Unit {
+                    #[display("{I32}")]
+                    Display,
+                    #[display("{I32:?}")]
+                    Debug,
+                    #[display("{:b}", I32)]
+                    Binary,
+                    #[display("{0:o}", I32)]
+                    Octal,
+                    #[display("{I32:x}")]
+                    LowerHex,
+                    #[display("{:X}", I32)]
+                    UpperHex,
+                    #[display("{F64:e}")]
+                    LowerExp,
+                    #[display("{named:E}", named = F64)]
+                    UpperExp,
+                    #[display("{POINTER:p}")]
+                    Pointer,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", Unit::Display), "011");
+                    assert_eq!(format!("{:03}", Unit::Debug), "011");
+                    assert_eq!(format!("{:07}", Unit::Binary), "0001011");
+                    assert_eq!(format!("{:07}", Unit::Octal), "0000111");
+                    assert_eq!(format!("{:03}", Unit::LowerHex), "00b");
+                    assert_eq!(format!("{:03}", Unit::UpperHex), "00B");
+                    assert_eq!(format!("{:07}", Unit::LowerExp), "03.14e0");
+                    assert_eq!(format!("{:07}", Unit::UpperExp), "03.14E0");
+                    assert_eq!(format!("{:018}", Unit::Pointer).len(), 18);
+                }
+            }
+
+            mod untriggered {
+                use super::*;
+
+                mod on_modifiers {
+                    use super::*;
+
+                    const I32: i32 = 11;
+                    const F64: f64 = 3.14;
+
+                    #[derive(Display)]
+                    enum Unit {
+                        #[display("{I32:x?}")]
+                        LowerDebug,
+                        #[display("{I32:X?}")]
+                        UpperDebug,
+                        #[display("{:^}", I32)]
+                        Align,
+                        #[display("{:+}", I32)]
+                        Sign,
+                        #[display("{:#b}", I32)]
+                        Alternate,
+                        #[display("{:0}", I32)]
+                        ZeroPadded,
+                        #[display("{:07}", I32)]
+                        Width,
+                        #[display("{:.1}", F64)]
+                        Precision,
+                    }
+
+                    #[test]
+                    fn assert() {
+                        assert_eq!(format!("{:03}", Unit::LowerDebug), "b");
+                        assert_eq!(format!("{:03}", Unit::UpperDebug), "B");
+                        assert_eq!(format!("{:03}", Unit::Align), "11");
+                        assert_eq!(format!("{:04}", Unit::Sign), "+11");
+                        assert_eq!(format!("{:07}", Unit::Alternate), "0b1011");
+                        assert_eq!(format!("{:07}", Unit::ZeroPadded), "11");
+                        assert_eq!(format!("{:03}", Unit::Width), "0000011");
+                        assert_eq!(format!("{:.3}", Unit::Precision), "3.1");
+                    }
+                }
+            }
         }
     }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -285,6 +285,78 @@ mod structs {
                     );
                 }
             }
+
+            mod suppressed {
+                use super::*;
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{_0}"))]
+                struct TupleDisplay(i32);
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{_0:?}"))]
+                struct TupleDebug(i32);
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{_0:b}"))]
+                struct TupleBinary(i32);
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{_0:o}"))]
+                struct TupleOctal(i32);
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{field:x}"))]
+                struct StructLowerHex {
+                    field: i32,
+                }
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{field:X}"))]
+                struct StructUpperHex {
+                    field: i32,
+                }
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{field:e}"))]
+                struct StructLowerExp {
+                    field: f64,
+                }
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{field:E}"))]
+                struct StructUpperExp {
+                    field: f64,
+                }
+
+                #[derive(Display)]
+                #[display("{}", format_args!("{field:p}"))]
+                struct StructPointer<'a> {
+                    field: &'a i32,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", TupleDisplay(7)), "7");
+                    assert_eq!(format!("{:03}", TupleDebug(8)), "8");
+                    assert_eq!(format!("{:07}", TupleBinary(7)), "111");
+                    assert_eq!(format!("{:03}", TupleOctal(9)), "11");
+                    assert_eq!(format!("{:03}", StructLowerHex { field: 42 }), "2a");
+                    assert_eq!(format!("{:03}", StructUpperHex { field: 42 }), "2A");
+                    assert_eq!(
+                        format!("{:07}", StructLowerExp { field: 42.0 }),
+                        "4.2e1",
+                    );
+                    assert_eq!(
+                        format!("{:07}", StructUpperExp { field: 42.0 }),
+                        "4.2E1",
+                    );
+                    assert_eq!(
+                        format!("{:018}", StructPointer { field: &42 }).len(),
+                        11,
+                    );
+                }
+            }
         }
     }
 
@@ -699,6 +771,104 @@ mod enums {
                     assert_eq!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
                 }
             }
+
+            mod suppressed {
+                use super::*;
+
+                #[derive(Display)]
+                enum Display {
+                    #[display("{}", format_args!("{_0}"))]
+                    A(i32),
+                    #[display("{}", format_args!("{}", field))]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum Debug {
+                    #[display("{}", format_args!("{_0:?}"))]
+                    A(i32),
+                    #[display("{}", format_args!("{:?}", field))]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum Binary {
+                    #[display("{}", format_args!("{_0:b}"))]
+                    A(i32),
+                    #[display("{}", format_args!("{:b}", field))]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum Octal {
+                    #[display("{}", format_args!("{_0:o}"))]
+                    A(i32),
+                    #[display("{}", format_args!("{:o}", field))]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum LowerHex {
+                    #[display("{}", format_args!("{_0:x}"))]
+                    A(i32),
+                    #[display("{}", format_args!("{:x}", field))]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum UpperHex {
+                    #[display("{}", format_args!("{_0:X}"))]
+                    A(i32),
+                    #[display("{}", format_args!("{:X}", field))]
+                    B { field: u8 },
+                }
+
+                #[derive(Display)]
+                enum LowerExp {
+                    #[display("{}", format_args!("{:e}", _0))]
+                    A(f64),
+                    #[display("{}", format_args!("{field:e}"))]
+                    B { field: f32 },
+                }
+
+                #[derive(Display)]
+                enum UpperExp {
+                    #[display("{}", format_args!("{:E}", _0))]
+                    A(f64),
+                    #[display("{}", format_args!("{field:E}"))]
+                    B { field: f32 },
+                }
+
+                #[derive(Display)]
+                enum Pointer<'a> {
+                    #[display("{}", format_args!("{:p}", _0))]
+                    A(&'a i32),
+                    #[display("{}", format_args!("{field:p}"))]
+                    B { field: &'a u8 },
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", Display::A(7)), "7");
+                    assert_eq!(format!("{:03}", Display::B { field: 8 }), "8");
+                    assert_eq!(format!("{:03}", Debug::A(8)), "8");
+                    assert_eq!(format!("{:03}", Debug::B { field: 9 }), "9");
+                    assert_eq!(format!("{:07}", Binary::A(7)), "111");
+                    assert_eq!(format!("{:07}", Binary::B { field: 8 }), "1000");
+                    assert_eq!(format!("{:03}", Octal::A(9)), "11");
+                    assert_eq!(format!("{:03}", Octal::B { field: 10 }), "12");
+                    assert_eq!(format!("{:03}", LowerHex::A(42)), "2a");
+                    assert_eq!(format!("{:03}", LowerHex::B { field: 43 }), "2b");
+                    assert_eq!(format!("{:03}", UpperHex::A(42)), "2A");
+                    assert_eq!(format!("{:03}", UpperHex::B { field: 43 }), "2B");
+                    assert_eq!(format!("{:07}", LowerExp::A(42.0)), "4.2e1");
+                    assert_eq!(format!("{:07}", LowerExp::B { field: 43.0 }), "4.3e1");
+                    assert_eq!(format!("{:07}", UpperExp::A(42.0)), "4.2E1");
+                    assert_eq!(format!("{:07}", UpperExp::B { field: 43.0 }), "4.3E1");
+                    assert_eq!(format!("{:018}", Pointer::A(&7)).len(), 11);
+                    assert_eq!(format!("{:018}", Pointer::B { field: &42 }).len(), 11);
+                }
+            }
         }
     }
 
@@ -712,13 +882,13 @@ mod enums {
             #[display("named")]
             StrNamed { field1: i32, field2: i32 },
             #[display(
-            "{_0} {ident} {_1} {} {}",
-            _1, _0 + _1, ident = 123, _1 = _0,
+                "{_0} {ident} {_1} {} {}",
+                _1, _0 + _1, ident = 123, _1 = _0,
             )]
             InterpolatedUnnamed(i32, i32),
             #[display(
-            "{field1} {ident} {field2} {} {}",
-            field2, field1 + field2, ident = 123, field2 = field1,
+                "{field1} {ident} {field2} {} {}",
+                field2, field1 + field2, ident = 123, field2 = field1,
             )]
             InterpolatedNamed { field1: i32, field2: i32 },
         }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1893,5 +1893,63 @@ mod generic {
                 );
             }
         }
+
+        mod untriggered {
+            use super::*;
+
+            mod on_modifiers {
+                use super::*;
+
+                #[derive(Display)]
+                enum Enum<A, B, C, D> {
+                    #[display("{_0:x?}")]
+                    LowerDebug(A),
+                    #[display("{_0:X?}")]
+                    UpperDebug(B),
+                    #[display("{:^}", _0)]
+                    Align(C),
+                    #[display("{:+}", _0)]
+                    Sign(C),
+                    #[display("{:#b}", _0)]
+                    Alternate(C),
+                    #[display("{:0}", _0)]
+                    ZeroPadded(C),
+                    #[display("{:07}", _0)]
+                    Width(C),
+                    #[display("{:.5}", _0)]
+                    Precision(D),
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(
+                        format!("{:03}", Enum::<_, u8, u8, f64>::LowerDebug(7)),
+                        "7",
+                    );
+                    assert_eq!(
+                        format!("{:03}", Enum::<u8, _, u8, f64>::UpperDebug(8)),
+                        "8",
+                    );
+                    assert_eq!(format!("{:03}", Enum::<u8, u8, _, f64>::Align(5)), "5");
+                    assert_eq!(format!("{:03}", Enum::<u8, u8, _, f64>::Sign(5)), "+5");
+                    assert_eq!(
+                        format!("{:07}", Enum::<u8, u8, _, f64>::Alternate(5)),
+                        "0b101",
+                    );
+                    assert_eq!(
+                        format!("{:07}", Enum::<u8, u8, _, f64>::ZeroPadded(-5)),
+                        "-5",
+                    );
+                    assert_eq!(
+                        format!("{:03}", Enum::<u8, u8, _, f64>::Width(5)),
+                        "0000005",
+                    );
+                    assert_eq!(
+                        format!("{:.3}", Enum::<u8, u8, u8, _>::Precision(1.23456789)),
+                        "1.23457",
+                    );
+                }
+            }
+        }
     }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -347,6 +347,88 @@ mod structs {
                 );
             }
         }
+
+        mod delegation {
+            use super::*;
+
+            mod interpolated {
+                use super::*;
+
+                #[derive(Display)]
+                #[display("{_0}")]
+                struct TupleDisplay(i32, u64);
+
+                #[derive(Display)]
+                #[display("{_1:b}")]
+                struct TupleBinary(i32, u64);
+
+                #[derive(Display)]
+                #[display("{:o}", _0)]
+                struct TupleOctal(i32, u64);
+
+                #[derive(Display)]
+                #[display("{b:x}")]
+                struct StructLowerHex {
+                    a: i32,
+                    b: u64,
+                }
+
+                #[derive(Display)]
+                #[display("{:X}", a)]
+                struct StructUpperHex {
+                    a: i32,
+                    b: u64,
+                }
+
+                #[derive(Display)]
+                #[display("{a:e}")]
+                struct StructLowerExp {
+                    a: f64,
+                    b: f32,
+                }
+
+                #[derive(Display)]
+                #[display("{:E}", b)]
+                struct StructUpperExp {
+                    a: f64,
+                    b: f32,
+                }
+
+                #[derive(Display)]
+                #[display("{b:p}")]
+                struct StructPointer<'a> {
+                    a: &'a i32,
+                    b: &'a i32,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", TupleDisplay(7, 8)), "007");
+                    assert_eq!(format!("{:07}", TupleBinary(6, 7)), "0000111");
+                    assert_eq!(format!("{:03}", TupleOctal(9, 10)), "011");
+                    assert_eq!(
+                        format!("{:03}", StructLowerHex { a: 41, b: 42 }),
+                        "02a"
+                    );
+                    assert_eq!(
+                        format!("{:03}", StructUpperHex { a: 42, b: 43 }),
+                        "02A"
+                    );
+                    assert_eq!(
+                        format!("{:07}", StructLowerExp { a: 42.0, b: 43.0 }),
+                        "004.2e1",
+                    );
+                    assert_eq!(
+                        format!("{:07}", StructUpperExp { a: 41.0, b: 42.0 }),
+                        "004.2E1",
+                    );
+                    assert_eq!(
+                        format!("{:018}", StructPointer { a: &42, b: &43 }).len(),
+                        18,
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -641,6 +723,107 @@ mod enums {
                 .to_string(),
                 "1 123 1 2 3",
             );
+        }
+
+        mod delegation {
+            use super::*;
+
+            mod interpolated {
+                use super::*;
+
+                #[derive(Display)]
+                enum Display {
+                    #[display("{_0}")]
+                    A(i32, i64),
+                    #[display("{}", b)]
+                    B { a: u8, b: i32 },
+                }
+
+                #[derive(Display)]
+                enum Binary {
+                    #[display("{_0:b}")]
+                    A(i32, i64),
+                    #[display("{:b}", b)]
+                    B { a: u8, b: i32 },
+                }
+
+                #[derive(Display)]
+                enum Octal {
+                    #[display("{_0:o}")]
+                    A(i32, i64),
+                    #[display("{:o}", b)]
+                    B { a: u8, b: i32 },
+                }
+
+                #[derive(Display)]
+                enum LowerHex {
+                    #[display("{_0:x}")]
+                    A(i32, i64),
+                    #[display("{:x}", b)]
+                    B { a: u8, b: i32 },
+                }
+
+                #[derive(Display)]
+                enum UpperHex {
+                    #[display("{_0:X}")]
+                    A(i32, i64),
+                    #[display("{:X}", b)]
+                    B { a: u8, b: i32 },
+                }
+
+                #[derive(Display)]
+                enum LowerExp {
+                    #[display("{:e}", _1)]
+                    A(f64, f32),
+                    #[display("{a:e}")]
+                    B { a: f64, b: f32 },
+                }
+
+                #[derive(Display)]
+                enum UpperExp {
+                    #[display("{:E}", _1)]
+                    A(f64, f32),
+                    #[display("{a:E}")]
+                    B { a: f64, b: f32 },
+                }
+
+                #[derive(Display)]
+                enum Pointer<'a> {
+                    #[display("{:p}", _1)]
+                    A(&'a f64, &'a f32),
+                    #[display("{a:p}")]
+                    B { a: &'a f64, b: &'a f32 },
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(format!("{:03}", Display::A(7, 8)), "007");
+                    assert_eq!(format!("{:03}", Display::B { a: 7, b: 8 }), "008");
+                    assert_eq!(format!("{:07}", Binary::A(7, 8)), "0000111");
+                    assert_eq!(format!("{:07}", Binary::B { a: 7, b: 8 }), "0001000");
+                    assert_eq!(format!("{:03}", Octal::A(9, 10)), "011");
+                    assert_eq!(format!("{:03}", Octal::B { a: 9, b: 10 }), "012");
+                    assert_eq!(format!("{:03}", LowerHex::A(42, 41)), "02a");
+                    assert_eq!(format!("{:03}", LowerHex::B { a: 42, b: 43 }), "02b");
+                    assert_eq!(format!("{:03}", UpperHex::A(42, 41)), "02A");
+                    assert_eq!(format!("{:03}", UpperHex::B { a: 42, b: 43 }), "02B");
+                    assert_eq!(format!("{:07}", LowerExp::A(41.0, 42.0)), "004.2e1");
+                    assert_eq!(
+                        format!("{:07}", LowerExp::B { a: 43.0, b: 52.0 }),
+                        "004.3e1",
+                    );
+                    assert_eq!(format!("{:07}", UpperExp::A(41.0, 42.0)), "004.2E1");
+                    assert_eq!(
+                        format!("{:07}", UpperExp::B { a: 43.0, b: 52.0 }),
+                        "004.3E1",
+                    );
+                    assert_eq!(format!("{:018}", Pointer::A(&7.0, &8.3)).len(), 18);
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { a: &42.1, b: &43.3 }).len(),
+                        18,
+                    );
+                }
+            }
         }
     }
 }
@@ -1247,11 +1430,11 @@ mod generic {
 
             #[derive(Display)]
             #[display("{_0:b}")]
-            struct TupleBinary<T>(T);
+            struct TupleBinary<T, Y>(T, Y);
 
             #[derive(Display)]
-            #[display("{_0:o}")]
-            struct TupleOctal<T>(T);
+            #[display("{_1:o}")]
+            struct TupleOctal<Y, T>(Y, T);
 
             #[derive(Display)]
             #[display("{_0:x}")]
@@ -1280,15 +1463,17 @@ mod generic {
             }
 
             #[derive(Display)]
-            #[display("{field:b}")]
-            struct StructBinary<T> {
-                field: T,
+            #[display("{a:b}")]
+            struct StructBinary<T, Y> {
+                a: T,
+                b: Y,
             }
 
             #[derive(Display)]
-            #[display("{field:o}")]
-            struct StructOctal<T> {
-                field: T,
+            #[display("{b:o}")]
+            struct StructOctal<Y, T> {
+                a: Y,
+                b: T,
             }
 
             #[derive(Display)]
@@ -1330,19 +1515,19 @@ mod generic {
             }
 
             #[derive(Display)]
-            enum EnumBinary<A, B> {
+            enum EnumBinary<A, B, C, D> {
                 #[display("{_0:b}")]
-                A(A),
-                #[display("{:b}", field)]
-                B { field: B },
+                A(A, C),
+                #[display("{:b}", b)]
+                B { b: B, d: D },
             }
 
             #[derive(Display)]
-            enum EnumOctal<A, B> {
-                #[display("{_0:o}")]
-                A(A),
-                #[display("{:o}", field)]
-                B { field: B },
+            enum EnumOctal<A, B, C, D> {
+                #[display("{_1:o}")]
+                A(A, C),
+                #[display("{:o}", d)]
+                B { b: B, d: D },
             }
 
             #[derive(Display)]
@@ -1392,35 +1577,41 @@ mod generic {
                 assert_eq!(format!("{:03}", EnumDisplay::<_, i8>::A(7)), "007");
                 assert_eq!(
                     format!("{:03}", EnumDisplay::<i8, _>::B { field: 8 }),
-                    "008"
+                    "008",
                 );
-                assert_eq!(format!("{:07}", TupleBinary(7)), "0000111");
-                assert_eq!(format!("{:07}", StructBinary { field: 7 }), "0000111");
-                assert_eq!(format!("{:07}", EnumBinary::<_, i8>::A(7)), "0000111");
+                assert_eq!(format!("{:07}", TupleBinary(7, ())), "0000111");
+                assert_eq!(format!("{:07}", StructBinary { a: 7, b: () }), "0000111");
                 assert_eq!(
-                    format!("{:07}", EnumBinary::<i8, _>::B { field: 8 }),
-                    "0001000"
+                    format!("{:07}", EnumBinary::<_, i8, _, ()>::A(7, ())),
+                    "0000111",
                 );
-                assert_eq!(format!("{:03}", TupleOctal(9)), "011");
-                assert_eq!(format!("{:03}", StructOctal { field: 9 }), "011");
-                assert_eq!(format!("{:03}", EnumOctal::<_, i8>::A(9)), "011");
                 assert_eq!(
-                    format!("{:03}", EnumOctal::<i8, _>::B { field: 10 }),
-                    "012"
+                    format!("{:07}", EnumBinary::<i8, _, (), _>::B { b: 8, d: () }),
+                    "0001000",
+                );
+                assert_eq!(format!("{:03}", TupleOctal((), 9)), "011");
+                assert_eq!(format!("{:03}", StructOctal { a: (), b: 9 }), "011");
+                assert_eq!(
+                    format!("{:03}", EnumOctal::<_, (), _, i8>::A((), 9)),
+                    "011",
+                );
+                assert_eq!(
+                    format!("{:03}", EnumOctal::<(), _, i8, _>::B { b: (), d: 10 }),
+                    "012",
                 );
                 assert_eq!(format!("{:03}", TupleLowerHex(42)), "02a");
                 assert_eq!(format!("{:03}", StructLowerHex { field: 42 }), "02a");
                 assert_eq!(format!("{:03}", EnumLowerHex::<_, i8>::A(42)), "02a");
                 assert_eq!(
                     format!("{:03}", EnumLowerHex::<i8, _>::B { field: 43 }),
-                    "02b"
+                    "02b",
                 );
                 assert_eq!(format!("{:03}", TupleUpperHex(42)), "02A");
                 assert_eq!(format!("{:03}", StructUpperHex { field: 42 }), "02A");
                 assert_eq!(format!("{:03}", EnumUpperHex::<_, i8>::A(42)), "02A");
                 assert_eq!(
                     format!("{:03}", EnumUpperHex::<i8, _>::B { field: 43 }),
-                    "02B"
+                    "02B",
                 );
                 assert_eq!(format!("{:07}", TupleLowerExp(42.0)), "004.2e1");
                 assert_eq!(format!("{:07}", StructLowerExp { field: 42.0 }), "004.2e1");


### PR DESCRIPTION
Resolves #321



## Synopsis

See https://github.com/JelteF/derive_more/issues/321#issuecomment-1854069597:
> You’re discarding formatting flags provided by the user in format string, e.g.:
> 
> ```rust
> #[derive(derive_more::Display)]
> #[display(fmt = "{:?}", _0)]
> struct Num(usize);
> 
> impl std::fmt::Debug for Num {
>     fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
>         self.0.fmt(fmtr)
>     }
> }
> 
> fn main() {
>     let num = Num(7);
>     println!("{num:03?}");  // prints ‘007’ as expected
>     println!("{num:03}");   // prints ‘7’ instead
> }
> ```






## Solution

See https://github.com/JelteF/derive_more/issues/321#issuecomment-1854382465:
> Theoretically, we can support this with the current syntax, because we can detect so-called _trivial_ cases and transform them into delegation (we do parse formatting string literal anyway).
> 
> ```rust
> #[derive(derive_more::Display)]
> #[display("{_0:?}")] // <--- it's clear to be a trivial delegation case
> struct Num(usize);
> ```
> 
> would expand to
> 
> ```rust
> impl std::fmt::Display for Num {
>     fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
>         let _0 = &self.0;
>         std::fmt::Debug::fmt(_0, fmtr)
>     }
> }
> ```
> 
> rather than
> 
> ```rust
> impl std::fmt::Display for Num {
>     fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
>         let _0 = &self.0;
>         write!(fmtr, "{_0:?}")
>     }
> }
> ```




## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
