### PR TITLE
Fix TryInto derive for generics

### DIFF
--- a/impl/src/try_into.rs
+++ b/impl/src/try_into.rs
@@ -104,7 +104,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
             impl #impl_generics derive_more::core::convert::TryFrom<
                 #reference_with_lifetime #input_type #ty_generics
             > for (#(#reference_with_lifetime #original_types),*) #where_clause {
-                type Error = derive_more::TryIntoError<#reference_with_lifetime #input_type>;
+                type Error = derive_more::TryIntoError<#reference_with_lifetime #input_type #ty_generics>;
 
                 #[inline]
                 fn try_from(

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -3,7 +3,7 @@
 
 use derive_more::{
     Add, AddAssign, Constructor, Deref, DerefMut, Display, Error, From, FromStr, Index,
-    IndexMut, IntoIterator, Mul, MulAssign, Not, Sum,
+    IndexMut, IntoIterator, Mul, MulAssign, Not, Sum, TryInto,
 };
 
 #[derive(
@@ -261,4 +261,12 @@ struct StructLifetimeGenericBoundsConstDefault<
     const X: usize = 42,
 > {
     inner: &'lt E,
+}
+
+#[derive(Debug, Display)]
+struct Wrapper<'a, const Y: usize, U>(&'a [U; Y]);
+
+#[derive(Debug, Display, TryInto)]
+enum Foo<'lt: 'static, T: Clone, const X: usize> {
+    X(Wrapper<'lt, X, T>),
 }

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -40,6 +40,13 @@ enum MixedInts {
     Unit2,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Wrapper<'a, const Y: usize, U>(&'a [U; Y]);
+
+enum Foo<'lt: 'static, T: Clone, const X: usize> {
+    X(Wrapper<'lt, X, T>),
+}
+
 #[test]
 fn test_try_into() {
     let mut i = MixedInts::SmallInt(42);


### PR DESCRIPTION
Part of #335

## Synopsis

Our `TryFrom` derive would fail when the type had any generics, this was a bug introduced with our changes for 1.0.

## Solution

This fixes that by correctly adding the generic parameters to the `Error` type of `TryFrom`.

## Checklist

- [x] Tests are added/updated (if required)
