### PR TITLE
Add `#[allow(unreachable_code)]` to generated impls for `!` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Associated types of type parameters not being treated as generics in `Debug`
   and `Display` expansions.
   ([#399](https://github.com/JelteF/derive_more/pull/399))
+- `unreachable_code` warnings on generated code when `!` (never type) is used.
+  ([#404](https://github.com/JelteF/derive_more/pull/404))
 
 
 ## 1.0.0 - 2024-08-07

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -280,6 +280,7 @@ impl<'a> ToTokens for Expansion<'a> {
             };
 
             quote! {
+                #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
                 #[automatically_derived]
                 impl #impl_gens #trait_ty for #ty_ident #ty_gens #where_clause {
                     #[inline]

--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -26,6 +26,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
     let original_types = &get_field_types(&fields);
     quote! {
         #[allow(missing_docs)]
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
             #[inline]

--- a/impl/src/deref.rs
+++ b/impl/src/deref.rs
@@ -42,6 +42,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             type Target = #target;

--- a/impl/src/deref_mut.rs
+++ b/impl/src/deref_mut.rs
@@ -33,6 +33,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -60,6 +60,7 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
     };
 
     Ok(quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_gens derive_more::Debug for #ident #ty_gens #where_clause {
             #[inline]

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -62,6 +62,7 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
     };
 
     Ok(quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_gens derive_more::#trait_ident for #ident #ty_gens #where_clause {
             fn fmt(

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -224,9 +224,10 @@ impl<'a> Expansion<'a> {
                 let generics = {
                     let mut generics = self.generics.clone();
                     for (ty, ident) in field_tys.iter().zip(&gen_idents) {
-                        generics.make_where_clause().predicates.push(
-                            parse_quote! { #ty: derive_more::From<#ident> },
-                        );
+                        generics
+                            .make_where_clause()
+                            .predicates
+                            .push(parse_quote! { #ty: derive_more::From<#ident> });
                         generics
                             .params
                             .push(syn::TypeParam::from(ident.clone()).into());

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -172,6 +172,7 @@ impl<'a> Expansion<'a> {
                     });
 
                     Ok(quote! {
+                        #[allow(unreachable_code)] // omit warnings for `!` and unreachable types
                         #[automatically_derived]
                         impl #impl_gens derive_more::From<#ty> for #ident #ty_gens #where_clause {
                             #[inline]
@@ -192,6 +193,7 @@ impl<'a> Expansion<'a> {
                 });
 
                 Ok(quote! {
+                    #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
                     #[automatically_derived]
                     impl #impl_gens derive_more::From<(#( #field_tys ),*)> for #ident #ty_gens #where_clause {
                         #[inline]
@@ -234,6 +236,7 @@ impl<'a> Expansion<'a> {
                 let (impl_gens, _, where_clause) = generics.split_for_impl();
 
                 Ok(quote! {
+                    #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
                     #[automatically_derived]
                     impl #impl_gens derive_more::From<(#( #gen_idents ),*)> for #ident #ty_gens #where_clause {
                         #[inline]

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -53,6 +53,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -35,6 +35,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     };
 
     quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
             type Output = #output_type;

--- a/impl/src/try_unwrap.rs
+++ b/impl/src/try_unwrap.rs
@@ -123,6 +123,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/unwrap.rs
+++ b/impl/src/unwrap.rs
@@ -118,6 +118,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(clippy::unnecessary_mut_passed)] // testing correct signatures rather than actual code
 #![allow(dead_code)] // some code is tested for type checking only
 
@@ -422,6 +423,14 @@ mod single_field {
 
                 assert!(ptr::eq(item.as_mut(), item.0.as_mut()));
             }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsMut)]
+            struct Nothing(!);
         }
     }
 
@@ -881,6 +890,16 @@ mod single_field {
                 assert!(ptr::eq(item.as_mut(), item.first.as_mut()));
             }
         }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsMut)]
+            struct Nothing {
+                first: !,
+            }
+        }
     }
 }
 
@@ -1070,6 +1089,14 @@ mod multi_field {
 
                 assert!(ptr::eq(item.as_mut(), item.0.as_mut()));
             }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsMut)]
+            struct Nothing(String, !);
         }
     }
 
@@ -1344,6 +1371,17 @@ mod multi_field {
                 };
 
                 assert!(ptr::eq(item.as_mut(), item.first.as_mut()));
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsMut)]
+            struct Nothing {
+                first: !,
+                second: i32,
             }
         }
     }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -415,6 +416,14 @@ mod single_field {
 
                 assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
             }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsRef)]
+            struct Nothing(!);
         }
     }
 
@@ -874,6 +883,16 @@ mod single_field {
                 assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
             }
         }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsRef)]
+            struct Nothing {
+                first: !,
+            }
+        }
     }
 }
 
@@ -1063,6 +1082,14 @@ mod multi_field {
 
                 assert!(ptr::eq(item.as_ref(), item.0.as_ref()));
             }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsRef)]
+            struct Nothing(String, !);
         }
     }
 
@@ -1337,6 +1364,17 @@ mod multi_field {
                 };
 
                 assert!(ptr::eq(item.as_ref(), item.first.as_ref()));
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(AsRef)]
+            struct Nothing {
+                first: !,
+                second: i32,
             }
         }
     }

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -40,12 +40,16 @@ mod never {
     struct Tuple(!);
 
     #[derive(Constructor)]
-    struct Struct { field: ! }
+    struct Struct {
+        field: !,
+    }
 
     #[derive(Constructor)]
     struct TupleMulti(i32, !);
 
     #[derive(Constructor)]
-    struct StructMulti { field: !, other: i32 }
+    struct StructMulti {
+        field: !,
+        other: i32,
+    }
 }
-

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Constructor;
@@ -30,3 +31,21 @@ struct Point2D {
 }
 
 const POINT_2D: Point2D = Point2D::new(-4, 7);
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(Constructor)]
+    struct Tuple(!);
+
+    #[derive(Constructor)]
+    struct Struct { field: ! }
+
+    #[derive(Constructor)]
+    struct TupleMulti(i32, !);
+
+    #[derive(Constructor)]
+    struct StructMulti { field: !, other: i32 }
+}
+

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -417,6 +418,19 @@ mod structs {
                 }
             }
         }
+
+        #[cfg(nightly)]
+        mod never {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            struct Tuple(!);
+
+            #[derive(Debug)]
+            struct Struct {
+                field: !,
+            }
+        }
     }
 
     mod multi_field {
@@ -674,6 +688,20 @@ mod structs {
                     format!("{:.1?}", StructLowerExp { a: 7, b: 3.15 }),
                     "3.1e0",
                 );
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            struct Tuple(i32, !);
+
+            #[derive(Debug)]
+            struct Struct {
+                field: !,
+                other: i32,
             }
         }
     }
@@ -980,6 +1008,17 @@ mod enums {
                 }
             }
         }
+
+        #[cfg(nightly)]
+        mod never {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            enum Enum {
+                Unnamed(!),
+                Named { field: ! },
+            }
+        }
     }
 
     mod multi_field_variant {
@@ -1153,6 +1192,17 @@ mod enums {
                     format!("{:.1?}", Enum::StructLowerExp { a: 7, b: 3.15 }),
                     "3.1e0",
                 );
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            enum Enum {
+                Unnamed(i32, !),
+                Named { field: !, other: i32 },
             }
         }
     }

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -72,4 +73,15 @@ struct GenericBox<T>(#[deref(forward)] Box<T>);
 fn deref_generic_forward() {
     let boxed = GenericBox(Box::new(1i32));
     assert_eq!(*boxed, 1i32);
+}
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(Deref)]
+    struct Tuple(!);
+
+    #[derive(Deref)]
+    struct Struct { field: ! }
 }

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -83,5 +83,7 @@ mod never {
     struct Tuple(!);
 
     #[derive(Deref)]
-    struct Struct { field: ! }
+    struct Struct {
+        field: !,
+    }
 }

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -134,4 +135,35 @@ fn deref_mut_generic_forward() {
     let mut boxed = GenericBox(Box::new(1i32));
     *boxed = 3;
     assert_eq!(*boxed, 3i32);
+}
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(DerefMut)]
+    struct Tuple(!);
+
+    // `Deref` implementation is required for `DerefMut`.
+    impl ::core::ops::Deref for Tuple {
+        type Target = !;
+        #[inline]
+        fn deref(&self) -> &Self::Target {
+            self.0
+        }
+    }
+
+    #[derive(DerefMut)]
+    struct Struct {
+        field: !,
+    }
+
+    // `Deref` implementation is required for `DerefMut`.
+    impl ::core::ops::Deref for Struct {
+        type Target = !;
+        #[inline]
+        fn deref(&self) -> &Self::Target {
+            self.field
+        }
+    }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -528,6 +529,19 @@ mod structs {
                 }
             }
         }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(Display)]
+            struct Tuple(!);
+
+            #[derive(Display)]
+            struct Struct {
+                field: !,
+            }
+        }
     }
 
     mod multi_field {
@@ -680,6 +694,22 @@ mod structs {
                         format!("{:018p}", &b),
                     );
                 }
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(Display)]
+            #[display("{_0}")]
+            struct Tuple(i32, !);
+
+            #[derive(Display)]
+            #[display("{field}")]
+            struct Struct {
+                field: !,
+                other: i32,
             }
         }
     }
@@ -1154,6 +1184,17 @@ mod enums {
                 }
             }
         }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(Display)]
+            enum Enum {
+                Unnamed(!),
+                Named { field: ! },
+            }
+        }
     }
 
     mod multi_field_variant {
@@ -1311,6 +1352,19 @@ mod enums {
                         format!("{:018p}", &b),
                     );
                 }
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(Display)]
+            enum Enum {
+                #[display("{_0}")]
+                Unnamed(i32, !),
+                #[display("{field}")]
+                Named { field: !, other: i32 },
             }
         }
 

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -453,6 +454,20 @@ mod structs {
                         (1, 2_i8).into(),
                     );
                 }
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(From)]
+            struct Tuple(i32, !);
+
+            #[derive(From)]
+            struct Struct {
+                field1: !,
+                field2: i16,
             }
         }
     }
@@ -1785,6 +1800,17 @@ mod enums {
                     },
                     (0_i16, 1_i16).into(),
                 );
+            }
+        }
+
+        #[cfg(nightly)]
+        mod never {
+            use super::*;
+
+            #[derive(From)]
+            enum Enum {
+                Tuple(i8, !),
+                Struct { field1: !, field2: i16 },
             }
         }
     }

--- a/tests/is_variant.rs
+++ b/tests/is_variant.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::IsVariant;
@@ -161,3 +162,16 @@ const _: () = {
     assert!(!ks.is_never_mind());
     assert!(ks.is_nothing_to_see_here());
 };
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(IsVariant)]
+    enum Enum {
+        Tuple(!),
+        Struct { field: ! },
+        TupleMulti(i32, !),
+        StructMulti { field: !, other: i32 },
+    }
+}

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Not;
@@ -26,4 +27,34 @@ enum MixedInts {
 enum EnumWithUnit {
     SmallInt(i32),
     Unit,
+}
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(Not)]
+    struct Tuple(!);
+
+    #[derive(Not)]
+    struct Struct {
+        field: !,
+    }
+
+    #[derive(Not)]
+    struct TupleMulti(i32, !);
+
+    #[derive(Not)]
+    struct StructMulti {
+        field: !,
+        other: i32,
+    }
+
+    #[derive(Not)]
+    enum Enum {
+        Tuple(!),
+        Struct { field: ! },
+        TupleMulti(i32, !),
+        StructMulti { field: !, other: i32 },
+    }
 }

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 #[cfg(not(feature = "std"))]
@@ -127,4 +128,15 @@ pub fn test_try_unwrap_mut_2() {
     }
 
     assert_eq!(value, Tuple::Double(255, 256));
+}
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(TryUnwrap)]
+    enum Enum {
+        Tuple(!),
+        TupleMulti(i32, !),
+    }
 }

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
 #![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::Unwrap;
@@ -116,4 +117,15 @@ pub fn test_unwrap_mut_2() {
     *x *= 2;
 
     assert_eq!(value, Tuple::Single(256));
+}
+
+#[cfg(nightly)]
+mod never {
+    use super::*;
+
+    #[derive(Unwrap)]
+    enum Enum {
+        Tuple(!),
+        TupleMulti(i32, !),
+    }
 }


### PR DESCRIPTION
Resolves #400

## Synopsis

For `!` never type used in trait signatures, `rustc` emits `unreachable_code` warning ignoring the `#[automatically_derived]` attribute.

## Solution

Add `#[allow(unreachable_code)]` to generated `impl`s to suppress such warnings for `!` and similar types.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
