### PR TITLE
Refactor `::derive_more` absolute paths to just `derive_more` (#338)

### DIFF
--- a/impl/doc/add.md
+++ b/impl/doc/add.md
@@ -112,9 +112,9 @@ Code like this will be generated:
 #     UnsignedTwo(u32),
 #     Unit,
 # }
-impl ::core::ops::Add for MixedInts {
-    type Output = Result<MixedInts, ::derive_more::BinaryError>;
-    fn add(self, rhs: MixedInts) -> Result<MixedInts, ::derive_more::BinaryError> {
+impl derive_more::core::ops::Add for MixedInts {
+    type Output = Result<MixedInts, derive_more::BinaryError>;
+    fn add(self, rhs: MixedInts) -> Result<MixedInts, derive_more::BinaryError> {
         match (self, rhs) {
             (MixedInts::SmallInt(__l_0), MixedInts::SmallInt(__r_0)) => {
                 Ok(MixedInts::SmallInt(__l_0.add(__r_0)))
@@ -138,11 +138,11 @@ impl ::core::ops::Add for MixedInts {
             (MixedInts::UnsignedTwo(__l_0), MixedInts::UnsignedTwo(__r_0)) => {
                 Ok(MixedInts::UnsignedTwo(__l_0.add(__r_0)))
             }
-            (MixedInts::Unit, MixedInts::Unit) => Err(::derive_more::BinaryError::Unit(
-                ::derive_more::UnitError::new("add"),
+            (MixedInts::Unit, MixedInts::Unit) => Err(derive_more::BinaryError::Unit(
+                derive_more::UnitError::new("add"),
             )),
-            _ => Err(::derive_more::BinaryError::Mismatch(
-                ::derive_more::WrongVariantError::new("add"),
+            _ => Err(derive_more::BinaryError::Mismatch(
+                derive_more::WrongVariantError::new("add"),
             )),
         }
     }

--- a/impl/doc/from_str.md
+++ b/impl/doc/from_str.md
@@ -122,13 +122,13 @@ Code like this will be generated:
 # }
 #
 impl ::core::str::FromStr for EnumNoFields {
-    type Err = ::derive_more::FromStrError;
+    type Err = derive_more::FromStrError;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Ok(match src.to_lowercase().as_str() {
             "foo" => EnumNoFields::Foo,
             "bar" => EnumNoFields::Bar,
             "baz" => EnumNoFields::Baz,
-            _ => return Err(::derive_more::FromStrError::new("EnumNoFields")),
+            _ => return Err(derive_more::FromStrError::new("EnumNoFields")),
         })
     }
 }

--- a/impl/doc/not.md
+++ b/impl/doc/not.md
@@ -23,7 +23,7 @@ Code like this will be generated:
 
 ```rust
 # struct MyInts(i32, i32);
-impl ::core::ops::Not for MyInts {
+impl derive_more::core::ops::Not for MyInts {
     type Output = MyInts;
     fn not(self) -> MyInts {
         MyInts(self.0.not(), self.1.not())
@@ -57,7 +57,7 @@ Code like this will be generated:
 #     x: i32,
 #     y: i32,
 # }
-impl ::core::ops::Not for Point2D {
+impl derive_more::core::ops::Not for Point2D {
     type Output = Point2D;
     fn not(self) -> Point2D {
         Point2D {
@@ -104,7 +104,7 @@ Code like this will be generated:
 #     UnsignedOne(u32),
 #     UnsignedTwo(u32),
 # }
-impl ::core::ops::Not for MixedInts {
+impl derive_more::core::ops::Not for MixedInts {
     type Output = MixedInts;
     fn not(self) -> MixedInts {
         match self {
@@ -147,12 +147,12 @@ Code like this will be generated:
 #     SmallInt(i32),
 #     Unit,
 # }
-impl ::core::ops::Not for EnumWithUnit {
-    type Output = Result<EnumWithUnit, ::derive_more::UnitError>;
-    fn not(self) -> Result<EnumWithUnit, ::derive_more::UnitError> {
+impl derive_more::core::ops::Not for EnumWithUnit {
+    type Output = Result<EnumWithUnit, derive_more::UnitError>;
+    fn not(self) -> Result<EnumWithUnit, derive_more::UnitError> {
         match self {
             EnumWithUnit::SmallInt(__0) => Ok(EnumWithUnit::SmallInt(__0.not())),
-            EnumWithUnit::Unit => Err(::derive_more::UnitError::new("not")),
+            EnumWithUnit::Unit => Err(derive_more::UnitError::new("not")),
         }
     }
 }

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -29,7 +29,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             #[inline]
             fn #method_ident(&mut self, rhs: #input_type #ty_generics) {
                 #( #exprs; )*

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -32,7 +32,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
         },
         Data::Enum(ref data_enum) => (
             quote! {
-                ::derive_more::core::result::Result<#input_type #ty_generics, ::derive_more::BinaryError>
+                derive_more::core::result::Result<#input_type #ty_generics, derive_more::BinaryError>
             },
             enum_content(input_type, data_enum, &method_ident),
         ),
@@ -42,7 +42,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;
 
             #[inline]
@@ -98,7 +98,7 @@ fn enum_content(
                 let matcher = quote! {
                     (#subtype(#(#l_vars),*),
                      #subtype(#(#r_vars),*)) => {
-                        ::derive_more::core::result::Result::Ok(#subtype(#(#l_vars.#method_iter(#r_vars)),*))
+                        derive_more::core::result::Result::Ok(#subtype(#(#l_vars.#method_iter(#r_vars)),*))
                     }
                 };
                 matches.push(matcher);
@@ -117,7 +117,7 @@ fn enum_content(
                 let matcher = quote! {
                     (#subtype{#(#field_names: #l_vars),*},
                      #subtype{#(#field_names: #r_vars),*}) => {
-                        ::derive_more::core::result::Result::Ok(#subtype{
+                        derive_more::core::result::Result::Ok(#subtype{
                             #(#field_names: #l_vars.#method_iter(#r_vars)),*
                         })
                     }
@@ -127,9 +127,9 @@ fn enum_content(
             Fields::Unit => {
                 let operation_name = method_ident.to_string();
                 matches.push(quote! {
-                    (#subtype, #subtype) => ::derive_more::core::result::Result::Err(
-                        ::derive_more::BinaryError::Unit(
-                            ::derive_more::UnitError::new(#operation_name)
+                    (#subtype, #subtype) => derive_more::core::result::Result::Err(
+                        derive_more::BinaryError::Unit(
+                            derive_more::UnitError::new(#operation_name)
                         )
                     )
                 });
@@ -142,8 +142,8 @@ fn enum_content(
         // match.
         let operation_name = method_ident.to_string();
         matches.push(quote! {
-            _ => ::derive_more::core::result::Result::Err(::derive_more::BinaryError::Mismatch(
-                ::derive_more::WrongVariantError::new(#operation_name)
+            _ => derive_more::core::result::Result::Err(derive_more::BinaryError::Mismatch(
+                derive_more::WrongVariantError::new(#operation_name)
             ))
         });
     }

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -240,7 +240,7 @@ impl<'a> ToTokens for Expansion<'a> {
             };
 
             let trait_ty = quote! {
-                ::derive_more::#trait_ident <#return_ty>
+                derive_more::#trait_ident <#return_ty>
             };
 
             let generics = match &impl_kind {
@@ -253,7 +253,7 @@ impl<'a> ToTokens for Expansion<'a> {
                     if is_blanket {
                         generics
                             .params
-                            .push(parse_quote! { #return_ty: ?::derive_more::core::marker::Sized });
+                            .push(parse_quote! { #return_ty: ?derive_more::core::marker::Sized });
                     }
                     Cow::Owned(generics)
                 }
@@ -270,11 +270,11 @@ impl<'a> ToTokens for Expansion<'a> {
                     <#field_ty as #trait_ty>::#method_ident(#field_ref)
                 }),
                 ImplKind::Specialized => Cow::Owned(quote! {
-                    use ::derive_more::__private::ExtractRef as _;
+                    use derive_more::__private::ExtractRef as _;
 
                     let conv =
-                        <::derive_more::__private::Conv<& #mut_ #field_ty, #return_ty>
-                         as ::derive_more::core::default::Default>::default();
+                        <derive_more::__private::Conv<& #mut_ #field_ty, #return_ty>
+                         as derive_more::core::default::Default>::default();
                     (&&conv).__extract_ref(#field_ref)
                 }),
             };

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -40,8 +40,8 @@ pub fn expand(
         // Not using `#[inline]` here on purpose, since this is almost never part
         // of a hot codepath.
         quote! {
-            fn source(&self) -> Option<&(dyn ::derive_more::Error + 'static)> {
-                use ::derive_more::__private::AsDynError;
+            fn source(&self) -> Option<&(dyn derive_more::Error + 'static)> {
+                use derive_more::__private::AsDynError;
                 #source
             }
         }
@@ -51,7 +51,7 @@ pub fn expand(
         // Not using `#[inline]` here on purpose, since this is almost never part
         // of a hot codepath.
         quote! {
-            fn provide<'_request>(&'_request self, request: &mut ::derive_more::core::error::Request<'_request>) {
+            fn provide<'_request>(&'_request self, request: &mut derive_more::core::error::Request<'_request>) {
                 #provide
             }
         }
@@ -65,7 +65,7 @@ pub fn expand(
             &generics,
             quote! {
                 where
-                    #ident #ty_generics: ::derive_more::core::fmt::Debug + ::derive_more::core::fmt::Display
+                    #ident #ty_generics: derive_more::core::fmt::Debug + derive_more::core::fmt::Display
             },
         );
     }
@@ -76,9 +76,9 @@ pub fn expand(
             &generics,
             quote! {
                 where #(
-                    #bounds: ::derive_more::core::fmt::Debug
-                             + ::derive_more::core::fmt::Display
-                             + ::derive_more::Error
+                    #bounds: derive_more::core::fmt::Debug
+                             + derive_more::core::fmt::Display
+                             + derive_more::Error
                              + 'static
                 ),*
             },
@@ -89,7 +89,7 @@ pub fn expand(
 
     let render = quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::Error for #ident #ty_generics #where_clause {
+        impl #impl_generics derive_more::Error for #ident #ty_generics #where_clause {
             #source
             #provide
         }
@@ -213,7 +213,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
         let source_provider = self.source.map(|source| {
             let source_expr = &self.data.members[source];
             quote! {
-                ::derive_more::Error::provide(&#source_expr, request);
+                derive_more::Error::provide(&#source_expr, request);
             }
         });
         let backtrace_provider = self
@@ -243,7 +243,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
-                        ::derive_more::Error::provide(source, request);
+                        derive_more::Error::provide(source, request);
                     }
                 })
             }
@@ -255,7 +255,7 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 Some(quote! {
                     #pattern => {
                         request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
-                        ::derive_more::Error::provide(source, request);
+                        derive_more::Error::provide(source, request);
                     }
                 })
             }

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -46,11 +46,11 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_gens ::derive_more::Debug for #ident #ty_gens #where_clause {
+        impl #impl_gens derive_more::Debug for #ident #ty_gens #where_clause {
             #[inline]
             fn fmt(
-                &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
-            ) -> ::derive_more::core::fmt::Result {
+                &self, __derive_more_f: &mut derive_more::core::fmt::Formatter<'_>
+            ) -> derive_more::core::fmt::Result {
                 #body
             }
         }
@@ -228,9 +228,9 @@ impl<'a> Expansion<'a> {
     fn generate_body(&self) -> syn::Result<TokenStream> {
         if let Some(fmt) = &self.attr.fmt {
             return Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                quote! { ::derive_more::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
+                quote! { derive_more::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
             } else {
-                quote! { ::derive_more::core::write!(__derive_more_f, #fmt) }
+                quote! { derive_more::core::write!(__derive_more_f, #fmt) }
             });
         };
 
@@ -238,7 +238,7 @@ impl<'a> Expansion<'a> {
             syn::Fields::Unit => {
                 let ident = self.ident.to_string();
                 Ok(quote! {
-                    ::derive_more::core::fmt::Formatter::write_str(
+                    derive_more::core::fmt::Formatter::write_str(
                         __derive_more_f,
                         #ident,
                     )
@@ -249,7 +249,7 @@ impl<'a> Expansion<'a> {
                 let ident_str = self.ident.to_string();
 
                 let out = quote! {
-                    &mut ::derive_more::__private::debug_tuple(
+                    &mut derive_more::__private::debug_tuple(
                         __derive_more_f,
                         #ident_str,
                     )
@@ -265,24 +265,24 @@ impl<'a> Expansion<'a> {
                                 Ok::<_, syn::Error>(out)
                             }
                             Some(FieldAttribute::Right(fmt_attr)) => Ok(quote! {
-                                ::derive_more::__private::DebugTuple::field(
+                                derive_more::__private::DebugTuple::field(
                                     #out,
-                                    &::derive_more::core::format_args!(#fmt_attr),
+                                    &derive_more::core::format_args!(#fmt_attr),
                                 )
                             }),
                             None => {
                                 let ident = format_ident!("_{i}");
                                 Ok(quote! {
-                                    ::derive_more::__private::DebugTuple::field(#out, #ident)
+                                    derive_more::__private::DebugTuple::field(#out, #ident)
                                 })
                             }
                         }
                     },
                 )?;
                 Ok(if exhaustive {
-                    quote! { ::derive_more::__private::DebugTuple::finish(#out) }
+                    quote! { derive_more::__private::DebugTuple::finish(#out) }
                 } else {
-                    quote! { ::derive_more::__private::DebugTuple::finish_non_exhaustive(#out) }
+                    quote! { derive_more::__private::DebugTuple::finish_non_exhaustive(#out) }
                 })
             }
             syn::Fields::Named(named) => {
@@ -290,7 +290,7 @@ impl<'a> Expansion<'a> {
                 let ident = self.ident.to_string();
 
                 let out = quote! {
-                    &mut ::derive_more::core::fmt::Formatter::debug_struct(
+                    &mut derive_more::core::fmt::Formatter::debug_struct(
                         __derive_more_f,
                         #ident,
                     )
@@ -308,21 +308,21 @@ impl<'a> Expansion<'a> {
                                 Ok::<_, syn::Error>(out)
                             }
                             Some(FieldAttribute::Right(fmt_attr)) => Ok(quote! {
-                                ::derive_more::core::fmt::DebugStruct::field(
+                                derive_more::core::fmt::DebugStruct::field(
                                     #out,
                                     #field_str,
-                                    &::derive_more::core::format_args!(#fmt_attr),
+                                    &derive_more::core::format_args!(#fmt_attr),
                                 )
                             }),
                             None => Ok(quote! {
-                                ::derive_more::core::fmt::DebugStruct::field(#out, #field_str, #field_ident)
+                                derive_more::core::fmt::DebugStruct::field(#out, #field_str, #field_ident)
                             }),
                         }
                     })?;
                 Ok(if exhaustive {
-                    quote! { ::derive_more::core::fmt::DebugStruct::finish(#out) }
+                    quote! { derive_more::core::fmt::DebugStruct::finish(#out) }
                 } else {
-                    quote! { ::derive_more::core::fmt::DebugStruct::finish_non_exhaustive(#out) }
+                    quote! { derive_more::core::fmt::DebugStruct::finish_non_exhaustive(#out) }
                 })
             }
         }
@@ -336,7 +336,7 @@ impl<'a> Expansion<'a> {
             out.extend(fmt.bounded_types(self.fields).map(|(ty, trait_name)| {
                 let trait_ident = format_ident!("{trait_name}");
 
-                parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }
+                parse_quote! { #ty: derive_more::core::fmt::#trait_ident }
             }));
             Ok(out)
         } else {
@@ -350,12 +350,12 @@ impl<'a> Expansion<'a> {
                             |(ty, trait_name)| {
                                 let trait_ident = format_ident!("{trait_name}");
 
-                                parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }
+                                parse_quote! { #ty: derive_more::core::fmt::#trait_ident }
                             },
                         ));
                     }
                     Some(FieldAttribute::Left(_skip)) => {}
-                    None => out.extend([parse_quote! { #ty: ::derive_more::Debug }]),
+                    None => out.extend([parse_quote! { #ty: derive_more::Debug }]),
                 }
                 Ok(out)
             })

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -50,10 +50,10 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_gens ::derive_more::#trait_ident for #ident #ty_gens #where_clause {
+        impl #impl_gens derive_more::#trait_ident for #ident #ty_gens #where_clause {
             fn fmt(
-                &self, __derive_more_f: &mut ::derive_more::core::fmt::Formatter<'_>
-            ) -> ::derive_more::core::fmt::Result {
+                &self, __derive_more_f: &mut derive_more::core::fmt::Formatter<'_>
+            ) -> derive_more::core::fmt::Result {
                 #body
             }
         }
@@ -188,7 +188,7 @@ fn expand_union(
 
     Ok((
         attrs.bounds.0.clone().into_iter().collect(),
-        quote! { ::derive_more::core::write!(__derive_more_f, #fmt) },
+        quote! { derive_more::core::write!(__derive_more_f, #fmt) },
     ))
 }
 
@@ -229,16 +229,16 @@ impl<'a> Expansion<'a> {
         match &self.attrs.fmt {
             Some(fmt) => {
                 Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                    quote! { ::derive_more::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
+                    quote! { derive_more::core::fmt::#trait_ident::fmt(&(#expr), __derive_more_f) }
                 } else {
-                    quote! { ::derive_more::core::write!(__derive_more_f, #fmt) }
+                    quote! { derive_more::core::write!(__derive_more_f, #fmt) }
                 })
             }
             None if self.fields.is_empty() => {
                 let ident_str = self.ident.to_string();
 
                 Ok(quote! {
-                    ::derive_more::core::write!(__derive_more_f, #ident_str)
+                    derive_more::core::write!(__derive_more_f, #ident_str)
                 })
             }
             None if self.fields.len() == 1 => {
@@ -251,7 +251,7 @@ impl<'a> Expansion<'a> {
                 let trait_ident = self.trait_ident;
 
                 Ok(quote! {
-                    ::derive_more::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)
+                    derive_more::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)
                 })
             }
             _ => Err(syn::Error::new(
@@ -275,7 +275,7 @@ impl<'a> Expansion<'a> {
                 .map(|f| {
                     let ty = &f.ty;
                     let trait_ident = &self.trait_ident;
-                    vec![parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }]
+                    vec![parse_quote! { #ty: derive_more::core::fmt::#trait_ident }]
                 })
                 .unwrap_or_default();
         };
@@ -284,7 +284,7 @@ impl<'a> Expansion<'a> {
             .map(|(ty, trait_name)| {
                 let trait_ident = format_ident!("{trait_name}");
 
-                parse_quote! { #ty: ::derive_more::core::fmt::#trait_ident }
+                parse_quote! { #ty: derive_more::core::fmt::#trait_ident }
             })
             .chain(self.attrs.bounds.0.clone())
             .collect()

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -165,7 +165,7 @@ impl<'a> Expansion<'a> {
                         let index = index.into_iter();
                         let from_ty = from_tys.next().unwrap_or_else(|| unreachable!());
                         quote! {
-                            #( #ident: )* <#ty as ::derive_more::From<#from_ty>>::from(
+                            #( #ident: )* <#ty as derive_more::From<#from_ty>>::from(
                                 value #( .#index )*
                             ),
                         }
@@ -173,7 +173,7 @@ impl<'a> Expansion<'a> {
 
                     Ok(quote! {
                         #[automatically_derived]
-                        impl #impl_gens ::derive_more::From<#ty> for #ident #ty_gens #where_clause {
+                        impl #impl_gens derive_more::From<#ty> for #ident #ty_gens #where_clause {
                             #[inline]
                             fn from(value: #ty) -> Self {
                                 #ident #( :: #variant )* #init
@@ -193,7 +193,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::derive_more::From<(#( #field_tys ),*)> for #ident #ty_gens #where_clause {
+                    impl #impl_gens derive_more::From<(#( #field_tys ),*)> for #ident #ty_gens #where_clause {
                         #[inline]
                         fn from(value: (#( #field_tys ),*)) -> Self {
                             #ident #( :: #variant )* #init
@@ -209,7 +209,7 @@ impl<'a> Expansion<'a> {
                     let index = index.into_iter();
                     let gen_ident = format_ident!("__FromT{i}");
                     let out = quote! {
-                        #( #ident: )* <#ty as ::derive_more::From<#gen_ident>>::from(
+                        #( #ident: )* <#ty as derive_more::From<#gen_ident>>::from(
                             value #( .#index )*
                         ),
                     };
@@ -223,7 +223,7 @@ impl<'a> Expansion<'a> {
                     let mut generics = self.generics.clone();
                     for (ty, ident) in field_tys.iter().zip(&gen_idents) {
                         generics.make_where_clause().predicates.push(
-                            parse_quote! { #ty: ::derive_more::From<#ident> },
+                            parse_quote! { #ty: derive_more::From<#ident> },
                         );
                         generics
                             .params
@@ -235,7 +235,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::derive_more::From<(#( #gen_idents ),*)> for #ident #ty_gens #where_clause {
+                    impl #impl_gens derive_more::From<(#( #gen_idents ),*)> for #ident #ty_gens #where_clause {
                         #[inline]
                         fn from(value: (#( #gen_idents ),*)) -> Self {
                             #ident #(:: #variant)* #init

--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -42,7 +42,7 @@ pub fn struct_from(state: &State, trait_name: &'static str) -> TokenStream {
             type Err = <#field_type as #trait_path>::Err;
 
             #[inline]
-            fn from_str(src: &str) -> ::derive_more::core::result::Result<Self, Self::Err> {
+            fn from_str(src: &str) -> derive_more::core::result::Result<Self, Self::Err> {
                 Ok(#body)
             }
         }
@@ -94,13 +94,13 @@ fn enum_from(
 
     quote! {
         impl #trait_path for #input_type {
-            type Err = ::derive_more::FromStrError;
+            type Err = derive_more::FromStrError;
 
             #[inline]
-            fn from_str(src: &str) -> ::derive_more::core::result::Result<Self, Self::Err> {
+            fn from_str(src: &str) -> derive_more::core::result::Result<Self, Self::Err> {
                 Ok(match src.to_lowercase().as_str() {
                     #(#cases)*
-                    _ => return Err(::derive_more::FromStrError::new(#input_type_name)),
+                    _ => return Err(derive_more::FromStrError::new(#input_type_name)),
                 })
             }
         }

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -179,13 +179,13 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
-                    impl #impl_gens ::derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
+                    impl #impl_gens derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
                      for ( #( #r #lf #m #tys ),* ) #where_clause
                     {
                         #[inline]
                         fn from(value: #r #lf #m #input_ident #ty_gens) -> Self {
                             (#(
-                                <#r #m #tys as ::derive_more::core::convert::From<_>>::from(
+                                <#r #m #tys as derive_more::core::convert::From<_>>::from(
                                     #r #m value. #fields_idents
                                 )
                             ),*)

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -36,7 +36,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics ::derive_more::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;
 
             #[inline]
@@ -108,7 +108,7 @@ fn enum_output_type_and_content(
                 let method_iter = method_iter.by_ref();
                 let mut body = quote! { #subtype(#(#vars.#method_iter()),*) };
                 if has_unit_type {
-                    body = quote! { ::derive_more::core::result::Result::Ok(#body) }
+                    body = quote! { derive_more::core::result::Result::Ok(#body) }
                 }
                 let matcher = quote! {
                     #subtype(#(#vars),*) => {
@@ -135,7 +135,7 @@ fn enum_output_type_and_content(
                     #subtype{#(#field_names: #vars.#method_iter()),*}
                 };
                 if has_unit_type {
-                    body = quote! { ::derive_more::core::result::Result::Ok(#body) }
+                    body = quote! { derive_more::core::result::Result::Ok(#body) }
                 }
                 let matcher = quote! {
                     #subtype{#(#field_names: #vars),*} => {
@@ -147,8 +147,8 @@ fn enum_output_type_and_content(
             Fields::Unit => {
                 let operation_name = method_ident.to_string();
                 matches.push(quote! {
-                    #subtype => ::derive_more::core::result::Result::Err(
-                        ::derive_more::UnitError::new(#operation_name)
+                    #subtype => derive_more::core::result::Result::Err(
+                        derive_more::UnitError::new(#operation_name)
                     )
                 });
             }
@@ -162,7 +162,7 @@ fn enum_output_type_and_content(
     };
 
     let output_type = if has_unit_type {
-        quote! { ::derive_more::core::result::Result<#input_type #ty_generics, ::derive_more::UnitError> }
+        quote! { derive_more::core::result::Result<#input_type #ty_generics, derive_more::UnitError> }
     } else {
         quote! { #input_type #ty_generics }
     };

--- a/impl/src/sum_like.rs
+++ b/impl/src/sum_like.rs
@@ -18,7 +18,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let op_trait_name = if trait_name == "Sum" { "Add" } else { "Mul" };
     let op_trait_ident = format_ident!("{op_trait_name}");
-    let op_path = quote! { ::derive_more::core::ops::#op_trait_ident };
+    let op_path = quote! { derive_more::core::ops::#op_trait_ident };
     let op_method_ident = format_ident!("{}", op_trait_name.to_lowercase());
     let has_type_params = input.generics.type_params().next().is_none();
     let generics = if has_type_params {
@@ -36,7 +36,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let initializers: Vec<_> = field_types
         .iter()
         .map(|field_type| {
-            quote! { #trait_path::#method_ident(::derive_more::core::iter::empty::<#field_type>()) }
+            quote! { #trait_path::#method_ident(derive_more::core::iter::empty::<#field_type>()) }
         })
         .collect();
     let identity = multi_field_data.initializer(&initializers);
@@ -45,7 +45,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]
-            fn #method_ident<I: ::derive_more::core::iter::Iterator<Item = Self>>(iter: I) -> Self {
+            fn #method_ident<I: derive_more::core::iter::Iterator<Item = Self>>(iter: I) -> Self {
                 iter.fold(#identity, #op_path::#op_method_ident)
             }
         }

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -121,16 +121,16 @@ impl ToTokens for Expansion {
 
         quote! {
             #[automatically_derived]
-            impl #impl_generics ::derive_more::TryFrom<#repr_ty #ty_generics> for #ident #where_clause {
-                type Error = ::derive_more::TryFromReprError<#repr_ty>;
+            impl #impl_generics derive_more::TryFrom<#repr_ty #ty_generics> for #ident #where_clause {
+                type Error = derive_more::TryFromReprError<#repr_ty>;
 
                 #[allow(non_upper_case_globals)]
                 #[inline]
-                fn try_from(val: #repr_ty) -> ::derive_more::core::result::Result<Self, Self::Error> {
+                fn try_from(val: #repr_ty) -> derive_more::core::result::Result<Self, Self::Error> {
                     #( const #consts: #repr_ty = #discriminants; )*
                     match val {
-                        #(#consts => ::derive_more::core::result::Result::Ok(#ident::#variants),)*
-                        _ => ::derive_more::core::result::Result::Err(::derive_more::TryFromReprError::new(val)),
+                        #(#consts => derive_more::core::result::Result::Ok(#ident::#variants),)*
+                        _ => derive_more::core::result::Result::Err(derive_more::TryFromReprError::new(val)),
                     }
                 }
             }

--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -102,20 +102,20 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         let try_from = quote! {
             #[automatically_derived]
             impl #impl_generics
-                 ::derive_more::core::convert::TryFrom<#reference_with_lifetime #input_type #ty_generics> for
+                 derive_more::core::convert::TryFrom<#reference_with_lifetime #input_type #ty_generics> for
                  (#(#reference_with_lifetime #original_types),*)
                  #where_clause
             {
-                type Error = ::derive_more::TryIntoError<#reference_with_lifetime #input_type>;
+                type Error = derive_more::TryIntoError<#reference_with_lifetime #input_type>;
 
                 #[inline]
                 fn try_from(
                     value: #reference_with_lifetime #input_type #ty_generics,
-                ) -> ::derive_more::core::result::Result<Self, Self::Error> {
+                ) -> derive_more::core::result::Result<Self, Self::Error> {
                     match value {
-                        #(#matchers)|* => ::derive_more::core::result::Result::Ok(#vars),
-                        _ => ::derive_more::core::result::Result::Err(
-                            ::derive_more::TryIntoError::new(value, #variant_names, #output_type),
+                        #(#matchers)|* => derive_more::core::result::Result::Ok(#vars),
+                        _ => derive_more::core::result::Result::Err(
+                            derive_more::TryIntoError::new(value, #variant_names, #output_type),
                         ),
                     }
                 }

--- a/impl/src/try_unwrap.rs
+++ b/impl/src/try_unwrap.rs
@@ -18,7 +18,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     )?;
     assert!(
         state.derive_type == DeriveType::Enum,
-        "TryUnwrap can only be derived for enums"
+        "TryUnwrap can only be derived for enums",
     );
 
     let enum_name = &input.ident;
@@ -71,9 +71,9 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             #[track_caller]
             #[doc = #doc_owned]
             #[doc = #doc_else]
-            pub fn #fn_name(self) -> Result<(#(#data_types),*), ::derive_more::TryUnwrapError<Self>> {
+            pub fn #fn_name(self) -> derive_more::core::result::Result<(#(#data_types),*), derive_more::TryUnwrapError<Self>> {
                 match self {
-                    #pattern => Ok(#ret_value),
+                    #pattern => derive_more::core::result::Result::Ok(#ret_value),
                     val @ _ => #failed_block,
                 }
             }
@@ -84,9 +84,9 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             #[track_caller]
             #[doc = #doc_ref]
             #[doc = #doc_else]
-            pub fn #ref_fn_name(&self) -> Result<(#(&#data_types),*), ::derive_more::TryUnwrapError<&Self>> {
+            pub fn #ref_fn_name(&self) -> derive_more::core::result::Result<(#(&#data_types),*), derive_more::TryUnwrapError<&Self>> {
                 match self {
-                    #pattern => Ok(#ret_value),
+                    #pattern => derive_more::core::result::Result::Ok(#ret_value),
                     val @ _ => #failed_block_ref,
                 }
             }
@@ -97,9 +97,9 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             #[track_caller]
             #[doc = #doc_mut]
             #[doc = #doc_else]
-            pub fn #mut_fn_name(&mut self) -> Result<(#(&mut #data_types),*), ::derive_more::TryUnwrapError<&mut Self>> {
+            pub fn #mut_fn_name(&mut self) -> derive_more::core::result::Result<(#(&mut #data_types),*), derive_more::TryUnwrapError<&mut Self>> {
                 match self {
-                    #pattern => Ok(#ret_value),
+                    #pattern => derive_more::core::result::Result::Ok(#ret_value),
                     val @ _ => #failed_block_mut,
                 }
             }
@@ -154,8 +154,8 @@ fn failed_block(state: &State, enum_name: &Ident, func_name: &Ident) -> TokenStr
                 Fields::Unit => quote! {},
             };
             let variant_ident = &variant.ident;
-        let error = quote! { ::derive_more::TryUnwrapError::<_>::new(val, stringify!(#enum_name), stringify!(#variant_ident), stringify!(#func_name)) };
-            quote! { val @ #enum_name :: #variant_ident #data_pattern => Err(#error) }
+        let error = quote! { derive_more::TryUnwrapError::<_>::new(val, stringify!(#enum_name), stringify!(#variant_ident), stringify!(#func_name)) };
+            quote! { val @ #enum_name :: #variant_ident #data_pattern => derive_more::core::result::Result::Err(#error) }
         });
 
     quote! {

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -144,7 +144,7 @@ pub fn add_extra_type_param_bound_op_output<'a>(
     for type_param in &mut generics.type_params_mut() {
         let type_ident = &type_param.ident;
         let bound: TypeParamBound = parse_quote! {
-            ::derive_more::core::ops::#trait_ident<Output=#type_ident>
+            derive_more::core::ops::#trait_ident<Output = #type_ident>
         };
         type_param.bounds.push(bound)
     }
@@ -158,7 +158,7 @@ pub fn add_extra_ty_param_bound_op<'a>(
 ) -> Generics {
     add_extra_ty_param_bound(
         generics,
-        &quote! { ::derive_more::core::ops::#trait_ident },
+        &quote! { derive_more::core::ops::#trait_ident },
     )
 }
 
@@ -229,11 +229,11 @@ pub fn add_where_clauses_for_new_ident<'a>(
     sized: bool,
 ) -> Generics {
     let generic_param = if fields.len() > 1 {
-        quote! { #type_ident: ::derive_more::core::marker::Copy }
+        quote! { #type_ident: derive_more::core::marker::Copy }
     } else if sized {
         quote! { #type_ident }
     } else {
-        quote! { #type_ident: ?::derive_more::core::marker::Sized }
+        quote! { #type_ident: ?derive_more::core::marker::Sized }
     };
 
     let generics = add_extra_where_clauses(generics, type_where_clauses);
@@ -377,7 +377,7 @@ impl<'input> State<'input> {
         let trait_name = trait_name.trim_end_matches("ToInner");
         let trait_ident = format_ident!("{trait_name}");
         let method_ident = format_ident!("{trait_attr}");
-        let trait_path = quote! { ::derive_more::#trait_ident };
+        let trait_path = quote! { derive_more::#trait_ident };
         let (derive_type, fields, variants): (_, Vec<_>, Vec<_>) = match input.data {
             Data::Struct(ref data_struct) => match data_struct.fields {
                 Fields::Unnamed(ref fields) => {
@@ -520,7 +520,7 @@ impl<'input> State<'input> {
         let trait_name = trait_name.trim_end_matches("ToInner");
         let trait_ident = format_ident!("{trait_name}");
         let method_ident = format_ident!("{trait_attr}");
-        let trait_path = quote! { ::derive_more::#trait_ident };
+        let trait_path = quote! { derive_more::#trait_ident };
         let (derive_type, fields): (_, Vec<_>) = match variant.fields {
             Fields::Unnamed(ref fields) => {
                 (DeriveType::Unnamed, unnamed_to_vec(fields))


### PR DESCRIPTION
Resolves #338




## Synopsis

At the moment, the `derive_more` macros cannot be re-exported or the `derive_more` crate cannot be renamed as the dependency, because expansions require `::derive_more` module be present in the scope. See #338 for details.




## Solution

Use `derive_more::*` paths instead of `::derive_more::*` in expansions, allowing to provide this module in the scope on the call site even when `derive_more` is transitive dependency of the crate.




## Checklist

- [ ] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [ ] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
