### PR TITLE
Fix variant name interpolation in documentation for `IsVariant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#297](https://github.com/JelteF/derive_more/pull/297))
 - Hygiene of macro expansions in presence of custom `core` crate.
   ([#327](https://github.com/JelteF/derive_more/pull/327))
+- Fix documentation of generated methods in `IsVariant` derive.
 
 ## 0.99.10 - 2020-09-11
 

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -39,10 +39,9 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             Fields::Unnamed(_) => quote! { (..) },
             Fields::Unit => quote! {},
         };
-        let variant_name = stringify!(variant_ident);
         let func = quote! {
             #[doc = "Returns `true` if this value is of type `"]
-            #[doc = #variant_name]
+            #[doc = stringify!(#variant_ident)]
             #[doc = "`. Returns `false` otherwise"]
             #[inline]
             #[must_use]


### PR DESCRIPTION
Resolves #357 

<!-- Remove the lines above if there are no related issues/PRs -->




## Synopsis

<!-- Give a brief overview of the problem -->

Generated documentation is incorrect, see issue


## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

Ensure `stringify!` happens after `quote!` interpolation


## Checklist

- [ ] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)


---

Something for consideration: https://matklad.github.io/2022/10/24/actions-permissions.html

[l:1]: /CHANGELOG.md
