### PR TITLE
Fix clippy errors in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - run: cargo clippy --workspace --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(nightly)', 'cfg(msrv)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(msrv)", "cfg(nightly)"] }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(nightly)', 'cfg(msrv)'] }
 
 [features]
 default = ["std"]

--- a/examples/deny_missing_docs.rs
+++ b/examples/deny_missing_docs.rs
@@ -1,5 +1,6 @@
 //! Some docs
 
+#![allow(dead_code)]
 #![deny(missing_docs)]
 
 use derive_more::{

--- a/examples/deny_missing_docs.rs
+++ b/examples/deny_missing_docs.rs
@@ -1,7 +1,7 @@
 //! Some docs
 
-#![allow(dead_code)]
 #![deny(missing_docs)]
+#![allow(dead_code)] // for illustration purposes
 
 use derive_more::{
     Add, AddAssign, Constructor, Deref, DerefMut, Display, From, FromStr, Index,
@@ -34,7 +34,6 @@ pub struct MyBoxedInt(Box<i32>);
 pub struct MyVec(Vec<i32>);
 
 /// Some docs
-#[allow(dead_code)]
 #[derive(Clone, Copy, TryInto)]
 #[derive(IsVariant)]
 enum MixedInts {

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -44,7 +44,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(nighthly)'] }
 
 [features]
 default = []

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -44,7 +44,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(nighthly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(nighthly)"] }
 
 [features]
 default = []

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -495,7 +495,6 @@ where
 mod fmt_attribute_spec {
     use itertools::Itertools as _;
     use quote::ToTokens;
-    use syn;
 
     use super::FmtAttribute;
 
@@ -574,7 +573,7 @@ mod placeholder_parse_fmt_string_spec {
     fn indicates_position_and_trait_name_for_each_fmt_placeholder() {
         let fmt_string = "{},{:?},{{}},{{{1:0$}}}-{2:.1$x}{par:#?}{:width$}";
         assert_eq!(
-            Placeholder::parse_fmt_string(&fmt_string),
+            Placeholder::parse_fmt_string(fmt_string),
             vec![
                 Placeholder {
                     arg: Parameter::Positional(0),

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -179,6 +179,7 @@ impl<'a> Expansion<'a> {
 
                 Ok(quote! {
                     #[automatically_derived]
+                    #[allow(clippy::unused_unit)]
                     impl #impl_gens derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
                      for ( #( #r #lf #m #tys ),* ) #where_clause
                     {

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -178,8 +178,8 @@ impl<'a> Expansion<'a> {
                 let tys: Vec<_> = fields_tys.validate_type(out_ty)?.collect();
 
                 Ok(quote! {
-                    #[automatically_derived]
                     #[allow(clippy::unused_unit)]
+                    #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
                      for ( #( #r #lf #m #tys ),* ) #where_clause
                     {

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(
     not(all(feature = "add", feature = "mul")),
-    allow(dead_code),
-    allow(unused_mut)
+    allow(dead_code, unused_mut)
 )]
 
 use proc_macro2::TokenStream;

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Add;
 

--- a/tests/add_assign.rs
+++ b/tests/add_assign.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::AddAssign;
 

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, clippy::unnecessary_mut_passed)]
+#![allow(clippy::unnecessary_mut_passed)] // testing correct signatures rather than actual code
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/boats_display_derive.rs
+++ b/tests/boats_display_derive.rs
@@ -35,6 +35,7 @@ fn tuple_struct() {
     assert_eq!(s, "Error code: 2");
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Display)]
 enum EnumError {
     #[display("Error code: {}", code)]

--- a/tests/boats_display_derive.rs
+++ b/tests/boats_display_derive.rs
@@ -35,7 +35,7 @@ fn tuple_struct() {
     assert_eq!(s, "Error code: 2");
 }
 
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names)] // because of the original source
 #[derive(Display)]
 enum EnumError {
     #[display("Error code: {}", code)]

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Constructor;
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -53,8 +53,8 @@ mod structs {
             use derive_more::Debug;
 
             const I32: i32 = 11;
-            const F64: f64 = 3.14;
-            const POINTER: &f64 = &3.14;
+            const F64: f64 = 3.15;
+            const POINTER: &f64 = &3.15;
 
             #[derive(Debug)]
             #[debug("{I32}")]
@@ -100,8 +100,8 @@ mod structs {
                 assert_eq!(format!("{:07?}", Octal), "0000013");
                 assert_eq!(format!("{:03?}", LowerHex), "00b");
                 assert_eq!(format!("{:03?}", UpperHex), "00B");
-                assert_eq!(format!("{:07?}", LowerExp), "03.14e0");
-                assert_eq!(format!("{:07?}", UpperExp), "03.14E0");
+                assert_eq!(format!("{:07?}", LowerExp), "03.15e0");
+                assert_eq!(format!("{:07?}", UpperExp), "03.15E0");
                 assert_eq!(format!("{:018?}", Pointer).len(), 18);
             }
 
@@ -113,7 +113,7 @@ mod structs {
                     use derive_more::Debug;
 
                     const I32: i32 = 11;
-                    const F64: f64 = 3.14;
+                    const F64: f64 = 3.15;
 
                     #[derive(Debug)]
                     #[debug("{I32:x?}")]
@@ -593,7 +593,7 @@ mod structs {
             fn assert() {
                 assert_eq!(format!("{:03?}", TupleOctal(9, 4)), "011");
                 assert_eq!(
-                    format!("{:.1?}", StructLowerExp { a: 7, b: 3.14 }),
+                    format!("{:.1?}", StructLowerExp { a: 7, b: 3.15 }),
                     "3.1e0",
                 );
             }
@@ -642,8 +642,8 @@ mod enums {
             use derive_more::Debug;
 
             const I32: i32 = 11;
-            const F64: f64 = 3.14;
-            const POINTER: &f64 = &3.14;
+            const F64: f64 = 3.15;
+            const POINTER: &f64 = &3.15;
 
             #[derive(Debug)]
             enum Unit {
@@ -675,8 +675,8 @@ mod enums {
                 assert_eq!(format!("{:07?}", Unit::Octal), "0000013");
                 assert_eq!(format!("{:03?}", Unit::LowerHex), "00b");
                 assert_eq!(format!("{:03?}", Unit::UpperHex), "00B");
-                assert_eq!(format!("{:07?}", Unit::LowerExp), "03.14e0");
-                assert_eq!(format!("{:07?}", Unit::UpperExp), "03.14E0");
+                assert_eq!(format!("{:07?}", Unit::LowerExp), "03.15e0");
+                assert_eq!(format!("{:07?}", Unit::UpperExp), "03.15E0");
                 assert_eq!(format!("{:018?}", Unit::Pointer).len(), 18);
             }
 
@@ -688,7 +688,7 @@ mod enums {
                     use derive_more::Debug;
 
                     const I32: i32 = 11;
-                    const F64: f64 = 3.14;
+                    const F64: f64 = 3.15;
 
                     #[derive(Debug)]
                     enum Unit {
@@ -1069,7 +1069,7 @@ mod enums {
             fn assert() {
                 assert_eq!(format!("{:03?}", Enum::TupleOctal(9, 4)), "011");
                 assert_eq!(
-                    format!("{:.1?}", Enum::StructLowerExp { a: 7, b: 3.14 }),
+                    format!("{:.1?}", Enum::StructLowerExp { a: 7, b: 3.15 }),
                     "3.1e0",
                 );
             }
@@ -1840,7 +1840,7 @@ mod generic {
         #[test]
         fn assert() {
             assert_eq!(format!("{:03?}", Tuple(9)), "011");
-            assert_eq!(format!("{:.1?}", Struct { a: 9, b: 3.14 }), "3.1e0");
+            assert_eq!(format!("{:.1?}", Struct { a: 9, b: 3.15 }), "3.1e0");
             assert_eq!(format!("{:03?}", Enum::<_, u8, u8>::Debug(7)), "007");
             assert_eq!(
                 format!("{:03?}", Enum::<u8, _, _>::Display { b: 7, c: 8 }),

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -91,8 +91,8 @@ mod structs {
                 use super::*;
 
                 const I32: i32 = 11;
-                const F64: f64 = 3.14;
-                const POINTER: &f64 = &3.14;
+                const F64: f64 = 3.15;
+                const POINTER: &f64 = &3.15;
 
                 #[derive(Display)]
                 #[display("{I32}")]
@@ -138,8 +138,8 @@ mod structs {
                     assert_eq!(format!("{:07}", Octal), "0000013");
                     assert_eq!(format!("{:03}", LowerHex), "00b");
                     assert_eq!(format!("{:03}", UpperHex), "00B");
-                    assert_eq!(format!("{:07}", LowerExp), "03.14e0");
-                    assert_eq!(format!("{:07}", UpperExp), "03.14E0");
+                    assert_eq!(format!("{:07}", LowerExp), "03.15e0");
+                    assert_eq!(format!("{:07}", UpperExp), "03.15E0");
                     assert_eq!(format!("{:018}", Pointer).len(), 18);
                 }
             }
@@ -151,7 +151,7 @@ mod structs {
                     use super::*;
 
                     const I32: i32 = 11;
-                    const F64: f64 = 3.14;
+                    const F64: f64 = 3.15;
 
                     #[derive(Display)]
                     #[display("{I32:x?}")]
@@ -728,8 +728,8 @@ mod enums {
                 use super::*;
 
                 const I32: i32 = 11;
-                const F64: f64 = 3.14;
-                const POINTER: &f64 = &3.14;
+                const F64: f64 = 3.15;
+                const POINTER: &f64 = &3.15;
 
                 #[derive(Display)]
                 enum Unit {
@@ -761,8 +761,8 @@ mod enums {
                     assert_eq!(format!("{:07}", Unit::Octal), "0000013");
                     assert_eq!(format!("{:03}", Unit::LowerHex), "00b");
                     assert_eq!(format!("{:03}", Unit::UpperHex), "00B");
-                    assert_eq!(format!("{:07}", Unit::LowerExp), "03.14e0");
-                    assert_eq!(format!("{:07}", Unit::UpperExp), "03.14E0");
+                    assert_eq!(format!("{:07}", Unit::LowerExp), "03.15e0");
+                    assert_eq!(format!("{:07}", Unit::UpperExp), "03.15E0");
                     assert_eq!(format!("{:018}", Unit::Pointer).len(), 18);
                 }
             }
@@ -774,7 +774,7 @@ mod enums {
                     use super::*;
 
                     const I32: i32 = 11;
-                    const F64: f64 = 3.14;
+                    const F64: f64 = 3.15;
 
                     #[derive(Display)]
                     enum Unit {

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -1,4 +1,5 @@
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
+
 use super::*;
 
 derive_display!(TestErr);

--- a/tests/error/derives_for_generic_enums_with_source.rs
+++ b/tests/error/derives_for_generic_enums_with_source.rs
@@ -1,4 +1,5 @@
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
+
 use super::*;
 
 derive_display!(TestErr, T, E);

--- a/tests/error/derives_for_generic_structs_with_source.rs
+++ b/tests/error/derives_for_generic_structs_with_source.rs
@@ -1,4 +1,5 @@
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
+
 use super::*;
 
 #[test]

--- a/tests/error/derives_for_structs_with_source.rs
+++ b/tests/error/derives_for_structs_with_source.rs
@@ -1,4 +1,5 @@
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
+
 use super::*;
 
 #[test]

--- a/tests/error/nightly/derives_for_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_enums_with_backtrace.rs
@@ -1,7 +1,6 @@
-#![allow(dead_code)]
-// Allow redundant closures in tests, because we use them to create backtraces with different
-// addresses.
-#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
+// For creating backtraces with different addresses in tests.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)] // for testing
+#![allow(dead_code)] // some code is tested for type checking only
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_enums_with_backtrace.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+// Allow redundant closures in tests, because we use them to create backtraces with different
+// addresses.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
@@ -1,7 +1,6 @@
-#![allow(dead_code)]
-// Allow redundant closures in tests, because we use them to create backtraces with different
-// addresses.
-#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
+// For creating backtraces with different addresses in tests.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)] // for testing
+#![allow(dead_code)] // some code is tested for type checking only
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_enums_with_backtrace.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+// Allow redundant closures in tests, because we use them to create backtraces with different
+// addresses.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_generic_structs_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_structs_with_backtrace.rs
@@ -1,7 +1,6 @@
-#![allow(dead_code)]
-// Allow redundant closures in tests, because we use them to create backtraces with different
-// addresses.
-#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
+// For creating backtraces with different addresses in tests.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)] // for testing
+#![allow(dead_code)] // some code is tested for type checking only
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_generic_structs_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_generic_structs_with_backtrace.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+// Allow redundant closures in tests, because we use them to create backtraces with different
+// addresses.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_structs_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_structs_with_backtrace.rs
@@ -1,7 +1,6 @@
-#![allow(dead_code)]
-// Allow redundant closures in tests, because we use them to create backtraces with different
-// addresses.
-#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
+// For creating backtraces with different addresses in tests.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)] // for testing
+#![allow(dead_code)] // some code is tested for type checking only
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error/nightly/derives_for_structs_with_backtrace.rs
+++ b/tests/error/nightly/derives_for_structs_with_backtrace.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+// Allow redundant closures in tests, because we use them to create backtraces with different
+// addresses.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_call)]
 
 use core::error::{request_ref, request_value};
 

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,4 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(nightly, feature(error_generic_member_access, error_in_core))]
+#![cfg_attr(nightly, feature(error_generic_member_access))]
 
 mod error;

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, non_camel_case_types)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::{
     Add, AddAssign, Constructor, Deref, DerefMut, Display, Error, From, FromStr, Index,

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/index_mut.rs
+++ b/tests/index_mut.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::IndexMut;
 

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -58,7 +58,8 @@ impl<T> From<&mut Wrapped<T>> for &mut Transmuted<T> {
 }
 
 mod unit {
-    #![allow(clippy::unit_cmp)]
+    #![allow(clippy::unit_cmp)] // because of type inference in assertions
+
     use super::*;
 
     #[derive(Debug, Into, PartialEq)]
@@ -129,7 +130,8 @@ mod single_field {
 
         #[test]
         fn assert() {
-            #![allow(clippy::unit_cmp)]
+            #![allow(clippy::unit_cmp)] // because of type inference in assertions
+
             assert_eq!((), Tuple(42).into());
             assert_eq!((), Struct { field: 42 }.into());
         }
@@ -310,7 +312,8 @@ mod single_field {
 
             #[test]
             fn assert() {
-                #![allow(clippy::unit_cmp)]
+                #![allow(clippy::unit_cmp)] // because of type inference in assertions
+
                 assert_eq!((), Tuple(Wrapped(42)).into());
                 assert_eq!((), Struct { field: Wrapped(42) }.into());
             }
@@ -1074,10 +1077,10 @@ mod with_fields {
 
         #[test]
         fn tuple() {
-            let foo = Tuple(1, 2.0, 3.0);
+            let t = Tuple(1, 2.0, 3.0);
 
-            assert_eq!(1, foo.into());
-            assert_eq!(3.0, foo.into());
+            assert_eq!(1, t.into());
+            assert_eq!(3.0, t.into());
         }
 
         #[derive(Clone, Copy, Debug, Into)]
@@ -1107,14 +1110,14 @@ mod with_fields {
 
         #[test]
         fn named() {
-            let foo = Struct {
+            let s = Struct {
                 a: 1,
                 b: 2.0,
                 c: 3.0,
             };
 
-            assert_eq!(1, foo.into());
-            assert_eq!(3.0, foo.into());
+            assert_eq!(1, s.into());
+            assert_eq!(3.0, s.into());
         }
 
         mod types {
@@ -1145,12 +1148,12 @@ mod with_fields {
 
             #[test]
             fn tuple() {
-                let foo = Tuple("1".to_owned(), 2.0, 3.0);
+                let f = Tuple("1".to_owned(), 2.0, 3.0);
 
-                assert_eq!(Box::<str>::from("1".to_owned()), foo.clone().into());
-                assert_eq!(Cow::Borrowed("1"), Cow::<str>::from(foo.clone()));
-                assert_eq!(3.0f32, foo.clone().into());
-                assert_eq!(3.0f64, foo.into());
+                assert_eq!(Box::<str>::from("1".to_owned()), f.clone().into());
+                assert_eq!(Cow::Borrowed("1"), Cow::<str>::from(f.clone()));
+                assert_eq!(3.0f32, f.clone().into());
+                assert_eq!(3.0f64, f.into());
             }
 
             #[derive(Clone, Debug, Into)]
@@ -1188,16 +1191,16 @@ mod with_fields {
 
             #[test]
             fn named() {
-                let foo = Struct {
+                let s = Struct {
                     a: "1".to_owned(),
                     b: 2.0,
                     c: 3.0,
                 };
 
-                assert_eq!(Box::<str>::from("1".to_owned()), foo.clone().into());
-                assert_eq!(Cow::Borrowed("1"), Cow::<str>::from(foo.clone()));
-                assert_eq!(3.0f32, foo.clone().into());
-                assert_eq!(3.0f64, foo.into());
+                assert_eq!(Box::<str>::from("1".to_owned()), s.clone().into());
+                assert_eq!(Cow::Borrowed("1"), Cow::<str>::from(s.clone()));
+                assert_eq!(3.0f32, s.clone().into());
+                assert_eq!(3.0f64, s.into());
             }
 
             mod r#ref {
@@ -1216,10 +1219,10 @@ mod with_fields {
 
                 #[test]
                 fn tuple() {
-                    let foo = Tuple("1".to_owned(), 2.0, 3.0);
+                    let t = Tuple("1".to_owned(), 2.0, 3.0);
 
-                    assert_eq!(&"1".to_owned(), <&String>::from(&foo));
-                    assert_eq!(&3.0, <&f64>::from(&foo));
+                    assert_eq!(&"1".to_owned(), <&String>::from(&t));
+                    assert_eq!(&3.0, <&f64>::from(&t));
                 }
 
                 #[derive(Debug, Into)]
@@ -1249,14 +1252,14 @@ mod with_fields {
 
                 #[test]
                 fn named() {
-                    let foo = Struct {
+                    let s = Struct {
                         a: "1".to_owned(),
                         b: 2.0,
                         c: 3.0,
                     };
 
-                    assert_eq!(&"1".to_owned(), <&String>::from(&foo));
-                    assert_eq!(&3.0, <&f64>::from(&foo));
+                    assert_eq!(&"1".to_owned(), <&String>::from(&s));
+                    assert_eq!(&3.0, <&f64>::from(&s));
                 }
 
                 mod types {
@@ -1270,10 +1273,10 @@ mod with_fields {
 
                     #[test]
                     fn tuple() {
-                        let foo = Tuple(Wrapped(1), Wrapped(2));
+                        let t = Tuple(Wrapped(1), Wrapped(2));
 
-                        assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&foo));
-                        assert_eq!(&Wrapped(2), <&Wrapped<i64>>::from(&foo));
+                        assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&t));
+                        assert_eq!(&Wrapped(2), <&Wrapped<i64>>::from(&t));
                     }
 
                     #[derive(Debug, Into)]
@@ -1286,13 +1289,13 @@ mod with_fields {
 
                     #[test]
                     fn named() {
-                        let foo = Struct {
+                        let s = Struct {
                             a: Wrapped(1),
                             b: Wrapped(2),
                         };
 
-                        assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&foo));
-                        assert_eq!(&Wrapped(2), <&Wrapped<i64>>::from(&foo));
+                        assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&s));
+                        assert_eq!(&Wrapped(2), <&Wrapped<i64>>::from(&s));
                     }
                 }
 
@@ -1304,10 +1307,10 @@ mod with_fields {
 
                     #[test]
                     fn tuple() {
-                        let mut foo = Tuple(1, 2.0, 3.0);
+                        let mut t = Tuple(1, 2.0, 3.0);
 
-                        assert_eq!(&mut 1, <&mut i32>::from(&mut foo));
-                        assert_eq!(&mut 3.0, <&mut f64>::from(&mut foo));
+                        assert_eq!(&mut 1, <&mut i32>::from(&mut t));
+                        assert_eq!(&mut 3.0, <&mut f64>::from(&mut t));
                     }
 
                     #[derive(Debug, Into)]
@@ -1321,14 +1324,14 @@ mod with_fields {
 
                     #[test]
                     fn named() {
-                        let mut foo = Struct {
+                        let mut s = Struct {
                             a: 1,
                             b: 2.0,
                             c: 3.0,
                         };
 
-                        assert_eq!(&mut 1, <&mut i32>::from(&mut foo));
-                        assert_eq!(&mut 3.0, <&mut f64>::from(&mut foo));
+                        assert_eq!(&mut 1, <&mut i32>::from(&mut s));
+                        assert_eq!(&mut 3.0, <&mut f64>::from(&mut s));
                     }
 
                     mod types {
@@ -1342,15 +1345,15 @@ mod with_fields {
 
                         #[test]
                         fn tuple() {
-                            let mut foo = Tuple(Wrapped(1), Wrapped(2));
+                            let mut t = Tuple(Wrapped(1), Wrapped(2));
 
                             assert_eq!(
                                 &mut Transmuted(1),
-                                <&mut Transmuted<i32>>::from(&mut foo),
+                                <&mut Transmuted<i32>>::from(&mut t),
                             );
                             assert_eq!(
                                 &mut Wrapped(2),
-                                <&mut Wrapped<i64>>::from(&mut foo),
+                                <&mut Wrapped<i64>>::from(&mut t),
                             );
                         }
 
@@ -1364,18 +1367,18 @@ mod with_fields {
 
                         #[test]
                         fn named() {
-                            let mut foo = Struct {
+                            let mut s = Struct {
                                 a: Wrapped(1),
                                 b: Wrapped(2),
                             };
 
                             assert_eq!(
                                 &mut Transmuted(1),
-                                <&mut Transmuted<i32>>::from(&mut foo),
+                                <&mut Transmuted<i32>>::from(&mut s),
                             );
                             assert_eq!(
                                 &mut Wrapped(2),
-                                <&mut Wrapped<i64>>::from(&mut foo),
+                                <&mut Wrapped<i64>>::from(&mut s),
                             );
                         }
                     }
@@ -1399,14 +1402,14 @@ mod with_fields {
 
         #[test]
         fn tuple() {
-            let mut foo = Tuple(Wrapped(1), Wrapped(2.0), Wrapped(3.0));
+            let mut t = Tuple(Wrapped(1), Wrapped(2.0), Wrapped(3.0));
 
-            assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&foo));
-            assert_eq!(&mut Transmuted(3.0), <&mut Transmuted<f32>>::from(&mut foo));
-            assert_eq!(&mut Wrapped(3.0), <&mut Wrapped<f32>>::from(&mut foo));
-            assert_eq!((&Wrapped(1), &Transmuted(3.0)), (&foo).into());
-            assert_eq!(&Wrapped(2.0), <&Wrapped<f32>>::from(&foo));
-            assert_eq!(Wrapped(1), foo.into());
+            assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&t));
+            assert_eq!(&mut Transmuted(3.0), <&mut Transmuted<f32>>::from(&mut t));
+            assert_eq!(&mut Wrapped(3.0), <&mut Wrapped<f32>>::from(&mut t));
+            assert_eq!((&Wrapped(1), &Transmuted(3.0)), (&t).into());
+            assert_eq!(&Wrapped(2.0), <&Wrapped<f32>>::from(&t));
+            assert_eq!(Wrapped(1), t.into());
         }
 
         #[derive(Debug, Into)]
@@ -1423,18 +1426,18 @@ mod with_fields {
 
         #[test]
         fn named() {
-            let mut foo = Struct {
+            let mut s = Struct {
                 a: Wrapped(1),
                 b: Wrapped(2.0),
                 c: Wrapped(3.0),
             };
 
-            assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&foo));
-            assert_eq!(&mut Transmuted(3.0), <&mut Transmuted<f32>>::from(&mut foo));
-            assert_eq!(&mut Wrapped(3.0), <&mut Wrapped<f32>>::from(&mut foo));
-            assert_eq!((&Wrapped(1), &Transmuted(3.0)), (&foo).into());
-            assert_eq!(&Wrapped(2.0), <&Wrapped<f32>>::from(&foo));
-            assert_eq!(Wrapped(1), foo.into());
+            assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&s));
+            assert_eq!(&mut Transmuted(3.0), <&mut Transmuted<f32>>::from(&mut s));
+            assert_eq!(&mut Wrapped(3.0), <&mut Wrapped<f32>>::from(&mut s));
+            assert_eq!((&Wrapped(1), &Transmuted(3.0)), (&s).into());
+            assert_eq!(&Wrapped(2.0), <&Wrapped<f32>>::from(&s));
+            assert_eq!(Wrapped(1), s.into());
         }
 
         mod separate {
@@ -1458,21 +1461,18 @@ mod with_fields {
 
             #[test]
             fn tuple() {
-                let mut foo = Tuple(Wrapped(1), Wrapped(2.0));
+                let mut t = Tuple(Wrapped(1), Wrapped(2.0));
 
-                assert_eq!((&Wrapped(1), &Wrapped(2.0)), (&foo).into());
-                assert_eq!((Wrapped(1), Wrapped(2.0)), foo.into());
-                assert_eq!((Wrapped(1), Transmuted(2.0)), foo.into());
-                assert_eq!((&mut Wrapped(1), &mut Transmuted(2.0)), (&mut foo).into());
-                assert_eq!(&Wrapped(1), <&Wrapped<i32>>::from(&foo));
-                assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&foo));
-                assert_eq!(Wrapped(1), <Wrapped<i32>>::from(foo));
-                assert_eq!(&mut Wrapped(2.0), <&mut Wrapped<f32>>::from(&mut foo));
-                assert_eq!(
-                    &mut Transmuted(2.0),
-                    <&mut Transmuted<f32>>::from(&mut foo),
-                );
-                assert_eq!(Wrapped(2.0), <Wrapped<f32>>::from(foo));
+                assert_eq!((&Wrapped(1), &Wrapped(2.0)), (&t).into());
+                assert_eq!((Wrapped(1), Wrapped(2.0)), t.into());
+                assert_eq!((Wrapped(1), Transmuted(2.0)), t.into());
+                assert_eq!((&mut Wrapped(1), &mut Transmuted(2.0)), (&mut t).into());
+                assert_eq!(&Wrapped(1), <&Wrapped<i32>>::from(&t));
+                assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&t));
+                assert_eq!(Wrapped(1), <Wrapped<i32>>::from(t));
+                assert_eq!(&mut Wrapped(2.0), <&mut Wrapped<f32>>::from(&mut t));
+                assert_eq!(&mut Transmuted(2.0), <&mut Transmuted<f32>>::from(&mut t));
+                assert_eq!(Wrapped(2.0), <Wrapped<f32>>::from(t));
             }
 
             #[derive(Clone, Copy, Debug, Into)]
@@ -1493,24 +1493,21 @@ mod with_fields {
 
             #[test]
             fn named() {
-                let mut foo = Struct {
+                let mut s = Struct {
                     a: Wrapped(1),
                     b: Wrapped(2.0),
                 };
 
-                assert_eq!((&Wrapped(1), &Wrapped(2.0)), (&foo).into());
-                assert_eq!((Wrapped(1), Wrapped(2.0)), foo.into());
-                assert_eq!((Wrapped(1), Transmuted(2.0)), foo.into());
-                assert_eq!((&mut Wrapped(1), &mut Transmuted(2.0)), (&mut foo).into());
-                assert_eq!(&Wrapped(1), <&Wrapped<i32>>::from(&foo));
-                assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&foo));
-                assert_eq!(Wrapped(1), <Wrapped<i32>>::from(foo));
-                assert_eq!(&mut Wrapped(2.0), <&mut Wrapped<f32>>::from(&mut foo));
-                assert_eq!(
-                    &mut Transmuted(2.0),
-                    <&mut Transmuted<f32>>::from(&mut foo),
-                );
-                assert_eq!(Wrapped(2.0), <Wrapped<f32>>::from(foo));
+                assert_eq!((&Wrapped(1), &Wrapped(2.0)), (&s).into());
+                assert_eq!((Wrapped(1), Wrapped(2.0)), s.into());
+                assert_eq!((Wrapped(1), Transmuted(2.0)), s.into());
+                assert_eq!((&mut Wrapped(1), &mut Transmuted(2.0)), (&mut s).into());
+                assert_eq!(&Wrapped(1), <&Wrapped<i32>>::from(&s));
+                assert_eq!(&Transmuted(1), <&Transmuted<i32>>::from(&s));
+                assert_eq!(Wrapped(1), <Wrapped<i32>>::from(s));
+                assert_eq!(&mut Wrapped(2.0), <&mut Wrapped<f32>>::from(&mut s));
+                assert_eq!(&mut Transmuted(2.0), <&mut Transmuted<f32>>::from(&mut s),);
+                assert_eq!(Wrapped(2.0), <Wrapped<f32>>::from(s));
             }
         }
     }

--- a/tests/into.rs
+++ b/tests/into.rs
@@ -58,6 +58,7 @@ impl<T> From<&mut Wrapped<T>> for &mut Transmuted<T> {
 }
 
 mod unit {
+    #![allow(clippy::unit_cmp)]
     use super::*;
 
     #[derive(Debug, Into, PartialEq)]
@@ -128,6 +129,7 @@ mod single_field {
 
         #[test]
         fn assert() {
+            #![allow(clippy::unit_cmp)]
             assert_eq!((), Tuple(42).into());
             assert_eq!((), Struct { field: 42 }.into());
         }
@@ -308,6 +310,7 @@ mod single_field {
 
             #[test]
             fn assert() {
+                #![allow(clippy::unit_cmp)]
                 assert_eq!((), Tuple(Wrapped(42)).into());
                 assert_eq!((), Struct { field: Wrapped(42) }.into());
             }

--- a/tests/into_iterator.rs
+++ b/tests/into_iterator.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/tests/is_variant.rs
+++ b/tests/is_variant.rs
@@ -43,16 +43,16 @@ pub fn test_is_variant() {
 
 #[derive(IsVariant)]
 enum Color {
-    RGB(u8, u8, u8),
-    CMYK { c: u8, m: u8, y: u8, k: u8 },
+    Rgb(u8, u8, u8),
+    Cmyk { c: u8, m: u8, y: u8, k: u8 },
 }
 
 const _: () = {
-    let color = Color::RGB(0, 0, 0);
+    let color = Color::Rgb(0, 0, 0);
     assert!(color.is_rgb());
     assert!(!color.is_cmyk());
 
-    let color = Color::CMYK {
+    let color = Color::Cmyk {
         c: 0,
         m: 0,
         y: 0,

--- a/tests/is_variant.rs
+++ b/tests/is_variant.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::IsVariant;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -188,7 +188,7 @@ fn main() {
 
     let mut myint: MyInt = 5.into();
     let _: Unit = ().into();
-    assert_eq!((), Unit.into());
+    assert!(matches!(Unit.into(), ()));
     assert_eq!(Unit, Unit::new());
     assert_eq!(MyInt(5), 5.into());
     assert_eq!(Ok(MyInt(5)), "5".parse());

--- a/tests/mul.rs
+++ b/tests/mul.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Mul;
 

--- a/tests/mul_assign.rs
+++ b/tests/mul_assign.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use core::marker::PhantomData;
 

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::{
     Add, AddAssign, Constructor, Deref, DerefMut, Display, From, FromStr, Index,

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Not;
 

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -56,7 +56,6 @@ fn enum_with_complex_repr() {
     assert!(Enum::try_from(-1).is_err());
 }
 
-#[cfg(not(msrv))] // TODO: Remove once MSRV bumps 1.66 or higher.
 #[test]
 fn test_discriminants_on_enum_with_fields() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::TryFrom;
 
@@ -56,6 +56,7 @@ fn enum_with_complex_repr() {
     assert!(Enum::try_from(-1).is_err());
 }
 
+#[cfg(not(msrv))] // TODO: Remove once MSRV bumps 1.66 or higher.
 #[test]
 fn test_discriminants_on_enum_with_fields() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -230,5 +230,5 @@ fn test_try_into() {
         u32::try_from(i).unwrap_err().to_string(),
         "Only Unsigned, NamedUnsigned can be converted to u32"
     );
-    assert_eq!((), i.try_into().unwrap());
+    assert!(matches!(i.try_into().unwrap(), ()));
 }

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -25,8 +25,8 @@ enum Maybe<T> {
 
 #[derive(TryUnwrap)]
 enum Color {
-    RGB(u8, u8, u8),
-    CMYK(u8, u8, u8, u8),
+    Rgb(u8, u8, u8),
+    Cmyk(u8, u8, u8, u8),
 }
 
 /// With lifetime
@@ -79,24 +79,19 @@ enum Tuple<T> {
 #[test]
 pub fn test_try_unwrap() {
     assert_eq!(Maybe::<()>::Nothing.try_unwrap_nothing().ok(), Some(()));
-    assert_eq!((&Maybe::Just(1)).try_unwrap_just_ref().ok(), Some(&1));
-    assert_eq!(
-        (&mut Maybe::Just(42)).try_unwrap_just_mut().ok(),
-        Some(&mut 42)
-    );
+    assert_eq!(Maybe::Just(1).try_unwrap_just_ref().ok(), Some(&1));
+    assert_eq!(Maybe::Just(42).try_unwrap_just_mut().ok(), Some(&mut 42));
 
     assert_eq!(
         Maybe::<()>::Nothing.try_unwrap_just().map_err(|e| e.input),
         Err(Maybe::<()>::Nothing),
     );
     assert_eq!(
-        (&Maybe::Just(1))
-            .try_unwrap_nothing_ref()
-            .map_err(|e| e.input),
+        Maybe::Just(1).try_unwrap_nothing_ref().map_err(|e| e.input),
         Err(&Maybe::Just(1)),
     );
     assert_eq!(
-        (&mut Maybe::Just(42))
+        Maybe::Just(42)
             .try_unwrap_nothing_mut()
             .map_err(|e| e.to_string()),
         Err(

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(dead_code)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Unwrap;
 

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -19,8 +19,8 @@ enum Maybe<T> {
 
 #[derive(Unwrap)]
 enum Color {
-    RGB(u8, u8, u8),
-    CMYK(u8, u8, u8, u8),
+    Rgb(u8, u8, u8),
+    Cmyk(u8, u8, u8, u8),
 }
 
 /// With lifetime
@@ -72,11 +72,11 @@ enum Tuple<T> {
 
 #[test]
 pub fn test_unwrap() {
-    assert_eq!(Maybe::<()>::Nothing.unwrap_nothing(), ());
+    assert!(matches!(Maybe::<()>::Nothing.unwrap_nothing(), ()));
     assert_eq!(Maybe::Just(1).unwrap_just(), 1);
 
-    assert_eq!((&Maybe::Just(42)).unwrap_just_ref(), &42);
-    assert_eq!((&mut Maybe::Just(42)).unwrap_just_mut(), &mut 42);
+    assert_eq!(Maybe::Just(42).unwrap_just_ref(), &42);
+    assert_eq!(Maybe::Just(42).unwrap_just_mut(), &mut 42);
 }
 
 #[test]


### PR DESCRIPTION
## Synopsis

We were only running clippy on our normal code, not tests or examples.


## Solution

This starts running clippy on the full codebase by using `--all-targets`. It
also fixes all issues that this flag found.
