### PR TITLE
Fix incorrect `fmt::Pointer` implementations

### DIFF
--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -135,6 +135,21 @@ impl ToTokens for FmtAttribute {
 }
 
 impl FmtAttribute {
+    // TODO:
+    fn append_args(&mut self, more: impl IntoIterator<Item = FmtArgument>) {
+        let more = more
+            .into_iter()
+            .filter(|new| {
+                new.alias.is_none()
+                    || self
+                        .args
+                        .iter()
+                        .all(|old| old.alias.is_none() || old.alias != new.alias)
+            })
+            .collect::<Vec<_>>();
+        self.args.extend(more);
+    }
+
     /// Checks whether this [`FmtAttribute`] can be replaced with a transparent delegation (calling
     /// a formatting trait directly instead of interpolation syntax).
     ///
@@ -278,8 +293,7 @@ impl FmtAttribute {
     }
 }
 
-/// Representation of a [named parameter][1] (`identifier '=' expression`) in
-/// in a [`FmtAttribute`].
+/// Representation of a [named parameter][1] (`identifier '=' expression`) in a [`FmtAttribute`].
 ///
 /// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#named-parameters
 #[derive(Debug)]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -102,7 +102,7 @@ mod structs {
                 assert_eq!(format!("{:03?}", UpperHex), "00B");
                 assert_eq!(format!("{:07?}", LowerExp), "03.15e0");
                 assert_eq!(format!("{:07?}", UpperExp), "03.15E0");
-                assert_eq!(format!("{:018?}", Pointer).len(), 18);
+                assert_eq!(format!("{:018?}", Pointer), format!("{POINTER:018p}"));
             }
 
             mod omitted {
@@ -245,6 +245,35 @@ mod structs {
                     format!("{:#?}", Struct { field: 0 }),
                     "Struct {\n    field: 0.0,\n}",
                 );
+            }
+
+            mod pointer {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                struct Tuple<'a>(#[debug("{_0:p}.{:p}", self.0)] &'a i32);
+
+                #[derive(Debug)]
+                struct Struct<'a> {
+                    #[debug("{field:p}.{:p}", self.field)]
+                    field: &'a i32,
+                }
+
+                #[test]
+                fn assert() {
+                    let a = 42;
+                    assert_eq!(
+                        format!("{:?}", Tuple(&a)),
+                        format!("Tuple({0:p}.{0:p})", &a),
+                    );
+                    assert_eq!(
+                        format!("{:?}", Struct { field: &a }),
+                        format!("Struct {{ field: {0:p}.{0:p} }}", &a),
+                    );
+                }
             }
         }
 
@@ -527,6 +556,37 @@ mod structs {
                 assert_eq!(format!("{:?}", Tuple(10, true)), "10 * true");
                 assert_eq!(format!("{:?}", Struct { a: 10, b: true }), "10 * true");
             }
+
+            mod pointer {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                #[debug("{_0:p} * {_1:p}", _0 = self.0)]
+                struct Tuple<'a, 'b>(&'a u8, &'b bool);
+
+                #[derive(Debug)]
+                #[debug("{a:p} * {b:p}", a = self.a)]
+                struct Struct<'a, 'b> {
+                    a: &'a u8,
+                    b: &'b bool,
+                }
+
+                #[test]
+                fn assert() {
+                    let (a, b) = (10, true);
+                    assert_eq!(
+                        format!("{:?}", Tuple(&a, &b)),
+                        format!("{:p} * {:p}", &a, &b),
+                    );
+                    assert_eq!(
+                        format!("{:?}", Struct { a: &a, b: &b }),
+                        format!("{:p} * {:p}", &a, &b),
+                    );
+                }
+            }
         }
 
         mod ignore {
@@ -677,7 +737,10 @@ mod enums {
                 assert_eq!(format!("{:03?}", Unit::UpperHex), "00B");
                 assert_eq!(format!("{:07?}", Unit::LowerExp), "03.15e0");
                 assert_eq!(format!("{:07?}", Unit::UpperExp), "03.15E0");
-                assert_eq!(format!("{:018?}", Unit::Pointer).len(), 18);
+                assert_eq!(
+                    format!("{:018?}", Unit::Pointer),
+                    format!("{POINTER:018p}"),
+                );
             }
 
             mod omitted {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -140,7 +140,7 @@ mod structs {
                     assert_eq!(format!("{:03}", UpperHex), "00B");
                     assert_eq!(format!("{:07}", LowerExp), "03.15e0");
                     assert_eq!(format!("{:07}", UpperExp), "03.15E0");
-                    assert_eq!(format!("{:018}", Pointer).len(), 18);
+                    assert_eq!(format!("{:018}", Pointer), format!("{POINTER:018p}"));
                 }
             }
 
@@ -323,9 +323,10 @@ mod structs {
                         format!("{:07E}", StructUpperExp { field: 42.0 }),
                         "004.2E1",
                     );
+                    let a = 42;
                     assert_eq!(
-                        format!("{:018p}", StructPointer { field: &42 }).len(),
-                        18,
+                        format!("{:018p}", StructPointer { field: &a }),
+                        format!("{:018p}", &a),
                     );
                 }
             }
@@ -395,9 +396,10 @@ mod structs {
                         format!("{:07}", StructUpperExp { field: 42.0 }),
                         "004.2E1",
                     );
+                    let a = 42;
                     assert_eq!(
-                        format!("{:018}", StructPointer { field: &42 }).len(),
-                        18,
+                        format!("{:018}", StructPointer { field: &a }),
+                        format!("{:018p}", &a),
                     );
                 }
             }
@@ -467,9 +469,10 @@ mod structs {
                         format!("{:07}", StructUpperExp { field: 42.0 }),
                         "4.2E1",
                     );
-                    assert_ne!(
-                        format!("{:018}", StructPointer { field: &42 }).len(),
-                        18,
+                    let a = 42;
+                    assert_eq!(
+                        format!("{:018}", StructPointer { field: &a }),
+                        format!("{:p}", &a),
                     );
                 }
             }
@@ -672,9 +675,10 @@ mod structs {
                         format!("{:07}", StructUpperExp { a: 41.0, b: 42.0 }),
                         "004.2E1",
                     );
+                    let (a, b) = (42, 43);
                     assert_eq!(
-                        format!("{:018}", StructPointer { a: &42, b: &43 }).len(),
-                        18,
+                        format!("{:018}", StructPointer { a: &a, b: &b }),
+                        format!("{:018p}", &b),
                     );
                 }
             }
@@ -763,7 +767,10 @@ mod enums {
                     assert_eq!(format!("{:03}", Unit::UpperHex), "00B");
                     assert_eq!(format!("{:07}", Unit::LowerExp), "03.15e0");
                     assert_eq!(format!("{:07}", Unit::UpperExp), "03.15E0");
-                    assert_eq!(format!("{:018}", Unit::Pointer).len(), 18);
+                    assert_eq!(
+                        format!("{:018}", Unit::Pointer),
+                        format!("{POINTER:018p}"),
+                    );
                 }
             }
 
@@ -921,8 +928,15 @@ mod enums {
                         format!("{:07E}", UpperExp::B { field: 43.0 }),
                         "004.3E1",
                     );
-                    assert_eq!(format!("{:018p}", Pointer::A(&7)).len(), 18);
-                    assert_eq!(format!("{:018p}", Pointer::B { field: &42 }).len(), 18);
+                    let (a, b) = (7, 42);
+                    assert_eq!(
+                        format!("{:018p}", Pointer::A(&a)),
+                        format!("{:018p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:018p}", Pointer::B { field: &b }),
+                        format!("{:018p}", &b),
+                    );
                 }
             }
 
@@ -1025,8 +1039,15 @@ mod enums {
                         format!("{:07}", UpperExp::B { field: 43.0 }),
                         "004.3E1",
                     );
-                    assert_eq!(format!("{:018}", Pointer::A(&7)).len(), 18);
-                    assert_eq!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
+                    let (a, b) = (7, 42);
+                    assert_eq!(
+                        format!("{:018}", Pointer::A(&a)),
+                        format!("{:018p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { field: &b }),
+                        format!("{:018p}", &b),
+                    );
                 }
             }
 
@@ -1123,8 +1144,12 @@ mod enums {
                     assert_eq!(format!("{:07}", LowerExp::B { field: 43.0 }), "4.3e1");
                     assert_eq!(format!("{:07}", UpperExp::A(42.0)), "4.2E1");
                     assert_eq!(format!("{:07}", UpperExp::B { field: 43.0 }), "4.3E1");
-                    assert_ne!(format!("{:018}", Pointer::A(&7)).len(), 18);
-                    assert_ne!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
+                    let (a, b) = (7, 42);
+                    assert_eq!(format!("{:018}", Pointer::A(&a)), format!("{:0p}", &a));
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { field: &b }),
+                        format!("{:p}", &b),
+                    );
                 }
             }
         }
@@ -1275,10 +1300,14 @@ mod enums {
                         format!("{:07}", UpperExp::B { a: 43.0, b: 52.0 }),
                         "004.3E1",
                     );
-                    assert_eq!(format!("{:018}", Pointer::A(&7.0, &8.3)).len(), 18);
+                    let (a, b) = (8.3, 42.1);
                     assert_eq!(
-                        format!("{:018}", Pointer::B { a: &42.1, b: &43.3 }).len(),
-                        18,
+                        format!("{:018}", Pointer::A(&7.0, &a)),
+                        format!("{:018p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { a: &b, b: &43.3 }),
+                        format!("{:018p}", &b),
                     );
                 }
             }
@@ -1869,12 +1898,19 @@ mod generic {
                     format!("{:07E}", Enum::<i8, _>::B { field: 43.0 }),
                     "004.3E1",
                 );
-                assert_eq!(format!("{:018p}", Tuple(&42)).len(), 18);
-                assert_eq!(format!("{:018p}", Struct { field: &42 }).len(), 18);
-                assert_eq!(format!("{:018p}", Enum::<_, &i8>::A(&7)).len(), 18);
+                let (a, b) = (42, 7);
+                assert_eq!(format!("{:018p}", Tuple(&a)), format!("{:018p}", &a));
                 assert_eq!(
-                    format!("{:018p}", Enum::<&i8, _>::B { field: &42 }).len(),
-                    18,
+                    format!("{:018p}", Struct { field: &a }),
+                    format!("{:018p}", &a),
+                );
+                assert_eq!(
+                    format!("{:018p}", Enum::<_, &i8>::A(&b)),
+                    format!("{:018p}", &b),
+                );
+                assert_eq!(
+                    format!("{:018p}", Enum::<&i8, _>::B { field: &a }),
+                    format!("{:018p}", &a),
                 );
             }
         }
@@ -2090,12 +2126,19 @@ mod generic {
                     format!("{:07}", EnumUpperExp::<i8, _>::B { field: 43.0 }),
                     "004.3E1",
                 );
-                assert_eq!(format!("{:018}", TuplePointer(&42)).len(), 18);
-                assert_eq!(format!("{:018}", StructPointer { field: &42 }).len(), 18);
-                assert_eq!(format!("{:018}", EnumPointer::<_, &i8>::A(&7)).len(), 18);
+                let (a, b) = (42, 7);
+                assert_eq!(format!("{:018}", TuplePointer(&a)), format!("{:018p}", &a));
                 assert_eq!(
-                    format!("{:018}", EnumPointer::<&i8, _>::B { field: &42 }).len(),
-                    18,
+                    format!("{:018}", StructPointer { field: &a }),
+                    format!("{:018p}", &a),
+                );
+                assert_eq!(
+                    format!("{:018}", EnumPointer::<_, &i8>::A(&b)),
+                    format!("{:018p}", &b),
+                );
+                assert_eq!(
+                    format!("{:018}", EnumPointer::<&i8, _>::B { field: &a }),
+                    format!("{:018p}", &a),
                 );
             }
         }


### PR DESCRIPTION
## Synopsis

`Debug` and `Display` derives allow referring fields via short syntax (`_0` for unnamed fields and `name` for named fields):
```rust
#[derive(Display)]
#[display("{_0:o}")]
struct OctalInt(i32);
```
The way this works is by introducing a local binding in the macro expansion:
```rust
let _0 = &self.0;
```

This, however, introduces double pointer indirection. For most of the `fmt` traits, this is totally OK. However, the `fmt::Pointer` is sensitive to that:
```rust
#[derive(Display)]
#[display("--> {_0:p}")]
struct Int(&'static i32);

// expands to
impl fmt::Display for Int {
    fn fmt(&self, f: fmt::Formatter<'_>) -> fmt::Result {
        let _0 = &self.0; // has `&&i32` type, not `&i32`
        write!(f, "--> {_0:p}") // so, prints address of the `_0` local binding, 
                                // not the one of the `self.0` field as we would expect
    }
}
```




## Solution

Instead of introducing local bindings, try to replace this shortcuts (like `_0`) in idents and expressions with a field accessing syntax (like `self.0`). Or event just substitute `_0` with `(*_0)`, because for enum variants we cannot really access the fields via `self.`.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [ ] [CHANGELOG entry][l:1] is added




[l:1]: /CHANGELOG.md
