### PR TITLE
Add #[inline] attribute to a few more methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#298](https://github.com/JelteF/derive_more/pull/298))
 - Add `TryFrom` derive for enums to convert from their discriminant.
   ([#300](https://github.com/JelteF/derive_more/pull/300))
+- `#[inline]` attributes to `IsVariant` and `Debug` implementations.
+  ([#334](https://github.com/JelteF/derive_more/pull/334)
 
 ### Changed
 
@@ -80,8 +82,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade to `syn` 2.0.
 - The `Error` derive now works in nightly `no_std` environments when enabling
   `#![feature(error_in_core)]`.
-- `#[inline]` attributes are added to `IsVariant` and `Debug` implementations.
-  ([#334](https://github.com/JelteF/derive_more/pull/334)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade to `syn` 2.0.
 - The `Error` derive now works in nightly `no_std` environments when enabling
   `#![feature(error_in_core)]`.
+- `#[inline]` attributes are added to `IsVariant` and `Debug` implementations.
+  ([#334](https://github.com/JelteF/derive_more/pull/334)
 
 ### Fixed
 

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -37,6 +37,8 @@ pub fn expand(
     };
 
     let source = source.map(|source| {
+        // not using #[inline] on purpose since this is almost never part of a
+        // hot codepath
         quote! {
             fn source(&self) -> Option<&(dyn ::derive_more::Error + 'static)> {
                 use ::derive_more::__private::AsDynError;
@@ -46,6 +48,8 @@ pub fn expand(
     });
 
     let provide = provide.map(|provide| {
+        // not using #[inline] on purpose since this is almost never part of a
+        // hot codepath
         quote! {
             fn provide<'_request>(&'_request self, request: &mut ::derive_more::core::error::Request<'_request>) {
                 #provide

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -37,8 +37,8 @@ pub fn expand(
     };
 
     let source = source.map(|source| {
-        // not using #[inline] on purpose since this is almost never part of a
-        // hot codepath
+        // Not using `#[inline]` here on purpose, since this is almost never part
+        // of a hot codepath.
         quote! {
             fn source(&self) -> Option<&(dyn ::derive_more::Error + 'static)> {
                 use ::derive_more::__private::AsDynError;
@@ -48,8 +48,8 @@ pub fn expand(
     });
 
     let provide = provide.map(|provide| {
-        // not using #[inline] on purpose since this is almost never part of a
-        // hot codepath
+        // Not using `#[inline]` here on purpose, since this is almost never part
+        // of a hot codepath.
         quote! {
             fn provide<'_request>(&'_request self, request: &mut ::derive_more::core::error::Request<'_request>) {
                 #provide

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -47,6 +47,7 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
         impl #impl_gens ::derive_more::Debug for #ident #ty_gens #where_clause {
+            #[inline]
             fn fmt(
                 &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
             ) -> ::derive_more::core::fmt::Result {

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -44,6 +44,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             #[doc = "Returns `true` if this value is of type `"]
             #[doc = #variant_name]
             #[doc = "`. Returns `false` otherwise"]
+            #[inline]
             pub const fn #fn_name(&self) -> bool {
                 match self {
                     #enum_name ::#variant_ident #data_pattern => true,


### PR DESCRIPTION
To be clear the `#[inline]` does not hint that inlining is beneficial,
but it does give the compiler the option to inline if the compiler
things it would be beneficial.

This starts adding the `#[inline]` attribute to:

1. `IsVariant`: it's expected that this is often beneficial since its
   body is tiny.
2. `Debug`: This is to stay in line with the `std` implementation of the
   `Debug` derive. https://github.com/rust-lang/rust/pull/117727

It also explicitely doesn't add the attribute to the methods of `Error`,
since those are almost never called in hot code paths.

Fixes #317
