### PR TITLE
Bump up MSRV to 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,6 @@ jobs:
 
       - run: cargo test --workspace --features full,testing-helpers
                         -- --skip compile_fail
-        env:
-          RUSTFLAGS: --cfg msrv
-          RUSTDOCFLAGS: --cfg msrv
 
   no_std:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.65.0"]
+        msrv: ["1.75.0"]
         os:
           - ubuntu
           - macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
-- The minimum supported Rust version (MSRV) is now Rust 1.65.
+- The minimum supported Rust version (MSRV) is now Rust 1.75.
 - Add the `std` feature which should be disabled in `no_std` environments.
 - All Cargo features, except `std`, are now disabled by default. The `full`
   feature can be used to get the old behavior of supporting all possible

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive_more"
 version = "1.0.0-beta.6"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.75.0"
 description = "Adds #[derive(x)] macros for more traits"
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(msrv)", "cfg(nightly)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(nightly)"] }
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Version](https://img.shields.io/crates/v/derive_more.svg)](https://crates.io/crates/derive_more)
 [![Rust Documentation](https://docs.rs/derive_more/badge.svg)](https://docs.rs/derive_more)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/JelteF/derive_more/master/LICENSE)
-[![Rust 1.65+](https://img.shields.io/badge/rustc-1.65+-lightgray.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
+[![Rust 1.75+](https://img.shields.io/badge/rustc-1.75+-lightgray.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
 [![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance)
 
 Rust has lots of builtin traits that are implemented for its basic types, such
@@ -215,7 +215,7 @@ extern crate derive_more;
 
 ## [MSRV] policy
 
-This library requires Rust 1.65 or higher.
+This library requires Rust 1.75 or higher.
 
 Changing [MSRV] (minimum supported Rust version) of this crate is treated as a **minor version change** in terms of [Semantic Versioning].
 - So, if [MSRV] changes are **NOT concerning** for your project, just use the default [caret requirement]:

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive_more-impl"
 version = "1.0.0-beta.6"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.75.0"
 description = "Internal implementation of `derive_more` crate"
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"

--- a/impl/doc/try_from.md
+++ b/impl/doc/try_from.md
@@ -12,9 +12,8 @@ The type can be changed with a `#[repr(u/i*)]` attribute, e.g., `#[repr(u8)]` or
 Only field-less variants can be constructed from their variant, therefore the `TryFrom` implementation will return an error for a discriminant representing a variant with fields.
 
 ```rust
-# #[cfg(msrv)] fn main() {} // TODO: Remove once MSRV bumps 1.66 or higher.
-# #[cfg(not(msrv))] fn main() {
 # use derive_more::TryFrom;
+#
 #[derive(TryFrom, Debug, PartialEq)]
 #[try_from(repr)]
 #[repr(u32)]
@@ -31,5 +30,4 @@ assert_eq!(Enum::EmptySeven{}, Enum::try_from(7).unwrap());
 
 // Variants with fields are not supported, as the value for their fields would be undefined.
 assert!(Enum::try_from(6).is_err());
-# }
 ```

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -250,12 +250,7 @@ impl<'a> Expansion<'a> {
     fn generate_body(&self) -> syn::Result<TokenStream> {
         if let Some(fmt) = &self.attr.fmt {
             return Ok(if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                let expr = if self
-                    .fields
-                    .fmt_args_idents()
-                    .into_iter()
-                    .any(|field| expr == field)
-                {
+                let expr = if self.fields.fmt_args_idents().any(|field| expr == field) {
                     quote! { #expr }
                 } else {
                     quote! { &(#expr) }

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -282,16 +282,13 @@ impl<'a> Expansion<'a> {
 
                         quote! { &derive_more::core::format_args!(#fmt, #(#deref_args),*) }
                     } else if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                        let expr = if self
-                            .fields
-                            .fmt_args_idents()
-                            .into_iter()
-                            .any(|field| expr == field)
-                        {
-                            quote! { #expr }
-                        } else {
-                            quote! { &(#expr) }
-                        };
+                        let expr =
+                            if self.fields.fmt_args_idents().any(|field| expr == field)
+                            {
+                                quote! { #expr }
+                            } else {
+                                quote! { &(#expr) }
+                            };
 
                         quote! {
                             derive_more::core::fmt::#trait_ident::fmt(#expr, __derive_more_f)

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -290,16 +290,13 @@ impl FmtAttribute {
             })
             .collect::<Vec<_>>();
 
-        fields
-            .fmt_args_idents()
-            .into_iter()
-            .filter_map(move |field_name| {
-                (used_args.iter().any(|arg| field_name == arg)
-                    && !self.args.iter().any(|arg| {
-                        arg.alias.as_ref().map_or(false, |(n, _)| n == &field_name)
-                    }))
-                .then(|| quote! { #field_name = *#field_name })
-            })
+        fields.fmt_args_idents().filter_map(move |field_name| {
+            (used_args.iter().any(|arg| field_name == arg)
+                && !self.args.iter().any(|arg| {
+                    arg.alias.as_ref().map_or(false, |(n, _)| n == &field_name)
+                }))
+            .then(|| quote! { #field_name = *#field_name })
+        })
     }
 
     /// Errors in case legacy syntax is encountered: `fmt = "...", (arg),*`.
@@ -674,17 +671,14 @@ trait FieldsExt {
     /// [`FmtAttribute`] as [`FmtArgument`]s or named [`Placeholder`]s.
     ///
     /// [`syn::Ident`]: struct@syn::Ident
-    // TODO: Return `impl Iterator<Item = syn::Ident> + '_` once MSRV is bumped up to 1.75 or
-    //       higher.
-    fn fmt_args_idents(&self) -> Vec<syn::Ident>;
+    fn fmt_args_idents(&self) -> impl Iterator<Item = syn::Ident> + '_;
 }
 
 impl FieldsExt for syn::Fields {
-    fn fmt_args_idents(&self) -> Vec<syn::Ident> {
+    fn fmt_args_idents(&self) -> impl Iterator<Item = syn::Ident> + '_ {
         self.iter()
             .enumerate()
             .map(|(i, f)| f.ident.clone().unwrap_or_else(|| format_ident!("_{i}")))
-            .collect()
     }
 }
 

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -56,7 +56,6 @@ fn enum_with_complex_repr() {
     assert!(Enum::try_from(-1).is_err());
 }
 
-#[cfg(not(msrv))] // TODO: Remove once MSRV bumps 1.66 or higher.
 #[test]
 fn test_discriminants_on_enum_with_fields() {
     #[derive(TryFrom, Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Resolves https://github.com/JelteF/derive_more/pull/381#discussion_r1698786709

## Synopsis

It has sense to bump MSRV to 1.75 for using RPITIT in implementations.

## Solution

- [x] Bump up MSRV to 1.75.
- [x] Switch to RPITIT in extension traits.
- [x] Remove `cfg(msrv)`. 

## Checklist

- [x] Documentation is updated
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
