### PR TITLE
Add #[track_caller] to Add/Mul(Assign) derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#300](https://github.com/JelteF/derive_more/pull/300))
 - `#[inline]` attributes to `IsVariant` and `Debug` implementations.
   ([#334](https://github.com/JelteF/derive_more/pull/334)
+- Add `#[track_caller]` to `Add`, `Mul`, `AddAssign` and `MulAssign` derives
+  ([#378](https://github.com/JelteF/derive_more/pull/378)
+
 
 ### Changed
 

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -31,6 +31,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
         #[automatically_derived]
         impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             #[inline]
+            #[track_caller]
             fn #method_ident(&mut self, rhs: #input_type #ty_generics) {
                 #( #exprs; )*
             }

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -46,6 +46,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
             type Output = #output_type;
 
             #[inline]
+            #[track_caller]
             fn #method_ident(self, rhs: #input_type #ty_generics) -> #output_type {
                 #block
             }

--- a/impl/src/mul_assign_like.rs
+++ b/impl/src/mul_assign_like.rs
@@ -55,6 +55,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
         #[automatically_derived]
         impl #impl_generics #trait_path<#scalar_ident> for #input_type #ty_generics #where_clause {
             #[inline]
+            #[track_caller]
             fn #method_ident(&mut self, rhs: #scalar_ident) {
                 #( #exprs; )*
             }

--- a/impl/src/mul_like.rs
+++ b/impl/src/mul_like.rs
@@ -53,6 +53,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             type Output = #input_type #ty_generics;
 
             #[inline]
+            #[track_caller]
             fn #method_ident(self, rhs: #scalar_ident) -> #input_type #ty_generics {
                 #body
             }


### PR DESCRIPTION
Resolves #364

## Synopsis

In debug builds overflows cause panics. With our derives it's hard to spot
where these panics happen when RUST_BACKTRACE is not set. 

## Solution

This fixes that by marking our trait methods for Add/Mul(Assign) as `#[track_caller].

## Checklist

~- [ ] Documentation is updated (if required)~
~- [ ] Tests are added/updated (if required)~
- [x] [CHANGELOG entry][l:1] is added (if required)

[l:1]: /CHANGELOG.md
