### PR TITLE
Update documentation about Error in no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   should prevent code style linters from attempting to modify the generated
   code.
 - Upgrade to `syn` 2.0.
-- The `Error` derive now works in nightly `no_std` environments when enabling
-  `#![feature(error_in_core)]`.
+- The `Error` derive now works in nightly `no_std` environments
 
 ### Fixed
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -44,7 +44,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(nighthly)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(nightly)"] }
 
 [features]
 default = []

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -44,11 +44,9 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 
 ### What works in `no_std`?
 
-If you want to use the `Error` derive on `no_std` environments, then you need to
-compile with nightly and enable this feature:
-```ignore
-#![feature(error_in_core)]
-```
+If you want to use the `Error` derive on `no_std` environments, then
+you need to compile with nightly, or wait until Rust 1.81 when `Error`
+in `core` is expected to be stabilized.
 
 Backtraces don't work though, because the `Backtrace` type is only available in
 `std`.
@@ -59,9 +57,9 @@ Backtraces don't work though, because the `Backtrace` type is only available in
 ## Example usage
 
 ```rust
-# #![cfg_attr(nightly, feature(error_generic_member_access, error_in_core))]
-// Nightly requires enabling these features:
-// #![feature(error_generic_member_access, error_in_core)]
+# #![cfg_attr(nightly, feature(error_generic_member_access))]
+// Nightly requires enabling this feature:
+// #![feature(error_generic_member_access)]
 # #[cfg(not(nightly))] fn main() {}
 # #[cfg(nightly)] fn main() {
 # use core::error::{request_ref, request_value, Error as __};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@
     doc = include_str!("../README.md")
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(not(feature = "std"), feature = "error"), feature(error_in_core))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(any(not(docsrs), ci), deny(rustdoc::all))]
 #![forbid(non_ascii_idents, unsafe_code)]


### PR DESCRIPTION
The `error_in_core` feature is not necessary anymore when building, because the feature got [stabilized on nightly][1]. Now it's just a waiting game until it is on actual stable Rust. This updates the documentation accordingly, as well as adding some `no_std` tests for Error.

[1]: https://github.com/rust-lang/rust/pull/125951