### PR TITLE
Work around bug in rust-analyzer to make auto-imports work nicely

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,169 +137,283 @@ macro_rules! re_export_traits((
 
         #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
         #[doc(hidden)]
-        pub use crate::$new_module_name::*;
+        pub use crate::all_traits_and_derives::$new_module_name::*;
     }
 );
 
-re_export_traits!(
-    "add",
-    add_traits,
-    core::ops,
-    Add,
-    BitAnd,
-    BitOr,
-    BitXor,
-    Sub,
-);
-re_export_traits!(
-    "add_assign",
-    add_assign_traits,
-    core::ops,
-    AddAssign,
-    BitAndAssign,
-    BitOrAssign,
-    BitXorAssign,
-    SubAssign,
-);
-re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
-re_export_traits!("debug", debug_traits, core::fmt, Debug);
-re_export_traits!("deref", deref_traits, core::ops, Deref);
-re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
-re_export_traits!(
-    "display",
-    display_traits,
-    core::fmt,
-    Binary,
-    Display,
-    LowerExp,
-    LowerHex,
-    Octal,
-    Pointer,
-    UpperExp,
-    UpperHex,
-);
+mod all_traits_and_derives {
+    re_export_traits!(
+        "add",
+        add_traits,
+        core::ops,
+        Add,
+        BitAnd,
+        BitOr,
+        BitXor,
+        Sub,
+    );
+    re_export_traits!(
+        "add_assign",
+        add_assign_traits,
+        core::ops,
+        AddAssign,
+        BitAndAssign,
+        BitOrAssign,
+        BitXorAssign,
+        SubAssign,
+    );
+    re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
+    re_export_traits!("debug", debug_traits, core::fmt, Debug);
+    re_export_traits!("deref", deref_traits, core::ops, Deref);
+    re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
+    re_export_traits!(
+        "display",
+        display_traits,
+        core::fmt,
+        Binary,
+        Display,
+        LowerExp,
+        LowerHex,
+        Octal,
+        Pointer,
+        UpperExp,
+        UpperHex,
+    );
 
-#[cfg(not(feature = "std"))]
-re_export_traits!("error", error_traits, core::error, Error);
-#[cfg(feature = "std")]
-re_export_traits!("error", error_traits, std::error, Error);
+    #[cfg(not(feature = "std"))]
+    re_export_traits!("error", error_traits, core::error, Error);
+    #[cfg(feature = "std")]
+    re_export_traits!("error", error_traits, std::error, Error);
 
-re_export_traits!("from", from_traits, core::convert, From);
+    re_export_traits!("from", from_traits, core::convert, From);
 
-re_export_traits!("from_str", from_str_traits, core::str, FromStr);
+    re_export_traits!("from_str", from_str_traits, core::str, FromStr);
 
-re_export_traits!("index", index_traits, core::ops, Index);
+    re_export_traits!("index", index_traits, core::ops, Index);
 
-re_export_traits!("index_mut", index_mut_traits, core::ops, IndexMut);
+    re_export_traits!("index_mut", index_mut_traits, core::ops, IndexMut);
 
-re_export_traits!("into", into_traits, core::convert, Into);
+    re_export_traits!("into", into_traits, core::convert, Into);
 
-re_export_traits!(
-    "into_iterator",
-    into_iterator_traits,
-    core::iter,
-    IntoIterator,
-);
+    re_export_traits!(
+        "into_iterator",
+        into_iterator_traits,
+        core::iter,
+        IntoIterator,
+    );
 
-re_export_traits!("mul", mul_traits, core::ops, Div, Mul, Rem, Shl, Shr);
+    re_export_traits!("mul", mul_traits, core::ops, Div, Mul, Rem, Shl, Shr);
 
-#[cfg(feature = "mul_assign")]
-re_export_traits!(
-    "mul_assign",
-    mul_assign_traits,
-    core::ops,
-    DivAssign,
-    MulAssign,
-    RemAssign,
-    ShlAssign,
-    ShrAssign,
-);
+    #[cfg(feature = "mul_assign")]
+    re_export_traits!(
+        "mul_assign",
+        mul_assign_traits,
+        core::ops,
+        DivAssign,
+        MulAssign,
+        RemAssign,
+        ShlAssign,
+        ShrAssign,
+    );
 
-re_export_traits!("not", not_traits, core::ops, Neg, Not);
+    re_export_traits!("not", not_traits, core::ops, Neg, Not);
 
-re_export_traits!("sum", sum_traits, core::iter, Product, Sum);
+    re_export_traits!("sum", sum_traits, core::iter, Product, Sum);
 
-re_export_traits!("try_from", try_from_traits, core::convert, TryFrom);
+    re_export_traits!("try_from", try_from_traits, core::convert, TryFrom);
 
-re_export_traits!("try_into", try_into_traits, core::convert, TryInto);
+    re_export_traits!("try_into", try_into_traits, core::convert, TryInto);
 
-// Now re-export our own derives by their exact name to overwrite any derives that the trait
-// re-exporting might inadvertently pull into scope.
+    // Now re-export our own derives by their exact name to overwrite any derives that the trait
+    // re-exporting might inadvertently pull into scope.
+    #[cfg(feature = "add")]
+    pub use derive_more_impl::{Add, BitAnd, BitOr, BitXor, Sub};
+
+    #[cfg(feature = "add_assign")]
+    pub use derive_more_impl::{
+        AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, SubAssign,
+    };
+
+    #[cfg(feature = "as_ref")]
+    pub use derive_more_impl::{AsMut, AsRef};
+
+    #[cfg(feature = "constructor")]
+    pub use derive_more_impl::Constructor;
+
+    #[cfg(feature = "debug")]
+    pub use derive_more_impl::Debug;
+
+    #[cfg(feature = "deref")]
+    pub use derive_more_impl::Deref;
+
+    #[cfg(feature = "deref_mut")]
+    pub use derive_more_impl::DerefMut;
+
+    #[cfg(feature = "display")]
+    pub use derive_more_impl::{
+        Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+    };
+
+    #[cfg(feature = "error")]
+    pub use derive_more_impl::Error;
+
+    #[cfg(feature = "from")]
+    pub use derive_more_impl::From;
+
+    #[cfg(feature = "from_str")]
+    pub use derive_more_impl::FromStr;
+
+    #[cfg(feature = "index")]
+    pub use derive_more_impl::Index;
+
+    #[cfg(feature = "index_mut")]
+    pub use derive_more_impl::IndexMut;
+
+    #[cfg(feature = "into")]
+    pub use derive_more_impl::Into;
+
+    #[cfg(feature = "into_iterator")]
+    pub use derive_more_impl::IntoIterator;
+
+    #[cfg(feature = "is_variant")]
+    pub use derive_more_impl::IsVariant;
+
+    #[cfg(feature = "mul")]
+    pub use derive_more_impl::{Div, Mul, Rem, Shl, Shr};
+
+    #[cfg(feature = "mul_assign")]
+    pub use derive_more_impl::{DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign};
+
+    #[cfg(feature = "not")]
+    pub use derive_more_impl::{Neg, Not};
+
+    #[cfg(feature = "sum")]
+    pub use derive_more_impl::{Product, Sum};
+
+    #[cfg(feature = "try_from")]
+    pub use derive_more_impl::TryFrom;
+
+    #[cfg(feature = "try_into")]
+    pub use derive_more_impl::TryInto;
+
+    #[cfg(feature = "try_unwrap")]
+    pub use derive_more_impl::TryUnwrap;
+
+    #[cfg(feature = "unwrap")]
+    pub use derive_more_impl::Unwrap;
+}
+
+// Now re-export our own derives and the std traits by their exact name to make rust-analyzer
+// recognize the #[doc(hidden)] flag.
+// See issues:
+// 1. https://github.com/rust-lang/rust-analyzer/issues/11698
+// 2. https://github.com/rust-lang/rust-analyzer/issues/14079
 #[cfg(feature = "add")]
-pub use derive_more_impl::{Add, BitAnd, BitOr, BitXor, Sub};
+#[doc(hidden)]
+pub use all_traits_and_derives::{Add, BitAnd, BitOr, BitXor, Sub};
 
 #[cfg(feature = "add_assign")]
-pub use derive_more_impl::{
+#[doc(hidden)]
+pub use all_traits_and_derives::{
     AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, SubAssign,
 };
 
 #[cfg(feature = "as_ref")]
-pub use derive_more_impl::{AsMut, AsRef};
+#[doc(hidden)]
+pub use all_traits_and_derives::{AsMut, AsRef};
 
 #[cfg(feature = "constructor")]
-pub use derive_more_impl::Constructor;
+#[doc(hidden)]
+pub use all_traits_and_derives::Constructor;
 
 #[cfg(feature = "debug")]
-pub use derive_more_impl::Debug;
+#[doc(hidden)]
+pub use all_traits_and_derives::Debug;
 
 #[cfg(feature = "deref")]
-pub use derive_more_impl::Deref;
+#[doc(hidden)]
+pub use all_traits_and_derives::Deref;
 
 #[cfg(feature = "deref_mut")]
-pub use derive_more_impl::DerefMut;
+#[doc(hidden)]
+pub use all_traits_and_derives::DerefMut;
 
 #[cfg(feature = "display")]
-pub use derive_more_impl::{
+#[doc(hidden)]
+pub use all_traits_and_derives::{
     Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
 };
 
 #[cfg(feature = "error")]
-pub use derive_more_impl::Error;
+#[doc(hidden)]
+pub use all_traits_and_derives::Error;
 
 #[cfg(feature = "from")]
-pub use derive_more_impl::From;
+#[doc(hidden)]
+pub use all_traits_and_derives::From;
 
 #[cfg(feature = "from_str")]
-pub use derive_more_impl::FromStr;
+#[doc(hidden)]
+pub use all_traits_and_derives::FromStr;
 
 #[cfg(feature = "index")]
-pub use derive_more_impl::Index;
+#[doc(hidden)]
+pub use all_traits_and_derives::Index;
 
 #[cfg(feature = "index_mut")]
-pub use derive_more_impl::IndexMut;
+#[doc(hidden)]
+pub use all_traits_and_derives::IndexMut;
 
 #[cfg(feature = "into")]
-pub use derive_more_impl::Into;
+#[doc(hidden)]
+pub use all_traits_and_derives::Into;
 
 #[cfg(feature = "into_iterator")]
-pub use derive_more_impl::IntoIterator;
+#[doc(hidden)]
+pub use all_traits_and_derives::IntoIterator;
 
 #[cfg(feature = "is_variant")]
-pub use derive_more_impl::IsVariant;
+#[doc(hidden)]
+pub use all_traits_and_derives::IsVariant;
 
 #[cfg(feature = "mul")]
-pub use derive_more_impl::{Div, Mul, Rem, Shl, Shr};
+#[doc(hidden)]
+pub use all_traits_and_derives::{Div, Mul, Rem, Shl, Shr};
 
 #[cfg(feature = "mul_assign")]
-pub use derive_more_impl::{DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign};
+#[doc(hidden)]
+pub use all_traits_and_derives::{
+    DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign,
+};
 
 #[cfg(feature = "not")]
-pub use derive_more_impl::{Neg, Not};
+#[doc(hidden)]
+pub use all_traits_and_derives::{Neg, Not};
 
 #[cfg(feature = "sum")]
-pub use derive_more_impl::{Product, Sum};
+#[doc(hidden)]
+pub use all_traits_and_derives::{Product, Sum};
 
 #[cfg(feature = "try_from")]
-pub use derive_more_impl::TryFrom;
+#[doc(hidden)]
+pub use all_traits_and_derives::TryFrom;
 
 #[cfg(feature = "try_into")]
-pub use derive_more_impl::TryInto;
+#[doc(hidden)]
+pub use all_traits_and_derives::TryInto;
 
 #[cfg(feature = "try_unwrap")]
-pub use derive_more_impl::TryUnwrap;
+#[doc(hidden)]
+pub use all_traits_and_derives::TryUnwrap;
 
 #[cfg(feature = "unwrap")]
-pub use derive_more_impl::Unwrap;
+#[doc(hidden)]
+pub use all_traits_and_derives::Unwrap;
+
+// Re-export the derive macros again to show docs for our derives (but not for traits). This is
+// done using a glob import to not hit E0252.
+#[allow(unused_imports)]
+pub use derive_more_impl::*;
 
 // Check if any feature is enabled
 #[cfg(not(any(


### PR DESCRIPTION
Resolves #351


## Synopsis

Rust-analyzer doesn't ignore `#[doc(hidden)]` exports when they use a glob
pattern, only when they explicitely re-export. 


## Solution

This adds more level of indirection and one more glob pattern so that we put
`#[doc(hidden)]` on explicit re-exports. This definitely starts to feel like
we're doing hack upon hack here. But ah well, this seems to work. And working
well with the most popular LSP for Rust seems worth a bit of a hack.
