### PR TITLE
Upgrade `syn` crate to 2.0.45 version

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "2.0"
+syn = "2.0.45"
 convert_case = { version = "0.6", optional = true }
 unicode-xid = { version = "0.2.2", optional = true }
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1914,3 +1914,21 @@ mod generic {
         }
     }
 }
+
+// See: https://github.com/JelteF/derive_more/issues/301
+mod complex_enum_syntax {
+    #[cfg(not(feature = "std"))]
+    use alloc::{boxed::Box, format};
+
+    use derive_more::Debug;
+
+    #[derive(Debug)]
+    enum Enum {
+        A = if cfg!(unix) { 2 } else { 3 },
+    }
+
+    #[test]
+    fn assert() {
+        assert_eq!(format!("{:?}", Enum::A), "A");
+    }
+}


### PR DESCRIPTION
Related to #301




## Synopsis

[`syn`  2.0.45 fixes](https://github.com/dtolnay/syn/issues/1513#issuecomment-1873450968) the #301 issue:

> Otherwise this would not work:
> 
> ```rust
> #[derive(derive_more::Debug)]
> enum Enum {
>     A = if cfg!(unix) { 2 } else { 3 },
> }
> ```
> 
> ```
> error: proc-macro derive panicked
>  --> src/main.rs:1:10
>   |
> 1 | #[derive(derive_more::Debug)]
>   |          ^^^^^^^^^^^^^^^^^^
>   |
>   = help: message: called `Result::unwrap()` on an `Err` value: Error("unsupported expression; enable syn's features=[\"full\"]")
> ```




## Solution

Upgrade minimal version of `syn` up to 2.0.45 version and cover the use case with tests for future regressions.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)




[l:1]: /CHANGELOG.md
