### PR TITLE
Add rust-patterns as a category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/derive_more"
 
 readme = "README.md"
 keywords = ["derive", "Add", "From", "Display", "IntoIterator"]
-categories = ["rust-patterns", "development-tools", "development-tools::procedural-macro-helpers", "no-std"]
+categories = ["development-tools", "development-tools::procedural-macro-helpers", "no-std", "rust-patterns"]
 
 include = [
     "src/**/*.rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/derive_more"
 
 readme = "README.md"
 keywords = ["derive", "Add", "From", "Display", "IntoIterator"]
-categories = ["development-tools", "development-tools::procedural-macro-helpers", "no-std"]
+categories = ["rust-patterns", "development-tools", "development-tools::procedural-macro-helpers", "no-std"]
 
 include = [
     "src/**/*.rs",


### PR DESCRIPTION
The description of this category fits derive_more quite well:

> Shared solutions for particular situations specific to programming in Rust.
