### PR TITLE
Consider associated types of type parameters for implied bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.0.1 - Unreleased
 
+### Fixed
+
+- Associated types of type parameters not being treated as generics in `Debug`
+  and `Display` expansions.
+  ([#399](https://github.com/JelteF/derive_more/pull/399))
 
 
 ## 1.0.0 - 2024-08-07

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -632,8 +632,12 @@ impl ContainsGenericsExt for syn::Path {
         }
         self.segments
             .iter()
-            .any(|segment| match &segment.arguments {
-                syn::PathArguments::None => type_params.contains(&&segment.ident),
+            .enumerate()
+            .any(|(n, segment)| match &segment.arguments {
+                syn::PathArguments::None => {
+                    // `TypeParam::AssocType` case.
+                    (n == 0) && type_params.contains(&&segment.ident)
+                }
                 syn::PathArguments::AngleBracketed(
                     syn::AngleBracketedGenericArguments { args, .. },
                 ) => args.iter().any(|generic| match generic {

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -633,7 +633,7 @@ impl ContainsGenericsExt for syn::Path {
         self.segments
             .iter()
             .any(|segment| match &segment.arguments {
-                syn::PathArguments::None => false,
+                syn::PathArguments::None => type_params.contains(&&segment.ident),
                 syn::PathArguments::AngleBracketed(
                     syn::AngleBracketedGenericArguments { args, .. },
                 ) => args.iter().any(|generic| match generic {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -2018,7 +2018,9 @@ mod complex_enum_syntax {
 mod type_variables {
     mod our_alloc {
         #[cfg(not(feature = "std"))]
-        pub use alloc::{boxed::Box, format, iter, vec, vec::Vec};
+        pub use alloc::{boxed::Box, format, vec, vec::Vec};
+        #[cfg(not(feature = "std"))]
+        pub use core::iter;
         #[cfg(feature = "std")]
         pub use std::{boxed::Box, format, iter, vec, vec::Vec};
     }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -2023,7 +2023,7 @@ mod type_variables {
         pub use std::{boxed::Box, format, iter, vec, vec::Vec};
     }
 
-    use our_alloc::{format, vec, Box, Vec};
+    use our_alloc::{format, iter, vec, Box, Vec};
 
     use derive_more::Debug;
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -2116,6 +2116,19 @@ mod type_variables {
         elem: Option<I::Item>,
     }
 
+    #[derive(derive_more::Debug)]
+    struct CollidedPathName<Item> {
+        item: Item,
+        elem: Option<some_path::Item>,
+    }
+
+    mod some_path {
+        use super::Debug;
+
+        #[derive(Debug)]
+        pub struct Item;
+    }
+
     #[test]
     fn assert() {
         assert_eq!(
@@ -2165,6 +2178,17 @@ mod type_variables {
                 },
             ),
             "AssocType { iter: Empty, elem: None }",
+        );
+
+        assert_eq!(
+            format!(
+                "{:?}",
+                CollidedPathName {
+                    item: true,
+                    elem: None,
+                },
+            ),
+            "CollidedPathName { item: true, elem: None }",
         );
     }
 }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -2023,6 +2023,7 @@ mod type_variables {
         pub use std::{boxed::Box, format, vec, vec::Vec};
     }
 
+    use core::iter;
     use our_alloc::{format, vec, Box, Vec};
 
     use derive_more::Debug;
@@ -2110,6 +2111,12 @@ mod type_variables {
         t: Box<dyn MyTrait<T>>,
     }
 
+    #[derive(Debug)]
+    struct AssocType<I: Iterator> {
+        iter: I,
+        elem: Option<I::Item>,
+    }
+
     #[test]
     fn assert() {
         assert_eq!(
@@ -2148,6 +2155,17 @@ mod type_variables {
         assert_eq!(
             format!("{item:?}"),
             "Node { children: [Node { children: [], inner: 0 }, Leaf { inner: 1 }], inner: 2 }",
-        )
+        );
+
+        assert_eq!(
+            format!(
+                "{:?}",
+                AssocType {
+                    iter: iter::empty::<bool>(),
+                    elem: None,
+                },
+            ),
+            "AssocType { iter: Empty, elem: None }",
+        );
     }
 }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -2018,12 +2018,11 @@ mod complex_enum_syntax {
 mod type_variables {
     mod our_alloc {
         #[cfg(not(feature = "std"))]
-        pub use alloc::{boxed::Box, format, vec, vec::Vec};
+        pub use alloc::{boxed::Box, format, iter, vec, vec::Vec};
         #[cfg(feature = "std")]
-        pub use std::{boxed::Box, format, vec, vec::Vec};
+        pub use std::{boxed::Box, format, iter, vec, vec::Vec};
     }
 
-    use core::iter;
     use our_alloc::{format, vec, Box, Vec};
 
     use derive_more::Debug;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2584,20 +2584,24 @@ mod type_variables {
         );
 
         assert_eq!(
-            AssocType {
-                iter: iter::empty::<bool>(),
-                elem: None,
-            }
-            .to_string(),
+            format!(
+                "{}",
+                AssocType {
+                    iter: iter::empty::<bool>(),
+                    elem: None,
+                },
+            ),
             "Empty with None",
         );
 
         assert_eq!(
-            CollidedPathName {
-                item: false,
-                elem: Some(some_path::Item),
-            }
-            .to_string(),
+            format!(
+                "{}",
+                CollidedPathName {
+                    item: false,
+                    elem: Some(some_path::Item),
+                },
+            ),
             "false with Some(Item)",
         );
     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2519,6 +2519,18 @@ mod type_variables {
         elem: Option<I::Item>,
     }
 
+    #[derive(Display)]
+    #[display("{item:?} with {elem:?}")]
+    struct CollidedPathName<Item> {
+        item: Item,
+        elem: Option<some_path::Item>,
+    }
+
+    mod some_path {
+        #[derive(Debug)]
+        pub struct Item;
+    }
+
     #[test]
     fn assert() {
         assert_eq!(
@@ -2576,6 +2588,15 @@ mod type_variables {
             }
             .to_string(),
             "Empty with None",
+        );
+
+        assert_eq!(
+            CollidedPathName {
+                item: false,
+                elem: Some(some_path::Item),
+            }
+            .to_string(),
+            "false with Some(Item)",
         );
     }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2387,12 +2387,12 @@ mod generic {
 mod type_variables {
     mod our_alloc {
         #[cfg(not(feature = "std"))]
-        pub use alloc::{boxed::Box, format, vec::Vec};
+        pub use alloc::{boxed::Box, format, iter, vec::Vec};
         #[cfg(feature = "std")]
-        pub use std::{boxed::Box, format, vec::Vec};
+        pub use std::{boxed::Box, format, iter, vec::Vec};
     }
 
-    use our_alloc::{format, Box};
+    use our_alloc::{format, iter, Box};
 
     // We want `Vec` in scope to test that code generation works if it is there.
     #[allow(unused_imports)]
@@ -2512,6 +2512,13 @@ mod type_variables {
         t: Box<dyn MyTrait<T>>,
     }
 
+    #[derive(Display)]
+    #[display("{iter:?} with {elem:?}")]
+    struct AssocType<I: Iterator> {
+        iter: I,
+        elem: Option<I::Item>,
+    }
+
     #[test]
     fn assert() {
         assert_eq!(
@@ -2560,6 +2567,15 @@ mod type_variables {
         assert_eq!(
             format!("{item}"),
             "Some(Variant2 { next: OptionalBox { inner: None } })",
-        )
+        );
+
+        assert_eq!(
+            AssocType {
+                iter: iter::empty::<bool>(),
+                elem: None,
+            }
+            .to_string(),
+            "Empty with None",
+        );
     }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2387,7 +2387,9 @@ mod generic {
 mod type_variables {
     mod our_alloc {
         #[cfg(not(feature = "std"))]
-        pub use alloc::{boxed::Box, format, iter, vec::Vec};
+        pub use alloc::{boxed::Box, format, vec::Vec};
+        #[cfg(not(feature = "std"))]
+        pub use core::iter;
         #[cfg(feature = "std")]
         pub use std::{boxed::Box, format, iter, vec::Vec};
     }


### PR DESCRIPTION
Related to #387

## Synopsis

After #387, the following snippet fails to compile:
```rust
#[derive(Debug)]
struct AssocType<I: Iterator> {
    iter: I,
    elem: Option<I::Item>,
}
```
This happens, because the implied bound `Option<I::Item>: Debug` is not generated.

## Solution

Correct the `ContainsGenericsExt::contains_generics()` implementations to consider associated types of the type parameter.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
