### PR TITLE
Fix dead-code warning

### DIFF
--- a/tests/sum.rs
+++ b/tests/sum.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Sum;
 


### PR DESCRIPTION
Somehow this warning has started to show up on the master branch.
