### PR TITLE
Remove unused imports for no_std tests

### DIFF
--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -8,5 +8,5 @@ fi
 set -euxo pipefail
 
 for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
-    cargo +nightly test -p derive_more --tests --no-default-features --features "$feature$std,testing-helpers"
+    RUSTFLAGS='-D warnings' cargo +nightly test -p derive_more --tests --no-default-features --features "$feature$std,testing-helpers"
 done

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1918,7 +1918,7 @@ mod generic {
 // See: https://github.com/JelteF/derive_more/issues/301
 mod complex_enum_syntax {
     #[cfg(not(feature = "std"))]
-    use alloc::{boxed::Box, format};
+    use alloc::format;
 
     use derive_more::Debug;
 

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 
 use derive_more::DerefMut;
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -5,12 +5,7 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{format, string::ToString};
 
 use derive_more::{
     Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,


### PR DESCRIPTION
When running no_std tests I realised there were warnings. This removes all of
them and configures CI to complain when this happens next.
