### PR TITLE
Fix transparency and behavior of shared attribute formatting on enums (#377, #411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ambiguous associated item error when deriving `TryFrom`, `TryInto` or `FromStr`
   with an associated item called `Error` or `Err` respectively.
   ([#410](https://github.com/JelteF/derive_more/pull/410))
-- A top level `#[display("...")]` attribute on an enum being incorrectly
-  treated as transparent.
+- Top level `#[display("...")]` attribute on an enum being incorrectly treated
+  as transparent or wrapping.
   ([#395](https://github.com/JelteF/derive_more/pull/395))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.0.1 - Unreleased
 
+### Fixed
+
+- A top level `#[display("...")]` attribute on an enum being incorrectly
+  treated as transparent.
+  ([#395](https://github.com/JelteF/derive_more/pull/395))
 
 
 ## 1.0.0 - 2024-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `use derive_more::SomeTrait` now imports macro only. Importing macro with
   its trait along is possible now via `use derive_more::with_trait::SomeTrait`.
   ([#406](https://github.com/JelteF/derive_more/pull/406))
+- Top-level `#[display("...")]` attribute on an enum now has defaulting behavior
+  instead of replacing when no wrapping is possible (no `_variant` placeholder).
+  ([#395](https://github.com/JelteF/derive_more/pull/395))
 
 ### Fixed
 
@@ -24,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ambiguous associated item error when deriving `TryFrom`, `TryInto` or `FromStr`
   with an associated item called `Error` or `Err` respectively.
   ([#410](https://github.com/JelteF/derive_more/pull/410))
-- Top level `#[display("...")]` attribute on an enum being incorrectly treated
+- Top-level `#[display("...")]` attribute on an enum being incorrectly treated
   as transparent or wrapping.
   ([#395](https://github.com/JelteF/derive_more/pull/395))
 

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -214,13 +214,13 @@ then it acts as the default one for the variants without its own format.
 enum Enum {
     #[display("A {_0}")]
     A(i32),
-    B { field: i32 },
+    B(u32),
     #[display("c")]
     C,
 }
 
 assert_eq!(Enum::A(1).to_string(), "A 1");
-assert_eq!(Enum::B { field: 2 }.to_string(), "Variant: 2 & 2");
+assert_eq!(Enum::B(2).to_string(), "Variant: 2 & 2");
 assert_eq!(Enum::C.to_string(), "c");
 ```
 

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -45,12 +45,6 @@ let a = &123;
 assert_eq!(format!("{}", RefInt{field: &a}), format!("{a:p} {:p}", a));
 ```
 
-For enums you can also specify a shared format on the enum itself instead of
-the variant. This format is used for each of the variants, and can be
-customized per variant by including the special `{_variant}` placeholder in
-this shared format, which is then replaced by the format string that's provided
-on the variant.
-
 
 ### Other formatting traits
 
@@ -177,6 +171,57 @@ struct MyOctalInt(i32);
 
 // and so, additional formatting parameters have no effect
 assert_eq!(format!("{:07}", MyOctalInt(9)), "11");
+```
+
+
+### Shared enum format
+
+Enums can have shared top-level `#[display("...", args...)]` attribute. Depending on its contents,
+it can act either as a default format or a wrapping one.
+
+#### Wrapping enum format
+
+To act as a wrapping format, the shared top-level `#[display("...", args...)]` attribute should
+contain at least one special `{_variant}` placeholder, which is then replaced by the format string
+that's provided (or inferred) on the variant.
+```rust
+# use derive_more::Display;
+#
+#[derive(Display)]
+#[display("Variant: {_variant} & {}", _variant)]
+enum Enum {
+    #[display("A {_0}")]
+    A(i32),
+    B { field: i32 },
+    #[display("c")]
+    C,
+}
+
+assert_eq!(Enum::A(1).to_string(), "Variant: A 1 & A 1");
+assert_eq!(Enum::B { field: 2 }.to_string(), "Variant: 2 & 2");
+assert_eq!(Enum::C.to_string(), "Variant: c & c");
+```
+
+#### Default enum format
+
+If the shared top-level `#[display("...", args...)]` attribute contains no `{_variant}` placeholders,
+then it acts as the default one for the variants without its own format.
+```rust
+# use derive_more::Display;
+#
+#[derive(Display)]
+#[display("Variant: {_0} & {}", _0)] // fields can be used too!
+enum Enum {
+    #[display("A {_0}")]
+    A(i32),
+    B { field: i32 },
+    #[display("c")]
+    C,
+}
+
+assert_eq!(Enum::A(1).to_string(), "A 1");
+assert_eq!(Enum::B { field: 2 }.to_string(), "Variant: 2 & 2");
+assert_eq!(Enum::C.to_string(), "c");
 ```
 
 

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -266,9 +266,13 @@ impl<'a> Expansion<'a> {
         let mut body = TokenStream::new();
 
         // If `shared_attr` is a transparent call, then we consider it being absent.
-        let has_shared_attr = self
-            .shared_attr
-            .map_or(false, |a| a.transparent_call().is_none());
+        //let has_shared_attr = self
+        //    .shared_attr
+        //    .map_or(false, |a| a.transparent_call().is_none());
+        let has_shared_attr = self.shared_attr.map_or(false, |a| {
+            a.transparent_call()
+                .map_or(true, |(_, called_trait)| &called_trait != self.trait_ident)
+        });
 
         if !has_shared_attr
             || self

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1518,7 +1518,7 @@ mod enums {
                 fn assert() {
                     assert_eq!(Enum::<NoDisplay, u8>::A(1).to_string(), "A");
                     assert_eq!(Enum::<NoDisplay, u8>::B("abc").to_string(), "B");
-                    assert_eq!(Enum::<NoDisplay, u8>::C(9).to_string(), "C");
+                    assert_eq!(Enum::<NoDisplay, u8>::C(NoDisplay).to_string(), "C");
                     assert_eq!(Enum::<NoDisplay, u8>::D(9).to_string(), "9");
                 }
             }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1467,6 +1467,29 @@ mod enums {
                 }
             }
 
+            mod as_debug {
+                use super::*;
+
+                #[derive(Debug, Display)]
+                #[display("{self:?}")]
+                enum Enum {
+                    #[display("A {_0}")]
+                    A(i32),
+                    #[display("B {}", field)]
+                    B {
+                        field: i32,
+                    },
+                    C,
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(Enum::A(1).to_string(), "A(1)");
+                    assert_eq!(Enum::B { field: 2 }.to_string(), "B { field: 2 }");
+                    assert_eq!(Enum::C.to_string(), "C");
+                }
+            }
+
             mod pointer {
                 use super::*;
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1470,10 +1470,10 @@ mod enums {
 
                 #[test]
                 fn assert() {
-                    assert_eq!(Enum::<NoDisplay>::A(1).to_string(), "Variant");
+                    assert_eq!(Enum::<NoDisplay>::A(1).to_string(), "A 1");
                     assert_eq!(
                         Enum::<NoDisplay>::B { field: 2 }.to_string(),
-                        "Variant",
+                        "B 2",
                     );
                     assert_eq!(Enum::<NoDisplay>::C.to_string(), "Variant");
                     assert_eq!(Enum::<NoDisplay>::D(NoDisplay).to_string(), "Variant");
@@ -1511,13 +1511,15 @@ mod enums {
                     B(&'static str),
                     #[display("C")]
                     C(T),
+                    D(T),
                 }
 
                 #[test]
                 fn assert() {
-                    assert_eq!(Enum::<u8>::A(1).to_string(), "1");
-                    assert_eq!(Enum::<u8>::B("abc").to_string(), "abc");
-                    assert_eq!(Enum::<u8>::C(9).to_string(), "9");
+                    assert_eq!(Enum::<u8>::A(1).to_string(), "A");
+                    assert_eq!(Enum::<u8>::B("abc").to_string(), "B");
+                    assert_eq!(Enum::<u8>::C(9).to_string(), "C");
+                    assert_eq!(Enum::<u8>::D(9).to_string(), "9");
                 }
             }
 
@@ -1533,6 +1535,7 @@ mod enums {
                     B(&'static str),
                     #[display("C")]
                     C(T),
+                    D(T),
                 }
 
                 #[test]
@@ -1540,6 +1543,7 @@ mod enums {
                     assert_eq!(Enum::<u8>::A(1).to_string(), "Variant A 1");
                     assert_eq!(Enum::<u8>::B("abc").to_string(), "Variant B abc");
                     assert_eq!(Enum::<u8>::C(9).to_string(), "Variant C 9");
+                    assert_eq!(Enum::<u8>::D(9).to_string(), "Variant 9 9");
                 }
             }
 
@@ -1556,13 +1560,17 @@ mod enums {
                         field: i32,
                     },
                     C,
+                    D {
+                        field: i32,
+                    },
                 }
 
                 #[test]
                 fn assert() {
-                    assert_eq!(Enum::A(1).to_string(), "A(1)");
-                    assert_eq!(Enum::B { field: 2 }.to_string(), "B { field: 2 }");
+                    assert_eq!(Enum::A(1).to_string(), "A 1");
+                    assert_eq!(Enum::B { field: 2 }.to_string(), "B 2");
                     assert_eq!(Enum::C.to_string(), "C");
+                    assert_eq!(Enum::D { field: 4 }.to_string(), "D { field: 4 }");
                 }
             }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1384,6 +1384,8 @@ mod enums {
                         field: i32,
                     },
                     C,
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
                 }
 
                 #[test]
@@ -1391,6 +1393,7 @@ mod enums {
                     assert_eq!(Enum::A(1).to_string(), "Variant: A 1");
                     assert_eq!(Enum::B { field: 2 }.to_string(), "Variant: B 2");
                     assert_eq!(Enum::C.to_string(), "Variant: C");
+                    assert_eq!(Enum::D(1, 2).to_string(), "Variant: D 1 2");
                 }
             }
 
@@ -1407,6 +1410,8 @@ mod enums {
                         field: i32,
                     },
                     C,
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
                     #[display("{_0:b}")]
                     TransparentBinary(i32),
                 }
@@ -1416,6 +1421,7 @@ mod enums {
                     assert_eq!(Enum::A(1).to_string(), "A 1");
                     assert_eq!(Enum::B { field: 2 }.to_string(), "B 2");
                     assert_eq!(Enum::C.to_string(), "C");
+                    assert_eq!(Enum::D(1, 2).to_string(), "D 1 2");
                     assert_eq!(
                         format!("{:08}", Enum::TransparentBinary(4)),
                         "00000100",
@@ -1436,6 +1442,8 @@ mod enums {
                         field: i32,
                     },
                     C,
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
                 }
 
                 #[test]
@@ -1446,6 +1454,7 @@ mod enums {
                         "B 2 Variant: B 2 B 2",
                     );
                     assert_eq!(Enum::C.to_string(), "C Variant: C C");
+                    assert_eq!(Enum::D(1, 2).to_string(), "D 1 2 Variant: D 1 2 D 1 2",);
                 }
             }
 
@@ -1465,7 +1474,13 @@ mod enums {
                         field: i32,
                     },
                     C,
-                    D(T),
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
+                    E {
+                        a: u8,
+                        b: i8,
+                    },
+                    X(T),
                 }
 
                 #[test]
@@ -1473,7 +1488,12 @@ mod enums {
                     assert_eq!(Enum::<NoDisplay>::A(1).to_string(), "A 1");
                     assert_eq!(Enum::<NoDisplay>::B { field: 2 }.to_string(), "B 2",);
                     assert_eq!(Enum::<NoDisplay>::C.to_string(), "Variant");
-                    assert_eq!(Enum::<NoDisplay>::D(NoDisplay).to_string(), "Variant");
+                    assert_eq!(Enum::<NoDisplay>::D(1, 2).to_string(), "D 1 2");
+                    assert_eq!(
+                        Enum::<NoDisplay>::E { a: 2, b: 1 }.to_string(),
+                        "Variant"
+                    );
+                    assert_eq!(Enum::<NoDisplay>::X(NoDisplay).to_string(), "Variant");
                 }
             }
 
@@ -1485,14 +1505,19 @@ mod enums {
                 enum Enum<T> {
                     A(i32),
                     B(&'static str),
-                    C(T),
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
+                    E(u8, i8),
+                    X(T),
                 }
 
                 #[test]
                 fn assert() {
                     assert_eq!(Enum::<u8>::A(1).to_string(), "Variant 1");
                     assert_eq!(Enum::<u8>::B("abc").to_string(), "Variant abc");
-                    assert_eq!(Enum::<u8>::C(9).to_string(), "Variant 9");
+                    assert_eq!(Enum::<u8>::D(1, 2).to_string(), "D 1 2");
+                    assert_eq!(Enum::<u8>::E(2, 1).to_string(), "Variant 2");
+                    assert_eq!(Enum::<u8>::X(9).to_string(), "Variant 9");
                 }
             }
 
@@ -1504,22 +1529,59 @@ mod enums {
 
                 #[derive(Display)]
                 #[display("{_0}")]
-                enum Enum<C, D> {
+                enum Enum<X, Y> {
                     #[display("A")]
                     A(i32),
                     #[display("B")]
                     B(&'static str),
-                    #[display("C")]
-                    C(C),
-                    D(D),
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
+                    E(u8, i8),
+                    #[display("X")]
+                    X(X),
+                    Y(Y),
                 }
 
                 #[test]
                 fn assert() {
                     assert_eq!(Enum::<NoDisplay, u8>::A(1).to_string(), "A");
                     assert_eq!(Enum::<NoDisplay, u8>::B("abc").to_string(), "B");
-                    assert_eq!(Enum::<NoDisplay, u8>::C(NoDisplay).to_string(), "C");
-                    assert_eq!(Enum::<NoDisplay, u8>::D(9).to_string(), "9");
+                    assert_eq!(Enum::<NoDisplay, u8>::D(1, 2).to_string(), "D 1 2");
+                    assert_eq!(Enum::<NoDisplay, u8>::E(2, 1).to_string(), "2");
+                    assert_eq!(Enum::<NoDisplay, u8>::X(NoDisplay).to_string(), "X");
+                    assert_eq!(Enum::<NoDisplay, u8>::Y(9).to_string(), "9");
+                }
+            }
+
+            mod only_multiple_field {
+                use super::*;
+
+                /// Make sure that top-level-specific bounds are not added if a field is not used.
+                struct NoDisplay;
+
+                #[derive(Display)]
+                #[display("{_0} & {_1}")]
+                enum Enum<X, Y> {
+                    #[display("A")]
+                    A(i32),
+                    #[display("B")]
+                    B(&'static str),
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
+                    E(u8, i8),
+                    #[display("X")]
+                    X(X),
+                    Y(Y, i8),
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(Enum::<NoDisplay, u8>::A(1).to_string(), "A");
+                    assert_eq!(Enum::<NoDisplay, u8>::B("abc").to_string(), "B");
+                    assert_eq!(Enum::<NoDisplay, u8>::D(1, 2).to_string(), "D 1 2");
+                    assert_eq!(Enum::<NoDisplay, u8>::E(2, 1).to_string(), "2 & 1");
+                    assert_eq!(Enum::<NoDisplay, u8>::X(NoDisplay).to_string(), "X");
+                    assert_eq!(Enum::<NoDisplay, u8>::Y(9, 10).to_string(), "9 & 10");
                 }
             }
 
@@ -1533,17 +1595,20 @@ mod enums {
                     A(i32),
                     #[display("B")]
                     B(&'static str),
-                    #[display("C")]
-                    C(T),
-                    D(T),
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
+                    #[display("X")]
+                    X(T),
+                    Y(T),
                 }
 
                 #[test]
                 fn assert() {
                     assert_eq!(Enum::<u8>::A(1).to_string(), "Variant A 1");
                     assert_eq!(Enum::<u8>::B("abc").to_string(), "Variant B abc");
-                    assert_eq!(Enum::<u8>::C(9).to_string(), "Variant C 9");
-                    assert_eq!(Enum::<u8>::D(9).to_string(), "Variant 9 9");
+                    assert_eq!(Enum::<u8>::D(1, 2).to_string(), "Variant D 1 2 1");
+                    assert_eq!(Enum::<u8>::X(9).to_string(), "Variant X 9");
+                    assert_eq!(Enum::<u8>::Y(9).to_string(), "Variant 9 9");
                 }
             }
 
@@ -1560,8 +1625,11 @@ mod enums {
                         field: i32,
                     },
                     C,
-                    D {
-                        field: i32,
+                    #[display("D {_0} {}", _1)]
+                    D(i8, u8),
+                    E {
+                        a: u8,
+                        b: i8,
                     },
                 }
 
@@ -1570,7 +1638,8 @@ mod enums {
                     assert_eq!(Enum::A(1).to_string(), "A 1");
                     assert_eq!(Enum::B { field: 2 }.to_string(), "B 2");
                     assert_eq!(Enum::C.to_string(), "C");
-                    assert_eq!(Enum::D { field: 4 }.to_string(), "D { field: 4 }");
+                    assert_eq!(Enum::D(1, 2).to_string(), "D 1 2");
+                    assert_eq!(Enum::E { a: 2, b: 1 }.to_string(), "E { a: 2, b: 1 }");
                 }
             }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1471,10 +1471,7 @@ mod enums {
                 #[test]
                 fn assert() {
                     assert_eq!(Enum::<NoDisplay>::A(1).to_string(), "A 1");
-                    assert_eq!(
-                        Enum::<NoDisplay>::B { field: 2 }.to_string(),
-                        "B 2",
-                    );
+                    assert_eq!(Enum::<NoDisplay>::B { field: 2 }.to_string(), "B 2",);
                     assert_eq!(Enum::<NoDisplay>::C.to_string(), "Variant");
                     assert_eq!(Enum::<NoDisplay>::D(NoDisplay).to_string(), "Variant");
                 }
@@ -1502,24 +1499,27 @@ mod enums {
             mod only_field {
                 use super::*;
 
+                /// Make sure that top-level-specific bounds are not added if a field is not used.
+                struct NoDisplay;
+
                 #[derive(Display)]
                 #[display("{_0}")]
-                enum Enum<T> {
+                enum Enum<C, D> {
                     #[display("A")]
                     A(i32),
                     #[display("B")]
                     B(&'static str),
                     #[display("C")]
-                    C(T),
-                    D(T),
+                    C(C),
+                    D(D),
                 }
 
                 #[test]
                 fn assert() {
-                    assert_eq!(Enum::<u8>::A(1).to_string(), "A");
-                    assert_eq!(Enum::<u8>::B("abc").to_string(), "B");
-                    assert_eq!(Enum::<u8>::C(9).to_string(), "C");
-                    assert_eq!(Enum::<u8>::D(9).to_string(), "9");
+                    assert_eq!(Enum::<NoDisplay, u8>::A(1).to_string(), "A");
+                    assert_eq!(Enum::<NoDisplay, u8>::B("abc").to_string(), "B");
+                    assert_eq!(Enum::<NoDisplay, u8>::C(9).to_string(), "C");
+                    assert_eq!(Enum::<NoDisplay, u8>::D(9).to_string(), "9");
                 }
             }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1445,6 +1445,28 @@ mod enums {
                 }
             }
 
+            mod only_field {
+                use super::*;
+
+                #[derive(Display)]
+                #[display("{_0}")]
+                enum Enum<T> {
+                    #[display("A")]
+                    A(i32),
+                    #[display("B")]
+                    B(&'static str),
+                    #[display("C")]
+                    C(T),
+                }
+
+                #[test]
+                fn assert() {
+                    assert_eq!(Enum::<u8>::A(1).to_string(), "1");
+                    assert_eq!(Enum::<u8>::B("abc").to_string(), "abc");
+                    assert_eq!(Enum::<u8>::C(9).to_string(), "9");
+                }
+            }
+
             mod use_field_and_variant {
                 use super::*;
 


### PR DESCRIPTION
Follows #377  
Resolves #411

## Synopsis

At the moment, the following example:
```rust
#[derive(Debug, Display)]
#[display("{self:?}")]
enum Enum {
    #[display("A {_0}")]
    A(i32),
    #[display("B {}", field)]
    B { field: i32 },
    C,
}
```
expand incorrectly as:
```rust
#[automatically_derived]
impl derive_more::Display for Enum {
    fn fmt(&self, __derive_more_f: &mut derive_more::core::fmt::Formatter<'_>) -> derive_more::core::fmt::Result {
        match self {
            Self::A(_0) => { derive_more::core::write!(__derive_more_f, "A {_0}", _0 = *_0) }
            Self::B {
                field
            } => { derive_more::core::write!(__derive_more_f, "B {}", field, ) }
            Self::C => { __derive_more_f.write_str("C") }
        } 
    } 
}
```

This is because transparency check of the shared `#[display(...)]` formatting attribute doesn't consider the actual trait, called transparently, in correspondence with the implemented trait.

## Solution

Instead of
```rust
let has_shared_attr = self
    .shared_attr
    .map_or(false, |a| a.transparent_call().is_none());
```
do this
```rust
let has_shared_attr = self.shared_attr.map_or(false, |a| {
    a.transparent_call()
        .map_or(true, |(_, called_trait)| &called_trait != self.trait_ident)
});
```

## Additionally

As discussed [below](https://github.com/JelteF/derive_more/pull/395#discussion_r1722920866), the original replacing behavior of a shared attribute (when it has no `{_variant}` placeholder) is deadly wrong, that's why this PR also changes it to acts as default one.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
