### PR TITLE
Add compile_fail test for on purpose limited bounds

### DIFF
--- a/tests/compile_fail/debug/lifetime_no_debug.rs
+++ b/tests/compile_fail/debug/lifetime_no_debug.rs
@@ -1,0 +1,10 @@
+struct NoDebug<'a> {
+    a: &'a f64,
+}
+
+#[derive(derive_more::Debug)]
+struct SomeType<'a> {
+    no_debug: NoDebug<'a>,
+}
+
+fn main() {}

--- a/tests/compile_fail/debug/lifetime_no_debug.stderr
+++ b/tests/compile_fail/debug/lifetime_no_debug.stderr
@@ -1,0 +1,16 @@
+error[E0277]: `NoDebug<'_>` doesn't implement `Debug`
+ --> tests/compile_fail/debug/lifetime_no_debug.rs:5:10
+  |
+5 | #[derive(derive_more::Debug)]
+  |          ^^^^^^^^^^^^^^^^^^ `NoDebug<'_>` cannot be formatted using `{:?}`
+  |
+  = help: the trait `Debug` is not implemented for `NoDebug<'_>`, which is required by `&NoDebug<'_>: Debug`
+  = note: add `#[derive(Debug)]` to `NoDebug<'_>` or manually `impl Debug for NoDebug<'_>`
+  = note: required for `&NoDebug<'_>` to implement `Debug`
+  = note: required for the cast from `&&NoDebug<'_>` to `&dyn Debug`
+  = note: this error originates in the derive macro `derive_more::Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NoDebug<'_>` with `#[derive(Debug)]`
+  |
+1 + #[derive(Debug)]
+2 | struct NoDebug<'a> {
+  |


### PR DESCRIPTION
Resolves #392
Related to #371

## Synopsis

Before #371 this code would compile without any issues, but that would actually
hide the problem that the resulting `Debug` implementation was never
applicable, because the bounds could not be satisfied.

## Solution

This problem was already solved by #371, but this adds a test case to ensure
that we don't regress here again.

## Checklist

- [x] Tests are added/updated (if required)
