### PR TITLE
Better hygiene for `core` crate naming (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#284](https://github.com/JelteF/derive_more/pull/284))
 - Fix documentation of generated bounds in `Display` derive.
   ([#297](https://github.com/JelteF/derive_more/pull/297))
+- Hygiene of macro expansions in presence of custom `core` crate.
+  ([#327](https://github.com/JelteF/derive_more/pull/327))
 
 ## 0.99.10 - 2020-09-11
 

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -29,7 +29,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics ::derive_more::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
             #[inline]
             fn #method_ident(&mut self, rhs: #input_type #ty_generics) {
                 #( #exprs; )*

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -29,7 +29,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics ::derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             #[inline]
             fn #method_ident(&mut self, rhs: #input_type #ty_generics) {
                 #( #exprs; )*

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -32,7 +32,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
         },
         Data::Enum(ref data_enum) => (
             quote! {
-                ::core::result::Result<#input_type #ty_generics, ::derive_more::BinaryError>
+                ::derive_more::core::result::Result<#input_type #ty_generics, ::derive_more::BinaryError>
             },
             enum_content(input_type, data_enum, &method_ident),
         ),
@@ -98,7 +98,7 @@ fn enum_content(
                 let matcher = quote! {
                     (#subtype(#(#l_vars),*),
                      #subtype(#(#r_vars),*)) => {
-                        ::core::result::Result::Ok(#subtype(#(#l_vars.#method_iter(#r_vars)),*))
+                        ::derive_more::core::result::Result::Ok(#subtype(#(#l_vars.#method_iter(#r_vars)),*))
                     }
                 };
                 matches.push(matcher);
@@ -117,7 +117,9 @@ fn enum_content(
                 let matcher = quote! {
                     (#subtype{#(#field_names: #l_vars),*},
                      #subtype{#(#field_names: #r_vars),*}) => {
-                        ::core::result::Result::Ok(#subtype{#(#field_names: #l_vars.#method_iter(#r_vars)),*})
+                        ::derive_more::core::result::Result::Ok(#subtype{
+                            #(#field_names: #l_vars.#method_iter(#r_vars)),*
+                        })
                     }
                 };
                 matches.push(matcher);
@@ -125,7 +127,7 @@ fn enum_content(
             Fields::Unit => {
                 let operation_name = method_ident.to_string();
                 matches.push(quote! {
-                    (#subtype, #subtype) => ::core::result::Result::Err(
+                    (#subtype, #subtype) => ::derive_more::core::result::Result::Err(
                         ::derive_more::BinaryError::Unit(
                             ::derive_more::UnitError::new(#operation_name)
                         )
@@ -140,7 +142,7 @@ fn enum_content(
         // match.
         let operation_name = method_ident.to_string();
         matches.push(quote! {
-            _ => ::core::result::Result::Err(::derive_more::BinaryError::Mismatch(
+            _ => ::derive_more::core::result::Result::Err(::derive_more::BinaryError::Mismatch(
                 ::derive_more::WrongVariantError::new(#operation_name)
             ))
         });

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -235,7 +235,7 @@ impl<'a> ToTokens for Expansion<'a> {
                 ImplKind::Specialized
             };
 
-            let trait_ty = quote! { ::core::convert::#trait_ident <#return_ty> };
+            let trait_ty = quote! { ::derive_more::core::convert::#trait_ident <#return_ty> };
 
             let generics = match &impl_kind {
                 ImplKind::Forwarded => {
@@ -247,7 +247,7 @@ impl<'a> ToTokens for Expansion<'a> {
                     if is_blanket {
                         generics
                             .params
-                            .push(parse_quote! { #return_ty: ?::core::marker::Sized });
+                            .push(parse_quote! { #return_ty: ?::derive_more::core::marker::Sized });
                     }
                     Cow::Owned(generics)
                 }
@@ -268,7 +268,7 @@ impl<'a> ToTokens for Expansion<'a> {
 
                     let conv =
                         <::derive_more::__private::Conv<& #mut_ #field_ty, #return_ty>
-                         as ::core::default::Default>::default();
+                         as ::derive_more::core::default::Default>::default();
                     (&&conv).__extract_ref(#field_ref)
                 }),
             };

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -240,7 +240,7 @@ impl<'a> ToTokens for Expansion<'a> {
             };
 
             let trait_ty = quote! {
-                ::derive_more::core::convert::#trait_ident <#return_ty>
+                ::derive_more::#trait_ident <#return_ty>
             };
 
             let generics = match &impl_kind {

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -235,7 +235,9 @@ impl<'a> ToTokens for Expansion<'a> {
                 ImplKind::Specialized
             };
 
-            let trait_ty = quote! { ::derive_more::core::convert::#trait_ident <#return_ty> };
+            let trait_ty = quote! {
+                ::derive_more::core::convert::#trait_ident <#return_ty>
+            };
 
             let generics = match &impl_kind {
                 ImplKind::Forwarded => {

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -61,7 +61,7 @@ pub fn expand(
             &generics,
             quote! {
                 where
-                    #ident #ty_generics: ::derive_more::core::fmt::Debug + ::core::fmt::Display
+                    #ident #ty_generics: ::derive_more::core::fmt::Debug + ::derive_more::core::fmt::Display
             },
         );
     }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -47,7 +47,7 @@ pub fn expand(
 
     let provide = provide.map(|provide| {
         quote! {
-            fn provide<'_request>(&'_request self, request: &mut ::core::error::Request<'_request>) {
+            fn provide<'_request>(&'_request self, request: &mut ::derive_more::core::error::Request<'_request>) {
                 #provide
             }
         }
@@ -61,7 +61,7 @@ pub fn expand(
             &generics,
             quote! {
                 where
-                    #ident #ty_generics: ::core::fmt::Debug + ::core::fmt::Display
+                    #ident #ty_generics: ::derive_more::core::fmt::Debug + ::core::fmt::Display
             },
         );
     }
@@ -71,8 +71,12 @@ pub fn expand(
         generics = utils::add_extra_where_clauses(
             &generics,
             quote! {
-                where
-                    #(#bounds: ::core::fmt::Debug + ::core::fmt::Display + ::derive_more::Error + 'static),*
+                where #(
+                    #bounds: ::derive_more::core::fmt::Debug
+                             + ::derive_more::core::fmt::Display
+                             + ::derive_more::Error
+                             + 'static
+                ),*
             },
         );
     }

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -46,12 +46,12 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_gens ::core::fmt::Debug for #ident #ty_gens
+        impl #impl_gens ::derive_more::core::fmt::Debug for #ident #ty_gens
              #where_clause
         {
             fn fmt(
-                &self, __derive_more_f: &mut ::core::fmt::Formatter<'_>
-            ) -> ::core::fmt::Result {
+                &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
+            ) -> ::derive_more::core::fmt::Result {
                 #body
             }
         }
@@ -229,9 +229,9 @@ impl<'a> Expansion<'a> {
     fn generate_body(&self) -> syn::Result<TokenStream> {
         if let Some(fmt) = &self.attr.fmt {
             return Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                quote! { ::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
+                quote! { ::derive_more::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
             } else {
-                quote! { ::core::write!(__derive_more_f, #fmt) }
+                quote! { ::derive_more::core::write!(__derive_more_f, #fmt) }
             });
         };
 
@@ -239,7 +239,7 @@ impl<'a> Expansion<'a> {
             syn::Fields::Unit => {
                 let ident = self.ident.to_string();
                 Ok(quote! {
-                    ::core::fmt::Formatter::write_str(
+                    ::derive_more::core::fmt::Formatter::write_str(
                         __derive_more_f,
                         #ident,
                     )
@@ -268,7 +268,7 @@ impl<'a> Expansion<'a> {
                             Some(FieldAttribute::Right(fmt_attr)) => Ok(quote! {
                                 ::derive_more::__private::DebugTuple::field(
                                     #out,
-                                    &::core::format_args!(#fmt_attr),
+                                    &::derive_more::core::format_args!(#fmt_attr),
                                 )
                             }),
                             None => {
@@ -291,7 +291,7 @@ impl<'a> Expansion<'a> {
                 let ident = self.ident.to_string();
 
                 let out = quote! {
-                    &mut ::core::fmt::Formatter::debug_struct(
+                    &mut ::derive_more::core::fmt::Formatter::debug_struct(
                         __derive_more_f,
                         #ident,
                     )
@@ -309,21 +309,21 @@ impl<'a> Expansion<'a> {
                                 Ok::<_, syn::Error>(out)
                             }
                             Some(FieldAttribute::Right(fmt_attr)) => Ok(quote! {
-                                ::core::fmt::DebugStruct::field(
+                                ::derive_more::core::fmt::DebugStruct::field(
                                     #out,
                                     #field_str,
-                                    &::core::format_args!(#fmt_attr),
+                                    &::derive_more::core::format_args!(#fmt_attr),
                                 )
                             }),
                             None => Ok(quote! {
-                                ::core::fmt::DebugStruct::field(#out, #field_str, #field_ident)
+                                ::derive_more::core::fmt::DebugStruct::field(#out, #field_str, #field_ident)
                             }),
                         }
                     })?;
                 Ok(if exhaustive {
-                    quote! { ::core::fmt::DebugStruct::finish(#out) }
+                    quote! { ::derive_more::core::fmt::DebugStruct::finish(#out) }
                 } else {
-                    quote! { ::core::fmt::DebugStruct::finish_non_exhaustive(#out) }
+                    quote! { ::derive_more::core::fmt::DebugStruct::finish_non_exhaustive(#out) }
                 })
             }
         }
@@ -337,7 +337,7 @@ impl<'a> Expansion<'a> {
             out.extend(fmt.bounded_types(self.fields).map(|(ty, trait_name)| {
                 let trait_ident = format_ident!("{trait_name}");
 
-                parse_quote! { #ty: ::core::fmt::#trait_ident }
+                parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }
             }));
             Ok(out)
         } else {
@@ -351,12 +351,12 @@ impl<'a> Expansion<'a> {
                             |(ty, trait_name)| {
                                 let trait_ident = format_ident!("{trait_name}");
 
-                                parse_quote! { #ty: ::core::fmt::#trait_ident }
+                                parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }
                             },
                         ));
                     }
                     Some(FieldAttribute::Left(_skip)) => {}
-                    None => out.extend([parse_quote! { #ty: ::core::fmt::Debug }]),
+                    None => out.extend([parse_quote! { #ty: ::derive_more::core::fmt::Debug }]),
                 }
                 Ok(out)
             })

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -46,9 +46,7 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_gens ::derive_more::core::fmt::Debug for #ident #ty_gens
-             #where_clause
-        {
+        impl #impl_gens ::derive_more::Debug for #ident #ty_gens #where_clause {
             fn fmt(
                 &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
             ) -> ::derive_more::core::fmt::Result {
@@ -356,7 +354,7 @@ impl<'a> Expansion<'a> {
                         ));
                     }
                     Some(FieldAttribute::Left(_skip)) => {}
-                    None => out.extend([parse_quote! { #ty: ::derive_more::core::fmt::Debug }]),
+                    None => out.extend([parse_quote! { #ty: ::derive_more::Debug }]),
                 }
                 Ok(out)
             })

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -50,12 +50,12 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_gens ::core::fmt::#trait_ident for #ident #ty_gens
+        impl #impl_gens ::derive_more::core::fmt::#trait_ident for #ident #ty_gens
              #where_clause
         {
             fn fmt(
-                &self, __derive_more_f: &mut ::core::fmt::Formatter<'_>
-            ) -> ::core::fmt::Result {
+                &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
+            ) -> ::derive_more::core::fmt::Result {
                 #body
             }
         }
@@ -188,7 +188,7 @@ fn expand_union(
 
     Ok((
         attrs.bounds.0.clone().into_iter().collect(),
-        quote! { ::core::write!(__derive_more_f, #fmt) },
+        quote! { ::derive_more::core::write!(__derive_more_f, #fmt) },
     ))
 }
 
@@ -224,16 +224,16 @@ impl<'a> Expansion<'a> {
         match &self.attrs.fmt {
             Some(fmt) => {
                 Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                    quote! { ::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
+                    quote! { ::derive_more::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
                 } else {
-                    quote! { ::core::write!(__derive_more_f, #fmt) }
+                    quote! { ::derive_more::core::write!(__derive_more_f, #fmt) }
                 })
             }
             None if self.fields.is_empty() => {
                 let ident_str = self.ident.to_string();
 
                 Ok(quote! {
-                    ::core::write!(__derive_more_f, #ident_str)
+                    ::derive_more::core::write!(__derive_more_f, #ident_str)
                 })
             }
             None if self.fields.len() == 1 => {
@@ -246,7 +246,7 @@ impl<'a> Expansion<'a> {
                 let trait_ident = self.trait_ident;
 
                 Ok(quote! {
-                    ::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)
+                    ::derive_more::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)
                 })
             }
             _ => Err(syn::Error::new(
@@ -270,7 +270,7 @@ impl<'a> Expansion<'a> {
                 .map(|f| {
                     let ty = &f.ty;
                     let trait_ident = &self.trait_ident;
-                    vec![parse_quote! { #ty: ::core::fmt::#trait_ident }]
+                    vec![parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }]
                 })
                 .unwrap_or_default();
         };
@@ -279,7 +279,7 @@ impl<'a> Expansion<'a> {
             .map(|(ty, trait_name)| {
                 let trait_ident = format_ident!("{trait_name}");
 
-                parse_quote! { #ty: ::core::fmt::#trait_ident }
+                parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }
             })
             .chain(self.attrs.bounds.0.clone())
             .collect()

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -50,9 +50,7 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_gens ::derive_more::core::fmt::#trait_ident for #ident #ty_gens
-             #where_clause
-        {
+        impl #impl_gens ::derive_more::#trait_ident for #ident #ty_gens #where_clause {
             fn fmt(
                 &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
             ) -> ::derive_more::core::fmt::Result {

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -165,7 +165,7 @@ impl<'a> Expansion<'a> {
                         let index = index.into_iter();
                         let from_ty = from_tys.next().unwrap_or_else(|| unreachable!());
                         quote! {
-                            #( #ident: )* <#ty as ::derive_more::core::convert::From<#from_ty>>::from(
+                            #( #ident: )* <#ty as ::derive_more::From<#from_ty>>::from(
                                 value #( .#index )*
                             ),
                         }
@@ -173,9 +173,7 @@ impl<'a> Expansion<'a> {
 
                     Ok(quote! {
                         #[automatically_derived]
-                        impl #impl_gens ::derive_more::core::convert::From<#ty>
-                         for #ident #ty_gens #where_clause
-                        {
+                        impl #impl_gens ::derive_more::From<#ty> for #ident #ty_gens #where_clause {
                             #[inline]
                             fn from(value: #ty) -> Self {
                                 #ident #( :: #variant )* #init
@@ -195,9 +193,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::derive_more::core::convert::From<(#( #field_tys ),*)>
-                     for #ident #ty_gens #where_clause
-                    {
+                    impl #impl_gens ::derive_more::From<(#( #field_tys ),*)> for #ident #ty_gens #where_clause {
                         #[inline]
                         fn from(value: (#( #field_tys ),*)) -> Self {
                             #ident #( :: #variant )* #init
@@ -213,7 +209,7 @@ impl<'a> Expansion<'a> {
                     let index = index.into_iter();
                     let gen_ident = format_ident!("__FromT{i}");
                     let out = quote! {
-                        #( #ident: )* <#ty as ::derive_more::core::convert::From<#gen_ident>>::from(
+                        #( #ident: )* <#ty as ::derive_more::From<#gen_ident>>::from(
                             value #( .#index )*
                         ),
                     };
@@ -227,7 +223,7 @@ impl<'a> Expansion<'a> {
                     let mut generics = self.generics.clone();
                     for (ty, ident) in field_tys.iter().zip(&gen_idents) {
                         generics.make_where_clause().predicates.push(
-                            parse_quote! { #ty: ::derive_more::core::convert::From<#ident> },
+                            parse_quote! { #ty: ::derive_more::From<#ident> },
                         );
                         generics
                             .params
@@ -239,9 +235,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::derive_more::core::convert::From<(#( #gen_idents ),*)>
-                     for #ident #ty_gens #where_clause
-                    {
+                    impl #impl_gens ::derive_more::From<(#( #gen_idents ),*)> for #ident #ty_gens #where_clause {
                         #[inline]
                         fn from(value: (#( #gen_idents ),*)) -> Self {
                             #ident #(:: #variant)* #init

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -161,7 +161,7 @@ impl<'a> Expansion<'a> {
                         let index = index.into_iter();
                         let from_ty = from_tys.next().unwrap_or_else(|| unreachable!());
                         quote! {
-                            #( #ident: )* <#ty as ::core::convert::From<#from_ty>>::from(
+                            #( #ident: )* <#ty as ::derive_more::core::convert::From<#from_ty>>::from(
                                 value #( .#index )*
                             ),
                         }
@@ -169,7 +169,7 @@ impl<'a> Expansion<'a> {
 
                     Ok(quote! {
                         #[automatically_derived]
-                        impl #impl_gens ::core::convert::From<#ty>
+                        impl #impl_gens ::derive_more::core::convert::From<#ty>
                          for #ident #ty_gens #where_clause
                         {
                             #[inline]
@@ -191,7 +191,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::core::convert::From<(#( #field_tys ),*)>
+                    impl #impl_gens ::derive_more::core::convert::From<(#( #field_tys ),*)>
                      for #ident #ty_gens #where_clause
                     {
                         #[inline]
@@ -209,7 +209,7 @@ impl<'a> Expansion<'a> {
                     let index = index.into_iter();
                     let gen_ident = format_ident!("__FromT{i}");
                     let out = quote! {
-                        #( #ident: )* <#ty as ::core::convert::From<#gen_ident>>::from(
+                        #( #ident: )* <#ty as ::derive_more::core::convert::From<#gen_ident>>::from(
                             value #( .#index )*
                         ),
                     };
@@ -223,7 +223,7 @@ impl<'a> Expansion<'a> {
                     let mut generics = self.generics.clone();
                     for (ty, ident) in field_tys.iter().zip(&gen_idents) {
                         generics.make_where_clause().predicates.push(
-                            parse_quote! { #ty: ::core::convert::From<#ident> },
+                            parse_quote! { #ty: ::derive_more::core::convert::From<#ident> },
                         );
                         generics
                             .params
@@ -235,7 +235,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::core::convert::From<(#( #gen_idents ),*)>
+                    impl #impl_gens ::derive_more::core::convert::From<(#( #gen_idents ),*)>
                      for #ident #ty_gens #where_clause
                     {
                         #[inline]

--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -42,7 +42,7 @@ pub fn struct_from(state: &State, trait_name: &'static str) -> TokenStream {
             type Err = <#field_type as #trait_path>::Err;
 
             #[inline]
-            fn from_str(src: &str) -> ::core::result::Result<Self, Self::Err> {
+            fn from_str(src: &str) -> ::derive_more::core::result::Result<Self, Self::Err> {
                 Ok(#body)
             }
         }
@@ -97,7 +97,7 @@ fn enum_from(
             type Err = ::derive_more::FromStrError;
 
             #[inline]
-            fn from_str(src: &str) -> ::core::result::Result<Self, Self::Err> {
+            fn from_str(src: &str) -> ::derive_more::core::result::Result<Self, Self::Err> {
                 Ok(match src.to_lowercase().as_str() {
                     #(#cases)*
                     _ => return Err(::derive_more::FromStrError::new(#input_type_name)),

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -177,13 +177,13 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::core::convert::From<#r #lf #m #input_ident #ty_gens>
+                    impl #impl_gens ::derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
                      for ( #( #r #lf #m #tys ),* ) #where_clause
                     {
                         #[inline]
                         fn from(value: #r #lf #m #input_ident #ty_gens) -> Self {
                             (#(
-                                <#r #m #tys as ::core::convert::From<_>>::from(
+                                <#r #m #tys as ::derive_more::core::convert::From<_>>::from(
                                     #r #m value. #fields_idents
                                 )
                             ),*)

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -36,7 +36,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics ::derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;
 
             #[inline]

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -36,7 +36,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics ::derive_more::core::ops::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;
 
             #[inline]
@@ -108,7 +108,7 @@ fn enum_output_type_and_content(
                 let method_iter = method_iter.by_ref();
                 let mut body = quote! { #subtype(#(#vars.#method_iter()),*) };
                 if has_unit_type {
-                    body = quote! { ::core::result::Result::Ok(#body) }
+                    body = quote! { ::derive_more::core::result::Result::Ok(#body) }
                 }
                 let matcher = quote! {
                     #subtype(#(#vars),*) => {
@@ -135,7 +135,7 @@ fn enum_output_type_and_content(
                     #subtype{#(#field_names: #vars.#method_iter()),*}
                 };
                 if has_unit_type {
-                    body = quote! { ::core::result::Result::Ok(#body) }
+                    body = quote! { ::derive_more::core::result::Result::Ok(#body) }
                 }
                 let matcher = quote! {
                     #subtype{#(#field_names: #vars),*} => {
@@ -147,7 +147,7 @@ fn enum_output_type_and_content(
             Fields::Unit => {
                 let operation_name = method_ident.to_string();
                 matches.push(quote! {
-                    #subtype => ::core::result::Result::Err(
+                    #subtype => ::derive_more::core::result::Result::Err(
                         ::derive_more::UnitError::new(#operation_name)
                     )
                 });
@@ -162,7 +162,7 @@ fn enum_output_type_and_content(
     };
 
     let output_type = if has_unit_type {
-        quote! { ::core::result::Result<#input_type #ty_generics, ::derive_more::UnitError> }
+        quote! { ::derive_more::core::result::Result<#input_type #ty_generics, ::derive_more::UnitError> }
     } else {
         quote! { #input_type #ty_generics }
     };

--- a/impl/src/sum_like.rs
+++ b/impl/src/sum_like.rs
@@ -18,7 +18,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let op_trait_name = if trait_name == "Sum" { "Add" } else { "Mul" };
     let op_trait_ident = format_ident!("{op_trait_name}");
-    let op_path = quote! { ::core::ops::#op_trait_ident };
+    let op_path = quote! { ::derive_more::core::ops::#op_trait_ident };
     let op_method_ident = format_ident!("{}", op_trait_name.to_lowercase());
     let has_type_params = input.generics.type_params().next().is_none();
     let generics = if has_type_params {
@@ -36,7 +36,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let initializers: Vec<_> = field_types
         .iter()
         .map(|field_type| {
-            quote! { #trait_path::#method_ident(::core::iter::empty::<#field_type>()) }
+            quote! { #trait_path::#method_ident(::derive_more::core::iter::empty::<#field_type>()) }
         })
         .collect();
     let identity = multi_field_data.initializer(&initializers);
@@ -45,7 +45,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]
-            fn #method_ident<I: ::core::iter::Iterator<Item = Self>>(iter: I) -> Self {
+            fn #method_ident<I: ::derive_more::core::iter::Iterator<Item = Self>>(iter: I) -> Self {
                 iter.fold(#identity, #op_path::#op_method_ident)
             }
         }

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -119,18 +119,18 @@ impl ToTokens for Expansion {
 
         quote! {
             #[automatically_derived]
-            impl #impl_generics ::core::convert::TryFrom<#repr_ty #ty_generics> for #ident
+            impl #impl_generics ::derive_more::core::convert::TryFrom<#repr_ty #ty_generics> for #ident
                  #where_clause
             {
                 type Error = ::derive_more::TryFromReprError<#repr_ty>;
 
                 #[allow(non_upper_case_globals)]
                 #[inline]
-                fn try_from(val: #repr_ty) -> ::core::result::Result<Self, Self::Error> {
+                fn try_from(val: #repr_ty) -> ::derive_more::core::result::Result<Self, Self::Error> {
                     #( const #consts: #repr_ty = #discriminants; )*
                     match val {
-                        #(#consts => ::core::result::Result::Ok(#ident::#variants),)*
-                        _ => ::core::result::Result::Err(::derive_more::TryFromReprError::new(val)),
+                        #(#consts => ::derive_more::core::result::Result::Ok(#ident::#variants),)*
+                        _ => ::derive_more::core::result::Result::Err(::derive_more::TryFromReprError::new(val)),
                     }
                 }
             }

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -121,9 +121,7 @@ impl ToTokens for Expansion {
 
         quote! {
             #[automatically_derived]
-            impl #impl_generics ::derive_more::core::convert::TryFrom<#repr_ty #ty_generics> for #ident
-                 #where_clause
-            {
+            impl #impl_generics ::derive_more::TryFrom<#repr_ty #ty_generics> for #ident #where_clause {
                 type Error = ::derive_more::TryFromReprError<#repr_ty>;
 
                 #[allow(non_upper_case_globals)]

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -102,17 +102,21 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         let try_from = quote! {
             #[automatically_derived]
             impl #impl_generics
-                 ::core::convert::TryFrom<#reference_with_lifetime #input_type #ty_generics> for
+                 ::derive_more::core::convert::TryFrom<#reference_with_lifetime #input_type #ty_generics> for
                  (#(#reference_with_lifetime #original_types),*)
                  #where_clause
             {
                 type Error = ::derive_more::TryIntoError<#reference_with_lifetime #input_type>;
 
                 #[inline]
-                fn try_from(value: #reference_with_lifetime #input_type #ty_generics) -> ::core::result::Result<Self, Self::Error> {
+                fn try_from(
+                    value: #reference_with_lifetime #input_type #ty_generics,
+                ) -> ::derive_more::core::result::Result<Self, Self::Error> {
                     match value {
-                        #(#matchers)|* => ::core::result::Result::Ok(#vars),
-                        _ => ::core::result::Result::Err(::derive_more::TryIntoError::new(value, #variant_names, #output_type)),
+                        #(#matchers)|* => ::derive_more::core::result::Result::Ok(#vars),
+                        _ => ::derive_more::core::result::Result::Err(
+                            ::derive_more::TryIntoError::new(value, #variant_names, #output_type),
+                        ),
                     }
                 }
             }

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -144,7 +144,7 @@ pub fn add_extra_type_param_bound_op_output<'a>(
     for type_param in &mut generics.type_params_mut() {
         let type_ident = &type_param.ident;
         let bound: TypeParamBound = parse_quote! {
-            ::core::ops::#trait_ident<Output=#type_ident>
+            ::derive_more::core::ops::#trait_ident<Output=#type_ident>
         };
         type_param.bounds.push(bound)
     }
@@ -156,7 +156,7 @@ pub fn add_extra_ty_param_bound_op<'a>(
     generics: &'a Generics,
     trait_ident: &'a Ident,
 ) -> Generics {
-    add_extra_ty_param_bound(generics, &quote! { ::core::ops::#trait_ident })
+    add_extra_ty_param_bound(generics, &quote! { ::derive_more::core::ops::#trait_ident })
 }
 
 pub fn add_extra_ty_param_bound<'a>(
@@ -226,11 +226,11 @@ pub fn add_where_clauses_for_new_ident<'a>(
     sized: bool,
 ) -> Generics {
     let generic_param = if fields.len() > 1 {
-        quote! { #type_ident: ::core::marker::Copy }
+        quote! { #type_ident: ::derive_more::core::marker::Copy }
     } else if sized {
         quote! { #type_ident }
     } else {
-        quote! { #type_ident: ?::core::marker::Sized }
+        quote! { #type_ident: ?::derive_more::core::marker::Sized }
     };
 
     let generics = add_extra_where_clauses(generics, type_where_clauses);

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -156,7 +156,10 @@ pub fn add_extra_ty_param_bound_op<'a>(
     generics: &'a Generics,
     trait_ident: &'a Ident,
 ) -> Generics {
-    add_extra_ty_param_bound(generics, &quote! { ::derive_more::core::ops::#trait_ident })
+    add_extra_ty_param_bound(
+        generics,
+        &quote! { ::derive_more::core::ops::#trait_ident },
+    )
 }
 
 pub fn add_extra_ty_param_bound<'a>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,12 @@
 #![forbid(non_ascii_idents, unsafe_code)]
 #![warn(clippy::nonstandard_macro_braces)]
 
+// For macro expansion internals only.
+// Ensures better hygiene in case a local crate `core` is present in workspace of the user code,
+// or some other crate is renamed as `core`.
+#[doc(hidden)]
+pub use core;
+
 // Not public, but exported API. For macro expansion internals only.
 #[doc(hidden)]
 pub mod __private {


### PR DESCRIPTION
Resolves #180




## Synopsis

See https://github.com/JelteF/derive_more/issues/180#issue-1091650576 for details.

At the moment, compilation fails in a local crate `core` is present in workspace or some another crate is renamed as `core`.




## Solution

Use `::derive_more::core` instead of `::core` in macro expansions.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] ~~Tests are added/updated~~ (hard to test)
- [x] [CHANGELOG entry][l:1] is added



[l:1]: /CHANGELOG.md
