### PR TITLE
Don't use double ref vars in Debug derive

### DIFF
--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -82,7 +82,7 @@ fn expand_struct(
             .ident
             .clone()
             .map_or_else(|| syn::Member::Unnamed(i.into()), syn::Member::Named);
-        quote! { let #var = &&self.#member; }
+        quote! { let #var = &self.#member; }
     });
 
     let body = quote! {
@@ -275,7 +275,7 @@ impl<'a> Expansion<'a> {
                         None => {
                             let ident = format_ident!("_{i}");
                             Ok(quote! {
-                                derive_more::__private::DebugTuple::field(#out, #ident)
+                                derive_more::__private::DebugTuple::field(#out, &#ident)
                             })
                         }
                     },
@@ -316,7 +316,7 @@ impl<'a> Expansion<'a> {
                                 )
                             }),
                             None => Ok(quote! {
-                                derive_more::core::fmt::DebugStruct::field(#out, #field_str, #field_ident)
+                                derive_more::core::fmt::DebugStruct::field(#out, #field_str, &#field_ident)
                             }),
                         }
                     })?;


### PR DESCRIPTION
Related to #289
Related to #328

## Synopsis

While looking into #328 I realized the current situation around Pointer derives
and references was even weirder because we store a double-reference to the
fields in the local variables for Debug, but not for Display. The reason we
were doing this was because of #289.


## Solution

This stops storing a double-reference, and only adds the additional reference
in the places where its needed.
