### PR TITLE
Bugfix/double reference

### DIFF
--- a/tests/display.rs
+++ b/tests/display.rs
@@ -680,6 +680,55 @@ mod structs {
             }
         }
     }
+
+    mod unnamed_pointer {
+        use super::*;
+        use std::fmt;
+
+        #[derive(Display)]
+        #[display("{_0:p}")]
+        struct UnnamedPointer<'a>(&'a u32);
+
+        #[derive(Display)]
+        #[display("{}", format!("{_0:p}"))]
+        struct UnnamedPointerWithFormat<'a>(&'a u32);
+
+        #[derive(Pointer)]
+        struct UnnamedPointerDerivePointer<'a, E>(&'a E);
+
+        #[test]
+        fn assert_no_double_reference() {
+            let i: u32 = line!();
+            assert_eq!(
+                format!("{}", UnnamedPointer(&i)),
+                format!("{:p}", &i)
+            );
+        }
+
+        #[test]
+        fn assert_no_double_reference_with_format() {
+            let i: u32 = line!();
+            assert_eq!(
+                format!("{}", UnnamedPointerWithFormat(&i)),
+                format!("{:p}", &i)
+            );
+        }
+
+        #[test]
+        fn assert_no_double_reference_deriving_pointer() {
+            let i: u32 = line!();
+            let j: &u32 = &i;
+            let k: &&u32 = &j;
+            assert_eq!(
+                format!("{:p}", UnnamedPointerDerivePointer(j)),
+                format!("{:p}", j)
+            );
+            assert_eq!(
+                format!("{:p}", UnnamedPointerDerivePointer(k)),
+                format!("{:p}", k)
+            );
+        }
+    }
 }
 
 mod enums {


### PR DESCRIPTION
Resolves #328 

Part of #328 

<!-- Remove the lines above if there are no related issues/PRs -->




## Synopsis

This is an alternative solution to the double reference problem reported in #328.




## Solution

Instead of dereferencing macro-generated bindings such as  `_0` at the use sites, do the the following:

1. In binding generation, generate `let _0 = self.0` instead of `let _0 = &self.0` in case the field `self.0` is already a reference type.

2. In body generation, add `&` before `#ident` in the call `derive_more::core::fmt::#trait_ident::fmt(#ident, __derive_more_f)`, because the function `fmt` dereferences.

3. In bounds generation, strip `&` in the bounded type for traits other than `Pointer` because the `fmt` function of those traits dereferences exhaustively.


## Open questions

1. All previous test function names are `assert`. The tests added in this PR have distinct names so that they can be executed alone via `cargo test <substring-of-test-function-name>`. Is there a reason for the naming convention `assert`? If so I'd rename the new tests.

2. Are the improvements to tests in #328 important? I can incorporate them if needed.

3. Are there any breaking changes? I'm not 100% sure.


## Checklist

- [ ] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [ ] [CHANGELOG entry][l:1] is added (if required)




[l:1]: /CHANGELOG.md
