### PR TITLE
Fix incorrect `fmt::Pointer` implementations attempt two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Make `{field:p}` do the expected thing in format strings for `Display` and
   `Debug`. Also document weirdness around `Pointer` formatting when using
   expressions, due to field variables being references.
+  ([#381](https://github.com/JelteF/derive_more/pull/381))
 
 ## 0.99.10 - 2020-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Hygiene of macro expansions in presence of custom `core` crate.
   ([#327](https://github.com/JelteF/derive_more/pull/327))
 - Fix documentation of generated methods in `IsVariant` derive.
+- Make `{field:p}` do the expected thing in format strings for `Display` and
+  `Debug`. Also document weirdness around `Pointer` formatting when using
+  expressions, due to field variables being references.
 
 ## 0.99.10 - 2020-09-11
 

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -25,7 +25,9 @@ once to get the address of the field itself, instead of the address of the
 reference to the field:
 
 ```rust
-#[derive(derive_more::Debug)]
+# use derive_more::Debug;
+#
+#[derive(Debug)]
 #[debug("{field:p} {:p}", *field)]
 struct RefInt<'a> {
     field: &'a i32,
@@ -43,8 +45,8 @@ are bound by respective formatting trait.
 
 E.g., for a structure `Foo` defined like this:
 ```rust
-use derive_more::Debug;
-
+# use derive_more::Debug;
+#
 #[derive(Debug)]
 struct Foo<'a, T1, T2: Trait, T3, T4> {
     #[debug("{a}")]
@@ -82,9 +84,9 @@ possible. Our aim is to avoid imposing additional bounds, as they can be added w
 In the example below, we can infer only that `V: Display`, other bounds have to be supplied by the user:
 
 ```rust
-use std::fmt::Display;
-use derive_more::Debug;
-
+# use std::fmt::Display;
+# use derive_more::Debug;
+#
 #[derive(Debug)]
 #[debug(bound(T: MyTrait, U: Display))]
 struct MyStruct<T, U, V, F> {
@@ -155,9 +157,9 @@ assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
 ## Example usage
 
 ```rust
-use std::path::PathBuf;
-use derive_more::Debug;
-
+# use std::path::PathBuf;
+# use derive_more::Debug;
+#
 #[derive(Debug)]
 struct MyInt(i32);
 

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -14,8 +14,26 @@ This derive macro is a clever superset of `Debug` from standard library. Additio
 You supply a format by placing an attribute on a struct or enum variant, or its particular field:
 `#[debug("...", args...)]`. The format is exactly like in [`format!()`] or any other [`format_args!()`]-based macros.
 
-The variables available in the arguments is `self` and each member of the struct or enum variant, with members of tuple
-structs being named with a leading underscore and their index, i.e. `_0`, `_1`, `_2`, etc.
+The variables available in the arguments is `self` and each member of the
+struct or enum variant, with members of tuple structs being named with a
+leading underscore and their index, i.e. `_0`, `_1`, `_2`, etc. Due to
+ownership/lifetime limitations the member variables are all references to the
+fields, except when used directly in the format string. For most purposes this
+detail doesn't matter, but it is quite important when using `Pointer`
+formatting. If you don't use the `{field:p}` syntax, you have to dereference
+once to get the address of the field itself, instead of the address of the
+reference to the field:
+
+```rust
+#[derive(derive_more::Debug)]
+#[debug("{field:p} {:p}", *field)]
+struct RefInt<'a> {
+    field: &'a i32,
+}
+
+let a = &123;
+assert_eq!(format!("{:?}", RefInt{field: &a}), format!("{a:p} {:p}", a));
+```
 
 
 ### Generic data types

--- a/impl/doc/debug.md
+++ b/impl/doc/debug.md
@@ -25,8 +25,8 @@ once to get the address of the field itself, instead of the address of the
 reference to the field:
 
 ```rust
-# use derive_more::Debug;
-#
+use derive_more::Debug;
+
 #[derive(Debug)]
 #[debug("{field:p} {:p}", *field)]
 struct RefInt<'a> {
@@ -45,8 +45,8 @@ are bound by respective formatting trait.
 
 E.g., for a structure `Foo` defined like this:
 ```rust
-# use derive_more::Debug;
-#
+use derive_more::Debug;
+
 #[derive(Debug)]
 struct Foo<'a, T1, T2: Trait, T3, T4> {
     #[debug("{a}")]
@@ -84,9 +84,9 @@ possible. Our aim is to avoid imposing additional bounds, as they can be added w
 In the example below, we can infer only that `V: Display`, other bounds have to be supplied by the user:
 
 ```rust
-# use std::fmt::Display;
-# use derive_more::Debug;
-#
+use std::fmt::Display;
+use derive_more::Debug;
+
 #[derive(Debug)]
 #[debug(bound(T: MyTrait, U: Display))]
 struct MyStruct<T, U, V, F> {
@@ -110,8 +110,8 @@ If the top-level `#[debug("...", args...)]` attribute (the one for a whole struc
 and can be trivially substituted with a transparent delegation call to the inner type, then all the additional
 [formatting parameters][1] do work as expected:
 ```rust
-# use derive_more::Debug;
-#
+use derive_more::Debug;
+
 #[derive(Debug)]
 #[debug("{_0:o}")] // the same as calling `Octal::fmt()`
 struct MyOctalInt(i32);
@@ -130,8 +130,8 @@ assert_eq!(format!("{:07?}", MyBinaryInt(2)), "10");
 If, for some reason, transparency in trivial cases is not desired, it may be suppressed explicitly
 either with the [`format_args!()`] macro usage:
 ```rust
-# use derive_more::Debug;
-#
+use derive_more::Debug;
+
 #[derive(Debug)]
 #[debug("{}", format_args!("{_0:o}"))] // `format_args!()` obscures the inner type
 struct MyOctalInt(i32);
@@ -141,8 +141,8 @@ assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
 ```
 Or by adding [formatting parameters][1] which cause no visual effects:
 ```rust
-# use derive_more::Debug;
-#
+use derive_more::Debug;
+
 #[derive(Debug)]
 #[debug("{_0:^o}")] // `^` is centering, but in absence of additional width has no effect
 struct MyOctalInt(i32);
@@ -157,9 +157,9 @@ assert_eq!(format!("{:07?}", MyOctalInt(9)), "11");
 ## Example usage
 
 ```rust
-# use std::path::PathBuf;
-# use derive_more::Debug;
-#
+use std::path::PathBuf;
+use derive_more::Debug;
+
 #[derive(Debug)]
 struct MyInt(i32);
 

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -14,17 +14,33 @@ For enums, you can either specify it on each variant, or on the enum as a whole.
 For variants that don't have a format specified, it will simply defer to the format of the
 inner variable. If there is no such variable, or there is more than 1, an error is generated.
 
-
-
-
 ## The format of the format
 
 You supply a format by attaching an attribute of the syntax: `#[display("...", args...)]`.
 The format supplied is passed verbatim to `write!`.
 
-The variables available in the arguments is `self` and each member of the variant,
-with members of tuple structs being named with a leading underscore and their index,
-i.e. `_0`, `_1`, `_2`, etc.
+The variables available in the arguments is `self` and each member of the
+struct or enum variant, with members of tuple structs being named with a
+leading underscore and their index, i.e. `_0`, `_1`, `_2`, etc. Due to
+ownership/lifetime limitations the member variables are all references to the
+fields, except when used directly in the format string. For most purposes this
+detail doesn't matter, but it is quite important when using `Pointer`
+formatting. If you don't use the `{field:p}` syntax, you have to dereference
+once to get the address of the field itself, instead of the address of the
+reference to the field:
+
+```rust
+# use derive_more::Display;
+#
+#[derive(Display)]
+#[display("{field:p} {:p}", *field)]
+struct RefInt<'a> {
+    field: &'a i32,
+}
+
+let a = &123;
+assert_eq!(format!("{}", RefInt{field: &a}), format!("{a:p} {:p}", a));
+```
 
 For enums you can also specify a shared format on the enum itself instead of
 the variant. This format is used for each of the variants, and can be
@@ -55,7 +71,7 @@ E.g., for a structure `Foo` defined like this:
 # trait Trait { type Type; }
 #
 #[derive(Display)]
-#[display("{} {} {:?} {:p}", a, b, c, d)]
+#[display("{a} {b} {c:?} {d:p}")]
 struct Foo<'a, T1, T2: Trait, T3> {
     a: T1,
     b: <T2 as Trait>::Type,

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -14,6 +14,9 @@ For enums, you can either specify it on each variant, or on the enum as a whole.
 For variants that don't have a format specified, it will simply defer to the format of the
 inner variable. If there is no such variable, or there is more than 1, an error is generated.
 
+
+
+
 ## The format of the format
 
 You supply a format by attaching an attribute of the syntax: `#[display("...", args...)]`.

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -250,7 +250,12 @@ impl<'a> Expansion<'a> {
     fn generate_body(&self) -> syn::Result<TokenStream> {
         if let Some(fmt) = &self.attr.fmt {
             return Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                let expr = if self.fields.fmt_args_idents().any(|field| expr == field) {
+                let expr = if self
+                    .fields
+                    .fmt_args_idents()
+                    .into_iter()
+                    .any(|field| expr == field)
+                {
                     quote! { #expr }
                 } else {
                     quote! { &(#expr) }

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -282,13 +282,16 @@ impl<'a> Expansion<'a> {
 
                         quote! { &derive_more::core::format_args!(#fmt, #(#deref_args),*) }
                     } else if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                        let expr =
-                            if self.fields.fmt_args_idents().any(|field| expr == field)
-                            {
-                                quote! { #expr }
-                            } else {
-                                quote! { &(#expr) }
-                            };
+                        let expr = if self
+                            .fields
+                            .fmt_args_idents()
+                            .into_iter()
+                            .any(|field| expr == field)
+                        {
+                            quote! { #expr }
+                        } else {
+                            quote! { &(#expr) }
+                        };
 
                         quote! {
                             derive_more::core::fmt::#trait_ident::fmt(#expr, __derive_more_f)

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -290,13 +290,16 @@ impl FmtAttribute {
             })
             .collect::<Vec<_>>();
 
-        fields.fmt_args_idents().filter_map(move |field_name| {
-            (used_args.iter().any(|arg| field_name == arg)
-                && !self.args.iter().any(|arg| {
-                    arg.alias.as_ref().map_or(false, |(n, _)| n == &field_name)
-                }))
-            .then(|| quote! { #field_name = *#field_name })
-        })
+        fields
+            .fmt_args_idents()
+            .into_iter()
+            .filter_map(move |field_name| {
+                (used_args.iter().any(|arg| field_name == arg)
+                    && !self.args.iter().any(|arg| {
+                        arg.alias.as_ref().map_or(false, |(n, _)| n == &field_name)
+                    }))
+                .then(|| quote! { #field_name = *#field_name })
+            })
     }
 
     /// Errors in case legacy syntax is encountered: `fmt = "...", (arg),*`.
@@ -671,14 +674,17 @@ trait FieldsExt {
     /// [`FmtAttribute`] as [`FmtArgument`]s or named [`Placeholder`]s.
     ///
     /// [`syn::Ident`]: struct@syn::Ident
-    fn fmt_args_idents(&self) -> impl Iterator<Item = syn::Ident> + '_;
+    // TODO: Return `impl Iterator<Item = syn::Ident> + '_` once MSRV is bumped up to 1.75 or
+    //       higher.
+    fn fmt_args_idents(&self) -> Vec<syn::Ident>;
 }
 
 impl FieldsExt for syn::Fields {
-    fn fmt_args_idents(&self) -> impl Iterator<Item = syn::Ident> + '_ {
+    fn fmt_args_idents(&self) -> Vec<syn::Ident> {
         self.iter()
             .enumerate()
             .map(|(i, f)| f.ident.clone().unwrap_or_else(|| format_ident!("_{i}")))
+            .collect()
     }
 }
 

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -669,6 +669,8 @@ impl ContainsGenericsExt for syn::Path {
 trait FieldsExt {
     /// Returns an [`Iterator`] over [`syn::Ident`]s representing these [`syn::Fields`] in a
     /// [`FmtAttribute`] as [`FmtArgument`]s or named [`Placeholder`]s.
+    ///
+    /// [`syn::Ident`]: struct@syn::Ident
     fn fmt_args_idents(&self) -> impl Iterator<Item = syn::Ident> + '_;
 }
 

--- a/impl/src/parsing.rs
+++ b/impl/src/parsing.rs
@@ -71,6 +71,12 @@ impl Parse for Expr {
     }
 }
 
+impl PartialEq<syn::Ident> for Expr {
+    fn eq(&self, other: &syn::Ident) -> bool {
+        self.ident().map_or(false, |i| i == other)
+    }
+}
+
 impl ToTokens for Expr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1323,7 +1323,7 @@ mod generic {
 
     #[derive(Debug)]
     struct AliasedFieldNamedGenericStruct<T> {
-        #[debug("{field3}", field3 = field2)]
+        #[debug("{field1}", field1 = field2)]
         field1: T,
         field2: i32,
     }
@@ -1441,7 +1441,7 @@ mod generic {
     }
 
     #[derive(Debug)]
-    struct AliasedFieldUnnamedGenericStruct<T>(#[debug("{_2}", _2 = _1)] T, i32);
+    struct AliasedFieldUnnamedGenericStruct<T>(#[debug("{_0}", _0 = _1)] T, i32);
     #[test]
     fn aliased_field_unnamed_generic_struct() {
         assert_eq!(

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -102,7 +102,7 @@ mod structs {
                 assert_eq!(format!("{:03?}", UpperHex), "00B");
                 assert_eq!(format!("{:07?}", LowerExp), "03.15e0");
                 assert_eq!(format!("{:07?}", UpperExp), "03.15E0");
-                assert_eq!(format!("{:018?}", Pointer).len(), 18);
+                assert_eq!(format!("{:018?}", Pointer), format!("{POINTER:018p}"));
             }
 
             mod omitted {
@@ -245,6 +245,35 @@ mod structs {
                     format!("{:#?}", Struct { field: 0 }),
                     "Struct {\n    field: 0.0,\n}",
                 );
+            }
+
+            mod pointer {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                struct Tuple<'a>(#[debug("{_0:p}.{:p}", self.0)] &'a i32);
+
+                #[derive(Debug)]
+                struct Struct<'a> {
+                    #[debug("{field:p}.{:p}", self.field)]
+                    field: &'a i32,
+                }
+
+                #[test]
+                fn assert() {
+                    let a = 42;
+                    assert_eq!(
+                        format!("{:?}", Tuple(&a)),
+                        format!("Tuple({0:p}.{0:p})", &a),
+                    );
+                    assert_eq!(
+                        format!("{:?}", Struct { field: &a }),
+                        format!("Struct {{ field: {0:p}.{0:p} }}", &a),
+                    );
+                }
             }
         }
 
@@ -527,6 +556,37 @@ mod structs {
                 assert_eq!(format!("{:?}", Tuple(10, true)), "10 * true");
                 assert_eq!(format!("{:?}", Struct { a: 10, b: true }), "10 * true");
             }
+
+            mod pointer {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                #[debug("{_0:p} * {_1:p}", _0 = self.0)]
+                struct Tuple<'a, 'b>(&'a u8, &'b bool);
+
+                #[derive(Debug)]
+                #[debug("{a:p} * {b:p}", a = self.a)]
+                struct Struct<'a, 'b> {
+                    a: &'a u8,
+                    b: &'b bool,
+                }
+
+                #[test]
+                fn assert() {
+                    let (a, b) = (10, true);
+                    assert_eq!(
+                        format!("{:?}", Tuple(&a, &b)),
+                        format!("{:p} * {:p}", &a, &b),
+                    );
+                    assert_eq!(
+                        format!("{:?}", Struct { a: &a, b: &b }),
+                        format!("{:p} * {:p}", &a, &b),
+                    );
+                }
+            }
         }
 
         mod ignore {
@@ -677,7 +737,10 @@ mod enums {
                 assert_eq!(format!("{:03?}", Unit::UpperHex), "00B");
                 assert_eq!(format!("{:07?}", Unit::LowerExp), "03.15e0");
                 assert_eq!(format!("{:07?}", Unit::UpperExp), "03.15E0");
-                assert_eq!(format!("{:018?}", Unit::Pointer).len(), 18);
+                assert_eq!(
+                    format!("{:018?}", Unit::Pointer),
+                    format!("{POINTER:018p}"),
+                );
             }
 
             mod omitted {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -262,6 +262,16 @@ mod structs {
                     field: &'a i32,
                 }
 
+                #[derive(Debug)]
+                #[debug("{_0:p}")]
+                struct TupleTransparent<'a>(&'a i32);
+
+                #[derive(Debug)]
+                #[debug("{field:p}")]
+                struct StructTransparent<'a> {
+                    field: &'a i32,
+                }
+
                 #[test]
                 fn assert() {
                     let a = 42;
@@ -272,6 +282,14 @@ mod structs {
                     assert_eq!(
                         format!("{:?}", Struct { field: &a }),
                         format!("Struct {{ field: {0:p}.{0:p} }}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:?}", TupleTransparent(&a)),
+                        format!("{0:p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:?}", StructTransparent { field: &a }),
+                        format!("{0:p}", &a),
                     );
                 }
             }
@@ -564,11 +582,11 @@ mod structs {
                 use derive_more::Debug;
 
                 #[derive(Debug)]
-                #[debug("{_0:p} * {_1:p}", _0 = self.0)]
+                #[debug("{_0:p} * {_1:p}")]
                 struct Tuple<'a, 'b>(&'a u8, &'b bool);
 
                 #[derive(Debug)]
-                #[debug("{a:p} * {b:p}", a = self.a)]
+                #[debug("{a:p} * {b:p}")]
                 struct Struct<'a, 'b> {
                     a: &'a u8,
                     b: &'b bool,
@@ -1305,7 +1323,7 @@ mod generic {
 
     #[derive(Debug)]
     struct AliasedFieldNamedGenericStruct<T> {
-        #[debug("{field1}", field1 = field2)]
+        #[debug("{field3}", field3 = field2)]
         field1: T,
         field2: i32,
     }
@@ -1423,7 +1441,7 @@ mod generic {
     }
 
     #[derive(Debug)]
-    struct AliasedFieldUnnamedGenericStruct<T>(#[debug("{_0}", _0 = _1)] T, i32);
+    struct AliasedFieldUnnamedGenericStruct<T>(#[debug("{_2}", _2 = _1)] T, i32);
     #[test]
     fn aliased_field_unnamed_generic_struct() {
         assert_eq!(

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -447,7 +447,7 @@ mod structs {
                 }
 
                 #[derive(Display)]
-                #[display("{}", format_args!("{field:p}"))]
+                #[display("{}", format_args!("{field:p}", field = *field))]
                 struct StructPointer<'a> {
                     field: &'a i32,
                 }
@@ -566,15 +566,15 @@ mod structs {
 
             #[derive(Display)]
             #[display(
-                "{_0} {ident} {_1} {} {}",
-                _1, _0 + _1, ident = 123, _1 = _0,
+                "{_0} {ident} {_2} {} {}",
+                _1, _0 + _1, ident = 123, _2 = _0,
             )]
             struct Tuple(i32, i32);
 
             #[derive(Display)]
             #[display(
-                "{field1} {ident} {field2} {} {}",
-                field2, field1 + field2, ident = 123, field2 = field1,
+                "{field1} {ident} {field3} {} {}",
+                field2, field1 + field2, ident = 123, field3 = field1,
             )]
             struct Struct {
                 field1: i32,
@@ -1010,7 +1010,7 @@ mod enums {
 
                 #[derive(Display)]
                 enum Pointer<'a> {
-                    #[display("{:p}", _0)]
+                    #[display("{:p}", *_0)]
                     A(&'a i32),
                     #[display("{field:p}")]
                     B { field: &'a u8 },
@@ -1121,9 +1121,9 @@ mod enums {
 
                 #[derive(Display)]
                 enum Pointer<'a> {
-                    #[display("{}", format_args!("{:p}", _0))]
+                    #[display("{}", format_args!("{:p}", *_0))]
                     A(&'a i32),
-                    #[display("{}", format_args!("{field:p}"))]
+                    #[display("{}", format_args!("{field:p}", field = *field))]
                     B { field: &'a u8 },
                 }
 
@@ -1166,13 +1166,13 @@ mod enums {
             #[display("named")]
             StrNamed { field1: i32, field2: i32 },
             #[display(
-                "{_0} {ident} {_1} {} {}",
-                _1, _0 + _1, ident = 123, _1 = _0,
+                "{_0} {ident} {_2} {} {}",
+                _1, _0 + _1, ident = 123, _2 = _0,
             )]
             InterpolatedUnnamed(i32, i32),
             #[display(
-                "{field1} {ident} {field2} {} {}",
-                field2, field1 + field2, ident = 123, field2 = field1,
+                "{field1} {ident} {field3} {} {}",
+                field2, field1 + field2, ident = 123, field3 = field1,
             )]
             InterpolatedNamed { field1: i32, field2: i32 },
         }
@@ -1271,7 +1271,7 @@ mod enums {
 
                 #[derive(Display)]
                 enum Pointer<'a> {
-                    #[display("{:p}", _1)]
+                    #[display("{:p}", *_1)]
                     A(&'a f64, &'a f32),
                     #[display("{a:p}")]
                     B { a: &'a f64, b: &'a f32 },
@@ -1464,6 +1464,31 @@ mod enums {
                     assert_eq!(Enum::<u8>::A(1).to_string(), "Variant A 1");
                     assert_eq!(Enum::<u8>::B("abc").to_string(), "Variant B abc");
                     assert_eq!(Enum::<u8>::C(9).to_string(), "Variant C 9");
+                }
+            }
+
+            mod pointer {
+                use super::*;
+
+                #[derive(Display)]
+                #[display("Pointer {_0:p} {_variant} {_0:p}")]
+                enum Pointer<'a> {
+                    #[display("A")]
+                    A(&'a f64),
+                    #[display("B")]
+                    B(&'a f32),
+                }
+                #[test]
+                fn assert() {
+                    let (a, b) = (8.3, 42.1);
+                    assert_eq!(
+                        format!("{}", Pointer::A(&a)),
+                        format!("Pointer {0:p} A {0:p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{}", Pointer::B(&b)),
+                        format!("Pointer {0:p} B {0:p}", &b),
+                    );
                 }
             }
         }
@@ -2106,7 +2131,7 @@ mod generic {
             struct TupleUpperExp<T>(T);
 
             #[derive(Display)]
-            #[display("{:p}", _0)]
+            #[display("{_0:p}")]
             struct TuplePointer<T>(T);
 
             #[derive(Display)]
@@ -2154,7 +2179,7 @@ mod generic {
             }
 
             #[derive(Display)]
-            #[display("{:p}", field)]
+            #[display("{field:p}")]
             struct StructPointer<T> {
                 field: T,
             }
@@ -2217,7 +2242,7 @@ mod generic {
 
             #[derive(Display)]
             enum EnumPointer<A, B> {
-                #[display("{:p}", _0)]
+                #[display("{_0:p}")]
                 A(A),
                 #[display("{field:p}")]
                 B { field: B },

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -566,15 +566,15 @@ mod structs {
 
             #[derive(Display)]
             #[display(
-                "{_0} {ident} {_2} {} {}",
-                _1, _0 + _1, ident = 123, _2 = _0,
+                "{_0} {ident} {_1} {} {}",
+                _1, _0 + _1, ident = 123, _1 = _0,
             )]
             struct Tuple(i32, i32);
 
             #[derive(Display)]
             #[display(
-                "{field1} {ident} {field3} {} {}",
-                field2, field1 + field2, ident = 123, field3 = field1,
+                "{field1} {ident} {field2} {} {}",
+                field2, field1 + field2, ident = 123, field2 = field1,
             )]
             struct Struct {
                 field1: i32,
@@ -1166,13 +1166,13 @@ mod enums {
             #[display("named")]
             StrNamed { field1: i32, field2: i32 },
             #[display(
-                "{_0} {ident} {_2} {} {}",
-                _1, _0 + _1, ident = 123, _2 = _0,
+                "{_0} {ident} {_1} {} {}",
+                _1, _0 + _1, ident = 123, _1 = _0,
             )]
             InterpolatedUnnamed(i32, i32),
             #[display(
-                "{field1} {ident} {field3} {} {}",
-                field2, field1 + field2, ident = 123, field3 = field1,
+                "{field1} {ident} {field2} {} {}",
+                field2, field1 + field2, ident = 123, field2 = field1,
             )]
             InterpolatedNamed { field1: i32, field2: i32 },
         }
@@ -1482,11 +1482,11 @@ mod enums {
                 fn assert() {
                     let (a, b) = (8.3, 42.1);
                     assert_eq!(
-                        format!("{}", Pointer::A(&a)),
+                        Pointer::A(&a).to_string(),
                         format!("Pointer {0:p} A {0:p}", &a),
                     );
                     assert_eq!(
-                        format!("{}", Pointer::B(&b)),
+                        Pointer::B(&b).to_string(),
                         format!("Pointer {0:p} B {0:p}", &b),
                     );
                 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -139,7 +139,7 @@ mod structs {
                     assert_eq!(format!("{:03}", UpperHex), "00B");
                     assert_eq!(format!("{:07}", LowerExp), "03.15e0");
                     assert_eq!(format!("{:07}", UpperExp), "03.15E0");
-                    assert_eq!(format!("{:018}", Pointer).len(), 18);
+                    assert_eq!(format!("{:018}", Pointer), format!("{POINTER:018p}"));
                 }
             }
 
@@ -322,9 +322,10 @@ mod structs {
                         format!("{:07E}", StructUpperExp { field: 42.0 }),
                         "004.2E1",
                     );
+                    let a = 42;
                     assert_eq!(
-                        format!("{:018p}", StructPointer { field: &42 }).len(),
-                        18,
+                        format!("{:018p}", StructPointer { field: &a }),
+                        format!("{:018p}", &a),
                     );
                 }
             }
@@ -394,9 +395,10 @@ mod structs {
                         format!("{:07}", StructUpperExp { field: 42.0 }),
                         "004.2E1",
                     );
+                    let a = 42;
                     assert_eq!(
-                        format!("{:018}", StructPointer { field: &42 }).len(),
-                        18,
+                        format!("{:018}", StructPointer { field: &a }),
+                        format!("{:018p}", &a),
                     );
                 }
             }
@@ -466,9 +468,10 @@ mod structs {
                         format!("{:07}", StructUpperExp { field: 42.0 }),
                         "4.2E1",
                     );
-                    assert_ne!(
-                        format!("{:018}", StructPointer { field: &42 }).len(),
-                        18,
+                    let a = 42;
+                    assert_eq!(
+                        format!("{:018}", StructPointer { field: &a }),
+                        format!("{:p}", &a),
                     );
                 }
             }
@@ -671,9 +674,10 @@ mod structs {
                         format!("{:07}", StructUpperExp { a: 41.0, b: 42.0 }),
                         "004.2E1",
                     );
+                    let (a, b) = (42, 43);
                     assert_eq!(
-                        format!("{:018}", StructPointer { a: &42, b: &43 }).len(),
-                        18,
+                        format!("{:018}", StructPointer { a: &a, b: &b }),
+                        format!("{:018p}", &b),
                     );
                 }
             }
@@ -764,7 +768,10 @@ mod enums {
                     assert_eq!(format!("{:03}", Unit::UpperHex), "00B");
                     assert_eq!(format!("{:07}", Unit::LowerExp), "03.15e0");
                     assert_eq!(format!("{:07}", Unit::UpperExp), "03.15E0");
-                    assert_eq!(format!("{:018}", Unit::Pointer).len(), 18);
+                    assert_eq!(
+                        format!("{:018}", Unit::Pointer),
+                        format!("{POINTER:018p}"),
+                    );
                 }
             }
 
@@ -922,8 +929,15 @@ mod enums {
                         format!("{:07E}", UpperExp::B { field: 43.0 }),
                         "004.3E1",
                     );
-                    assert_eq!(format!("{:018p}", Pointer::A(&7)).len(), 18);
-                    assert_eq!(format!("{:018p}", Pointer::B { field: &42 }).len(), 18);
+                    let (a, b) = (7, 42);
+                    assert_eq!(
+                        format!("{:018p}", Pointer::A(&a)),
+                        format!("{:018p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:018p}", Pointer::B { field: &b }),
+                        format!("{:018p}", &b),
+                    );
                 }
             }
 
@@ -1026,8 +1040,15 @@ mod enums {
                         format!("{:07}", UpperExp::B { field: 43.0 }),
                         "004.3E1",
                     );
-                    assert_eq!(format!("{:018}", Pointer::A(&7)).len(), 18);
-                    assert_eq!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
+                    let (a, b) = (7, 42);
+                    assert_eq!(
+                        format!("{:018}", Pointer::A(&a)),
+                        format!("{:018p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { field: &b }),
+                        format!("{:018p}", &b),
+                    );
                 }
             }
 
@@ -1124,8 +1145,12 @@ mod enums {
                     assert_eq!(format!("{:07}", LowerExp::B { field: 43.0 }), "4.3e1");
                     assert_eq!(format!("{:07}", UpperExp::A(42.0)), "4.2E1");
                     assert_eq!(format!("{:07}", UpperExp::B { field: 43.0 }), "4.3E1");
-                    assert_ne!(format!("{:018}", Pointer::A(&7)).len(), 18);
-                    assert_ne!(format!("{:018}", Pointer::B { field: &42 }).len(), 18);
+                    let (a, b) = (7, 42);
+                    assert_eq!(format!("{:018}", Pointer::A(&a)), format!("{:0p}", &a));
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { field: &b }),
+                        format!("{:p}", &b),
+                    );
                 }
             }
         }
@@ -1276,10 +1301,14 @@ mod enums {
                         format!("{:07}", UpperExp::B { a: 43.0, b: 52.0 }),
                         "004.3E1",
                     );
-                    assert_eq!(format!("{:018}", Pointer::A(&7.0, &8.3)).len(), 18);
+                    let (a, b) = (8.3, 42.1);
                     assert_eq!(
-                        format!("{:018}", Pointer::B { a: &42.1, b: &43.3 }).len(),
-                        18,
+                        format!("{:018}", Pointer::A(&7.0, &a)),
+                        format!("{:018p}", &a),
+                    );
+                    assert_eq!(
+                        format!("{:018}", Pointer::B { a: &b, b: &43.3 }),
+                        format!("{:018p}", &b),
                     );
                 }
             }
@@ -2024,12 +2053,19 @@ mod generic {
                     format!("{:07E}", Enum::<i8, _>::B { field: 43.0 }),
                     "004.3E1",
                 );
-                assert_eq!(format!("{:018p}", Tuple(&42)).len(), 18);
-                assert_eq!(format!("{:018p}", Struct { field: &42 }).len(), 18);
-                assert_eq!(format!("{:018p}", Enum::<_, &i8>::A(&7)).len(), 18);
+                let (a, b) = (42, 7);
+                assert_eq!(format!("{:018p}", Tuple(&a)), format!("{:018p}", &a));
                 assert_eq!(
-                    format!("{:018p}", Enum::<&i8, _>::B { field: &42 }).len(),
-                    18,
+                    format!("{:018p}", Struct { field: &a }),
+                    format!("{:018p}", &a),
+                );
+                assert_eq!(
+                    format!("{:018p}", Enum::<_, &i8>::A(&b)),
+                    format!("{:018p}", &b),
+                );
+                assert_eq!(
+                    format!("{:018p}", Enum::<&i8, _>::B { field: &a }),
+                    format!("{:018p}", &a),
                 );
             }
         }
@@ -2245,12 +2281,19 @@ mod generic {
                     format!("{:07}", EnumUpperExp::<i8, _>::B { field: 43.0 }),
                     "004.3E1",
                 );
-                assert_eq!(format!("{:018}", TuplePointer(&42)).len(), 18);
-                assert_eq!(format!("{:018}", StructPointer { field: &42 }).len(), 18);
-                assert_eq!(format!("{:018}", EnumPointer::<_, &i8>::A(&7)).len(), 18);
+                let (a, b) = (42, 7);
+                assert_eq!(format!("{:018}", TuplePointer(&a)), format!("{:018p}", &a));
                 assert_eq!(
-                    format!("{:018}", EnumPointer::<&i8, _>::B { field: &42 }).len(),
-                    18,
+                    format!("{:018}", StructPointer { field: &a }),
+                    format!("{:018p}", &a),
+                );
+                assert_eq!(
+                    format!("{:018}", EnumPointer::<_, &i8>::A(&b)),
+                    format!("{:018p}", &b),
+                );
+                assert_eq!(
+                    format!("{:018}", EnumPointer::<&i8, _>::B { field: &a }),
+                    format!("{:018p}", &a),
                 );
             }
         }


### PR DESCRIPTION
Resolves #328
Requires #377
Requires #380 

## Synopsis

`Debug` and `Display` derives allow referring fields via short syntax (`_0` for unnamed fields and `name` for named fields):
```rust
#[derive(Display)]
#[display("{_0:o}")]
struct OctalInt(i32);
```
The way this works is by introducing a local binding in the macro expansion:
```rust
let _0 = &self.0;
```

This, however, introduces double pointer indirection. For most of the `fmt` traits, this is totally OK. However, the `fmt::Pointer` is sensitive to that:
```rust
#[derive(Display)]
#[display("--> {_0:p}")]
struct Int(&'static i32);

// expands to
impl fmt::Display for Int {
    fn fmt(&self, f: fmt::Formatter<'_>) -> fmt::Result {
        let _0 = &self.0; // has `&&i32` type, not `&i32`
        write!(f, "--> {_0:p}") // so, prints address of the `_0` local binding, 
                                // not the one of the `self.0` field as we would expect
    }
}
```


## Solution

Pass all local bindings also as named parameters and dereference them there.
This allows `"{_0:p}"` to work as expected. Positional arguments and expressions
still have the previous behaviour. This seems okay IMHO, as we can explain
that in expressions these local bindings are references and that you need
to dereference when needed, such as for `Pointer`.

A downside of the current implementation is that users cannot use the names of our named parameters as names for their own named parameters, because we already use them. With some additional code this is fixable, but it doesn't seem important enough to fix. People can simply use a different name when creating their own named parameters, which is a good idea anyway because it will be less confusing to any reader of the code. If it turns out to be important to support this after all, we can still start to support it in a backwards compatible way (because now it causes a compilation failure).

## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry][l:1] is added (if required)

[l:1]: /CHANGELOG.md
