### PR TITLE
Only put Debug-like bounds on type variables

### DIFF
--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -28,9 +28,9 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
         .generics
         .params
         .iter()
-        .filter_map(|param| match param {
-            syn::GenericParam::Type(param) => Some(&param.ident),
-            _ => None,
+        .filter_map(|p| match p {
+            syn::GenericParam::Type(t) => Some(&t.ident),
+            syn::GenericParam::Const(..) | syn::GenericParam::Lifetime(..) => None,
         })
         .collect();
 
@@ -393,6 +393,7 @@ impl<'a> Expansion<'a> {
         }
     }
 
+    /// Checks whether the provided [`syn::Path`] contains any of these [`Expansion::type_params`].
     fn path_contains_generic_param(&self, path: &syn::Path) -> bool {
         path.segments
             .iter()
@@ -411,7 +412,7 @@ impl<'a> Expansion<'a> {
                     | syn::GenericArgument::AssocConst(_)
                     | syn::GenericArgument::Constraint(_) => false,
                     _ => unimplemented!(
-                        "syntax is not supported by derive_more, please report a bug"
+                        "syntax is not supported by `derive_more`, please report a bug",
                     ),
                 }),
                 syn::PathArguments::Parenthesized(
@@ -428,7 +429,11 @@ impl<'a> Expansion<'a> {
             })
     }
 
+    /// Checks whether the provided [`syn::Type`] contains any of these [`Expansion::type_params`].
     fn contains_generic_param(&self, ty: &syn::Type) -> bool {
+        if self.type_params.is_empty() {
+            return false;
+        }
         match ty {
             syn::Type::Path(syn::TypePath { qself, path }) => {
                 if let Some(qself) = qself {
@@ -478,13 +483,13 @@ impl<'a> Expansion<'a> {
                     syn::TypeParamBound::Lifetime(_) => false,
                     syn::TypeParamBound::Verbatim(_) => false,
                     _ => unimplemented!(
-                        "syntax is not supported by derive_more, please report a bug"
+                        "syntax is not supported by `derive_more`, please report a bug",
                     ),
                 })
             }
             syn::Type::Verbatim(_) => false,
             _ => unimplemented!(
-                "syntax is not supported by derive_more, please report a bug"
+                "syntax is not supported by `derive_more`, please report a bug",
             ),
         }
     }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1978,7 +1978,9 @@ mod type_variables {
 
     mod parens {
         #![allow(unused_parens)] // test that type is found even in parentheses
+
         use derive_more::Debug;
+
         #[derive(Debug)]
         struct Paren<T> {
             t: (T),
@@ -2034,14 +2036,14 @@ mod type_variables {
                 "{:?}",
                 ItemStruct {
                     next: Some(Box::new(ItemStruct { next: None }))
-                }
+                },
             ),
-            "ItemStruct { next: Some(ItemStruct { next: None }) }"
+            "ItemStruct { next: Some(ItemStruct { next: None }) }",
         );
 
         assert_eq!(
-            format!("{:?}", ItemTuple(Some(Box::new(ItemTuple(None)))),),
-            "ItemTuple(Some(ItemTuple(None)))"
+            format!("{:?}", ItemTuple(Some(Box::new(ItemTuple(None))))),
+            "ItemTuple(Some(ItemTuple(None)))",
         );
 
         assert_eq!(
@@ -2049,7 +2051,7 @@ mod type_variables {
                 "{:?}",
                 ItemTupleContainerFmt(Some(Box::new(ItemTupleContainerFmt(None)))),
             ),
-            "Item(Some(Item(None)))"
+            "Item(Some(Item(None)))",
         );
 
         let item = ItemEnum::Node {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1935,8 +1935,14 @@ mod complex_enum_syntax {
 
 // See: https://github.com/JelteF/derive_more/issues/363
 mod type_variables {
-    #[cfg(not(feature = "std"))]
-    use alloc::{boxed::Box, format, vec, vec::Vec};
+    mod our_alloc {
+        #[cfg(not(feature = "std"))]
+        pub use alloc::{boxed::Box, format, vec, vec::Vec};
+        #[cfg(feature = "std")]
+        pub use std::{boxed::Box, format, vec, vec::Vec};
+    }
+
+    use our_alloc::{format, vec, Box, Vec};
 
     use derive_more::Debug;
 
@@ -1956,6 +1962,69 @@ mod type_variables {
     enum ItemEnum {
         Node { children: Vec<ItemEnum>, inner: i32 },
         Leaf { inner: i32 },
+    }
+
+    #[derive(Debug)]
+    struct VecMeansDifferent<Vec> {
+        next: our_alloc::Vec<i32>,
+        real: Vec,
+    }
+
+    #[derive(Debug)]
+    struct Array<T> {
+        #[debug("{t}")]
+        t: [T; 10],
+    }
+
+    mod parens {
+        #![allow(unused_parens)] // test that type is found even in parentheses
+        use derive_more::Debug;
+        #[derive(Debug)]
+        struct Paren<T> {
+            t: (T),
+        }
+    }
+
+    #[derive(Debug)]
+    struct ParenthesizedGenericArgumentsInput<T> {
+        t: dyn Fn(T) -> i32,
+    }
+
+    #[derive(Debug)]
+    struct ParenthesizedGenericArgumentsOutput<T> {
+        t: dyn Fn(i32) -> T,
+    }
+
+    #[derive(Debug)]
+    struct Ptr<T> {
+        t: *const T,
+    }
+
+    #[derive(Debug)]
+    struct Reference<'a, T> {
+        t: &'a T,
+    }
+
+    #[derive(Debug)]
+    struct Slice<'a, T> {
+        t: &'a [T],
+    }
+
+    #[derive(Debug)]
+    struct BareFn<T> {
+        t: Box<fn(T) -> T>,
+    }
+
+    #[derive(Debug)]
+    struct Tuple<T> {
+        t: Box<(T, T)>,
+    }
+
+    trait MyTrait<T> {}
+
+    #[derive(Debug)]
+    struct TraitObject<T> {
+        t: Box<dyn MyTrait<T>>,
     }
 
     #[test]

--- a/tests/sum.rs
+++ b/tests/sum.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Sum;
 


### PR DESCRIPTION
Resolves #363

Well, at least it's a suggestion for a resolution :p

## Synopsis

The problem, as reported in the issue, is that code like the following

```rust
#[derive(derive_more::Debug)]
struct Item {
    next: Option<Box<Item>>,
}
```

expands into something like

```rust
impl std::fmt::Debug for Item where Item: Debug { /* ... */ }
```

which does not compile. This PR changes the Debug derive so it does not emit those bounds.

## Solution

My understanding of the current code is that we iterate over all fields of the struct/enum and add either a specific
format bound (e.g. `: fmt::Binary`), a default `: fmt::Debug` bound or skip it if either it is marked
as `#[debug(skip)]` or the entire container has a format attribute. 

The suggested solution in the issue (if I understood it correctly) was to only add bounds if the type is a type
variable, since rustc already knows if a concrete type is, say, `: fmt::Debug`. So, instead of adding the bound for
every type, we first check that the type contains one of the container's type variables. Since types can be nested, it
is an unfortunately long recursive function handling the different types of types. This part of Rust syntax is probably
not going to change, so perhaps it is feasible to shorten some of the branches into `_ => false`.

One drawback of this implementation is that we iterate over the list of type variables every time we find a "leaf type".
I chose `Vec` over `HashSet` because in my experience there are only a handful of type variables per container.

## Status

I should add more tests, probably? I've at least verified the case mentioned above (for tuple structs, data structs and
enums). I must admit I haven't really looked in the documentation, but I should probably edit that too.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated (if required)
- [x] ~~[CHANGELOG entry][l:1] is added~~ (not required)

[l:1]: /CHANGELOG.md
