### PR TITLE
Swap macro re-export modules (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.1 - Unreleased
+
+## 2.0.0 - Unreleased
+
+### Breaking changes
+
+- `use derive_more::SomeTrait` now imports macro only. Importing macro with
+  its trait along is possible now via `use derive_more::with_trait::SomeTrait`.
+  ([#406](https://github.com/JelteF/derive_more/pull/406))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -139,17 +139,17 @@ These don't derive traits, but derive static methods instead.
 
 ### Re-exports
 
-This crate also re-exports all the standard library traits that it adds derives
-for. So, both the `Display` derive and the `Display` trait will be in scope when
-you add the following code:
+This crate also re-exports all the standard library traits, that it adds derives
+for, in the `with_trait` module. So, both the `Display` derive and the `Display`
+trait will be in scope when you add the following code:
 ```rust
-use derive_more::Display; // also imports `core::fmt::Display`
+use derive_more::with_trait::Display; // also imports `core::fmt::Display`
 ```
 
-For derive macros only, without the corresponding traits, do import them from
-the `derive` module:
+By default, derive macros only, without the corresponding traits, are import from
+the crate's root:
 ```rust
-use derive_more::derive::Display; // imports macro only
+use derive_more::Display; // imports macro only
 ```
 
 #### Hygiene

--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ trait will be in scope when you add the following code:
 use derive_more::with_trait::Display; // also imports `core::fmt::Display`
 ```
 
-By default, derive macros only, without the corresponding traits, are import from
-the crate's root:
+By default, derive macros only, without the corresponding traits, are imported from
+the crate's root (or from the `derive` module):
 ```rust
-use derive_more::Display; // imports macro only
+use derive_more::Display;   // imports macro only
+use derive_more::derive::*; // imports all macros only
 ```
 
 #### Hygiene

--- a/impl/doc/add.md
+++ b/impl/doc/add.md
@@ -26,7 +26,7 @@ Code like this will be generated:
 
 ```rust
 # struct MyInts(i32, i32);
-impl derive_more::Add for MyInts {
+impl derive_more::core::ops::Add for MyInts {
     type Output = MyInts;
     fn add(self, rhs: MyInts) -> MyInts {
         MyInts(self.0.add(rhs.0), self.1.add(rhs.1))
@@ -60,7 +60,7 @@ Code like this will be generated:
 #     x: i32,
 #     y: i32,
 # }
-impl derive_more::Add for Point2D {
+impl derive_more::core::ops::Add for Point2D {
     type Output = Point2D;
     fn add(self, rhs: Point2D) -> Point2D {
         Point2D {
@@ -112,7 +112,7 @@ Code like this will be generated:
 #     UnsignedTwo(u32),
 #     Unit,
 # }
-impl derive_more::Add for MixedInts {
+impl derive_more::core::ops::Add for MixedInts {
     type Output = Result<MixedInts, derive_more::BinaryError>;
     fn add(self, rhs: MixedInts) -> Result<MixedInts, derive_more::BinaryError> {
         match (self, rhs) {

--- a/impl/doc/add_assign.md
+++ b/impl/doc/add_assign.md
@@ -22,7 +22,7 @@ Code like this will be generated:
 
 ```rust
 # struct MyInts(i32, i32);
-impl derive_more::AddAssign for MyInts {
+impl derive_more::core::ops::AddAssign for MyInts {
     fn add_assign(&mut self, rhs: MyInts) {
         self.0.add_assign(rhs.0);
         self.1.add_assign(rhs.1);
@@ -56,7 +56,7 @@ Code like this will be generated:
 #     x: i32,
 #     y: i32,
 # }
-impl derive_more::AddAssign for Point2D {
+impl derive_more::core::ops::AddAssign for Point2D {
     fn add_assign(&mut self, rhs: Point2D) {
         self.x.add_assign(rhs.x);
         self.y.add_assign(rhs.y);

--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -24,7 +24,7 @@ Generates:
 
 ```rust
 # struct MyWrapper(String);
-impl derive_more::AsMut<String> for MyWrapper {
+impl AsMut<String> for MyWrapper {
     fn as_mut(&mut self) -> &mut String {
         &mut self.0
     }
@@ -50,9 +50,9 @@ This generates code equivalent to:
 
 ```rust
 # struct SingleFieldForward(Vec<i32>);
-impl<T: ?Sized> derive_more::AsMut<T> for SingleFieldForward
+impl<T: ?Sized> AsMut<T> for SingleFieldForward
 where
-    Vec<i32>: derive_more::AsMut<T>,
+    Vec<i32>: AsMut<T>,
 {
     #[inline]
     fn as_mut(&mut self) -> &mut T {

--- a/impl/doc/as_ref.md
+++ b/impl/doc/as_ref.md
@@ -24,7 +24,7 @@ Generates:
 
 ```rust
 # struct MyWrapper(String);
-impl derive_more::AsRef<String> for MyWrapper {
+impl AsRef<String> for MyWrapper {
     fn as_ref(&self) -> &String {
         &self.0
     }
@@ -50,9 +50,9 @@ This generates code equivalent to:
 
 ```rust
 # struct SingleFieldForward(Vec<i32>);
-impl<T: ?Sized> derive_more::AsRef<T> for SingleFieldForward
+impl<T: ?Sized> AsRef<T> for SingleFieldForward
 where
-    Vec<i32>: derive_more::AsRef<T>,
+    Vec<i32>: AsRef<T>,
 {
     #[inline]
     fn as_ref(&self) -> &T {

--- a/impl/doc/deref.md
+++ b/impl/doc/deref.md
@@ -67,7 +67,7 @@ Code like this will be generated:
 #     cool: bool,
 #     vec: Vec<i32>,
 # }
-impl derive_more::Deref for CoolVec {
+impl derive_more::core::ops::Deref for CoolVec {
     type Target = Vec<i32>;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -90,11 +90,11 @@ Code like this will be generated:
 
 ```rust
 # struct MyBoxedInt(Box<i32>);
-impl derive_more::Deref for MyBoxedInt {
-    type Target = <Box<i32> as derive_more::Deref>::Target;
+impl derive_more::core::ops::Deref for MyBoxedInt {
+    type Target = <Box<i32> as derive_more::core::ops::Deref>::Target;
     #[inline]
     fn deref(&self) -> &Self::Target {
-        <Box<i32> as derive_more::Deref>::deref(&self.0)
+        <Box<i32> as derive_more::core::ops::Deref>::deref(&self.0)
     }
 }
 ```

--- a/impl/doc/deref_mut.md
+++ b/impl/doc/deref_mut.md
@@ -85,7 +85,7 @@ Code like this will be generated:
 #         &self.vec
 #     }
 # }
-impl derive_more::DerefMut for CoolVec {
+impl derive_more::core::ops::DerefMut for CoolVec {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.vec
@@ -116,10 +116,10 @@ When deriving a forwarded `DerefMut` for a struct:
 #         <Box<i32> as Deref>::deref(&self.0)
 #     }
 # }
-impl derive_more::DerefMut for MyBoxedInt {
+impl derive_more::core::ops::DerefMut for MyBoxedInt {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        <Box<i32> as derive_more::DerefMut>::deref_mut(&mut self.0)
+        <Box<i32> as derive_more::core::ops::DerefMut>::deref_mut(&mut self.0)
     }
 }
 ```

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -33,7 +33,7 @@ once to get the address of the field itself, instead of the address of the
 reference to the field:
 
 ```rust
-# use derive_more::Display;
+# use derive_more::with_trait::Display;
 #
 #[derive(Display)]
 #[display("{field:p} {:p}", *field)]
@@ -107,7 +107,7 @@ Explicitly specified bounds are added to the inferred ones. Note how no `V: Disp
 because it's inferred already.
 
 ```rust
-# use derive_more::Display;
+# use derive_more::with_trait::Display;
 #
 # trait MyTrait { fn my_function(&self) -> i32; }
 #

--- a/impl/doc/from_str.md
+++ b/impl/doc/from_str.md
@@ -122,7 +122,7 @@ Code like this will be generated:
 # }
 #
 impl derive_more::core::str::FromStr for EnumNoFields {
-    type Err = derive_more::core::str::FromStrError;
+    type Err = derive_more::FromStrError;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Ok(match src.to_lowercase().as_str() {
             "foo" => EnumNoFields::Foo,

--- a/impl/doc/from_str.md
+++ b/impl/doc/from_str.md
@@ -44,8 +44,8 @@ Code like this will be generated:
 
 ```rust
 # struct MyInt(i32);
-impl derive_more::FromStr for MyInt {
-    type Err = <i32 as derive_more::FromStr>::Err;
+impl derive_more::core::str::FromStr for MyInt {
+    type Err = <i32 as derive_more::core::str::FromStr>::Err;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         return Ok(MyInt(i32::from_str(src)?));
     }
@@ -74,8 +74,8 @@ Code like this will be generated:
 # struct Point1D {
 #     x: i32,
 # }
-impl derive_more::FromStr for Point1D {
-    type Err = <i32 as derive_more::FromStr>::Err;
+impl derive_more::core::str::FromStr for Point1D {
+    type Err = <i32 as derive_more::core::str::FromStr>::Err;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         return Ok(Point1D {
             x: i32::from_str(src)?,
@@ -121,8 +121,8 @@ Code like this will be generated:
 #     Baz,
 # }
 #
-impl derive_more::FromStr for EnumNoFields {
-    type Err = derive_more::FromStrError;
+impl derive_more::core::str::FromStr for EnumNoFields {
+    type Err = derive_more::core::str::FromStrError;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Ok(match src.to_lowercase().as_str() {
             "foo" => EnumNoFields::Foo,

--- a/impl/doc/index.md
+++ b/impl/doc/index.md
@@ -54,14 +54,14 @@ Code like this will be generated:
 #     numbers: Vec<i32>,
 #     useless: bool,
 # }
-impl<__IdxT> derive_more::Index<__IdxT> for Numbers
+impl<__IdxT> derive_more::core::ops::Index<__IdxT> for Numbers
 where
-    Vec<i32>: derive_more::Index<__IdxT>,
+    Vec<i32>: derive_more::core::ops::Index<__IdxT>,
 {
-    type Output = <Vec<i32> as derive_more::Index<__IdxT>>::Output;
+    type Output = <Vec<i32> as derive_more::core::ops::Index<__IdxT>>::Output;
     #[inline]
     fn index(&self, idx: __IdxT) -> &Self::Output {
-        <Vec<i32> as derive_more::Index<__IdxT>>::index(&self.numbers, idx)
+        <Vec<i32> as derive_more::core::ops::Index<__IdxT>>::index(&self.numbers, idx)
     }
 }
 ```

--- a/impl/doc/index_mut.md
+++ b/impl/doc/index_mut.md
@@ -73,13 +73,13 @@ Code like this will be generated to implement `IndexMut`:
 #         <Vec<i32> as Index<__IdxT>>::index(&self.numbers, idx)
 #     }
 # }
-impl<__IdxT> derive_more::IndexMut<__IdxT> for Numbers
+impl<__IdxT> derive_more::core::ops::IndexMut<__IdxT> for Numbers
 where
-    Vec<i32>: derive_more::IndexMut<__IdxT>,
+    Vec<i32>: derive_more::core::ops::IndexMut<__IdxT>,
 {
     #[inline]
     fn index_mut(&mut self, idx: __IdxT) -> &mut Self::Output {
-        <Vec<i32> as derive_more::IndexMut<__IdxT>>::index_mut(&mut self.numbers, idx)
+        <Vec<i32> as derive_more::core::ops::IndexMut<__IdxT>>::index_mut(&mut self.numbers, idx)
     }
 }
 ```

--- a/impl/doc/into_iterator.md
+++ b/impl/doc/into_iterator.md
@@ -32,7 +32,7 @@ struct Numbers {
 
 assert_eq!(Some(5), MyVec(vec![5, 8]).into_iter().next());
 
-let mut nums = Numbers{numbers: vec![100, 200], useless: false};
+let mut nums = Numbers { numbers: vec![100, 200], useless: false };
 assert_eq!(Some(&100), (&nums).into_iter().next());
 assert_eq!(Some(&mut 100), (&mut nums).into_iter().next());
 assert_eq!(Some(100), nums.into_iter().next());
@@ -63,30 +63,30 @@ Code like this will be generated:
 #     numbers: Vec<i32>,
 #     useless: bool,
 # }
-impl derive_more::IntoIterator for Numbers {
-    type Item = <Vec<i32> as derive_more::IntoIterator>::Item;
-    type IntoIter = <Vec<i32> as derive_more::IntoIterator>::IntoIter;
+impl IntoIterator for Numbers {
+    type Item = <Vec<i32> as IntoIterator>::Item;
+    type IntoIter = <Vec<i32> as IntoIterator>::IntoIter;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        <Vec<i32> as derive_more::IntoIterator>::into_iter(self.numbers)
+        <Vec<i32> as IntoIterator>::into_iter(self.numbers)
     }
 }
 
-impl<'__deriveMoreLifetime> derive_more::IntoIterator for &'__deriveMoreLifetime Numbers {
-    type Item = <&'__deriveMoreLifetime Vec<i32> as derive_more::IntoIterator>::Item;
-    type IntoIter = <&'__deriveMoreLifetime Vec<i32> as derive_more::IntoIterator>::IntoIter;
+impl<'__deriveMoreLifetime> IntoIterator for &'__deriveMoreLifetime Numbers {
+    type Item = <&'__deriveMoreLifetime Vec<i32> as IntoIterator>::Item;
+    type IntoIter = <&'__deriveMoreLifetime Vec<i32> as IntoIterator>::IntoIter;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        <&'__deriveMoreLifetime Vec<i32> as derive_more::IntoIterator>::into_iter(&self.numbers)
+        <&'__deriveMoreLifetime Vec<i32> as IntoIterator>::into_iter(&self.numbers)
     }
 }
 
-impl<'__deriveMoreLifetime> derive_more::IntoIterator for &'__deriveMoreLifetime mut Numbers {
-    type Item = <&'__deriveMoreLifetime mut Vec<i32> as derive_more::IntoIterator>::Item;
-    type IntoIter = <&'__deriveMoreLifetime mut Vec<i32> as derive_more::IntoIterator>::IntoIter;
+impl<'__deriveMoreLifetime> IntoIterator for &'__deriveMoreLifetime mut Numbers {
+    type Item = <&'__deriveMoreLifetime mut Vec<i32> as IntoIterator>::Item;
+    type IntoIter = <&'__deriveMoreLifetime mut Vec<i32> as IntoIterator>::IntoIter;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        <&'__deriveMoreLifetime mut Vec<i32> as derive_more::IntoIterator>::into_iter(
+        <&'__deriveMoreLifetime mut Vec<i32> as IntoIterator>::into_iter(
             &mut self.numbers,
         )
     }

--- a/impl/doc/mul.md
+++ b/impl/doc/mul.md
@@ -35,8 +35,8 @@ Code like this will be generated:
 
 ```rust
 # struct MyInt(i32);
-impl<__RhsT> derive_more::Mul<__RhsT> for MyInt
-    where i32: derive_more::Mul<__RhsT, Output = i32>
+impl<__RhsT> derive_more::core::ops::Mul<__RhsT> for MyInt
+    where i32: derive_more::core::ops::Mul<__RhsT, Output = i32>
 {
     type Output = MyInt;
     fn mul(self, rhs: __RhsT) -> MyInt {
@@ -60,8 +60,8 @@ Code like this will be generated:
 
 ```rust
 # struct MyInts(i32, i32);
-impl<__RhsT: Copy> derive_more::Mul<__RhsT> for MyInts
-    where i32: derive_more::Mul<__RhsT, Output = i32>
+impl<__RhsT: Copy> derive_more::core::ops::Mul<__RhsT> for MyInts
+    where i32: derive_more::core::ops::Mul<__RhsT, Output = i32>
 {
     type Output = MyInts;
     fn mul(self, rhs: __RhsT) -> MyInts {
@@ -94,8 +94,8 @@ Code like this will be generated:
 # struct Point1D {
 #     x: i32,
 # }
-impl<__RhsT> derive_more::Mul<__RhsT> for Point1D
-    where i32: derive_more::Mul<__RhsT, Output = i32>
+impl<__RhsT> derive_more::core::ops::Mul<__RhsT> for Point1D
+    where i32: derive_more::core::ops::Mul<__RhsT, Output = i32>
 {
     type Output = Point1D;
     fn mul(self, rhs: __RhsT) -> Point1D {
@@ -125,8 +125,8 @@ Code like this will be generated:
 #     x: i32,
 #     y: i32,
 # }
-impl<__RhsT: Copy> derive_more::Mul<__RhsT> for Point2D
-    where i32: derive_more::Mul<__RhsT, Output = i32>
+impl<__RhsT: Copy> derive_more::core::ops::Mul<__RhsT> for Point2D
+    where i32: derive_more::core::ops::Mul<__RhsT, Output = i32>
 {
     type Output = Point2D;
     fn mul(self, rhs: __RhsT) -> Point2D {

--- a/impl/doc/mul_assign.md
+++ b/impl/doc/mul_assign.md
@@ -27,8 +27,8 @@ Code like this will be generated:
 
 ```rust
 # struct MyInts(i32, i32);
-impl<__RhsT: Copy> derive_more::MulAssign<__RhsT> for MyInts
-    where i32: derive_more::MulAssign<__RhsT>
+impl<__RhsT: Copy> derive_more::core::ops::MulAssign<__RhsT> for MyInts
+    where i32: derive_more::core::ops::MulAssign<__RhsT>
 {
     fn mul_assign(&mut self, rhs: __RhsT) {
         self.0.mul_assign(rhs);
@@ -64,8 +64,8 @@ Code like this will be generated:
 #     x: i32,
 #     y: i32,
 # }
-impl<__RhsT: Copy> derive_more::MulAssign<__RhsT> for Point2D
-    where i32: derive_more::MulAssign<__RhsT>
+impl<__RhsT: Copy> derive_more::core::ops::MulAssign<__RhsT> for Point2D
+    where i32: derive_more::core::ops::MulAssign<__RhsT>
 {
     fn mul_assign(&mut self, rhs: __RhsT) {
         self.x.mul_assign(rhs);

--- a/impl/doc/not.md
+++ b/impl/doc/not.md
@@ -23,7 +23,7 @@ Code like this will be generated:
 
 ```rust
 # struct MyInts(i32, i32);
-impl derive_more::Not for MyInts {
+impl derive_more::core::ops::Not for MyInts {
     type Output = MyInts;
     fn not(self) -> MyInts {
         MyInts(self.0.not(), self.1.not())
@@ -57,7 +57,7 @@ Code like this will be generated:
 #     x: i32,
 #     y: i32,
 # }
-impl derive_more::Not for Point2D {
+impl derive_more::core::ops::Not for Point2D {
     type Output = Point2D;
     fn not(self) -> Point2D {
         Point2D {
@@ -104,7 +104,7 @@ Code like this will be generated:
 #     UnsignedOne(u32),
 #     UnsignedTwo(u32),
 # }
-impl derive_more::Not for MixedInts {
+impl derive_more::core::ops::Not for MixedInts {
     type Output = MixedInts;
     fn not(self) -> MixedInts {
         match self {
@@ -147,7 +147,7 @@ Code like this will be generated:
 #     SmallInt(i32),
 #     Unit,
 # }
-impl derive_more::Not for EnumWithUnit {
+impl derive_more::core::ops::Not for EnumWithUnit {
     type Output = Result<EnumWithUnit, derive_more::UnitError>;
     fn not(self) -> Result<EnumWithUnit, derive_more::UnitError> {
         match self {

--- a/impl/doc/sum.md
+++ b/impl/doc/sum.md
@@ -22,7 +22,7 @@ easiest to implement by adding `#[derive(MulSelf)]`.
 struct MyInts(i32, i64);
 
 let int_vec = vec![MyInts(2, 3), MyInts(4, 5), MyInts(6, 7)];
-assert!(MyInts(12, 15) == int_vec.into_iter().sum())
+assert!(MyInts(12, 15) == int_vec.into_iter().sum());
 ```
 
 
@@ -51,7 +51,7 @@ Code like this will be generated for the `Sum` implementation:
 #         MyInts(self.0.add(rhs.0), self.1.add(rhs.1))
 #     }
 # }
-impl derive_more::core::ops::Sum for MyInts {
+impl derive_more::core::iter::Sum for MyInts {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(

--- a/impl/doc/sum.md
+++ b/impl/doc/sum.md
@@ -51,7 +51,7 @@ Code like this will be generated for the `Sum` implementation:
 #         MyInts(self.0.add(rhs.0), self.1.add(rhs.1))
 #     }
 # }
-impl derive_more::Sum for MyInts {
+impl derive_more::core::ops::Sum for MyInts {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(

--- a/impl/doc/try_into.md
+++ b/impl/doc/try_into.md
@@ -95,48 +95,48 @@ Code like this will be generated:
 #     UnsignedOne(u32),
 #     UnsignedTwo(u32),
 # }
-impl derive_more::TryFrom<MixedInts> for (i32) {
-    type Error = &'static str;
+impl TryFrom<MixedInts> for (i32) {
+    type Error = derive_more::TryIntoError<MixedInts>;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::SmallInt(__0) => Ok(__0),
-            _ => Err("Only SmallInt can be converted to i32"),
+            _ => Err(derive_more::TryIntoError::new(value, "SmallInt", "i32")),
         }
     }
 }
-impl derive_more::TryFrom<MixedInts> for (i64) {
-    type Error = &'static str;
+impl TryFrom<MixedInts> for (i64) {
+    type Error = derive_more::TryIntoError<MixedInts>;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::BigInt(__0) => Ok(__0),
-            _ => Err("Only BigInt can be converted to i64"),
+            _ => Err(derive_more::TryIntoError::new(value, "BigInt", "i64")),
         }
     }
 }
-impl derive_more::TryFrom<MixedInts> for (i32, i32) {
-    type Error = &'static str;
+impl TryFrom<MixedInts> for (i32, i32) {
+    type Error = derive_more::TryIntoError<MixedInts>;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::TwoSmallInts(__0, __1) => Ok((__0, __1)),
-            _ => Err("Only TwoSmallInts can be converted to (i32, i32)"),
+            _ => Err(derive_more::TryIntoError::new(value, "TwoSmallInts", "(i32, i32)")),
         }
     }
 }
-impl derive_more::TryFrom<MixedInts> for (i64, i64) {
-    type Error = &'static str;
+impl TryFrom<MixedInts> for (i64, i64) {
+    type Error = derive_more::TryIntoError<MixedInts>;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::NamedSmallInts { x: __0, y: __1 } => Ok((__0, __1)),
-            _ => Err("Only NamedSmallInts can be converted to (i64, i64)"),
+            _ => Err(derive_more::TryIntoError::new(value, "NamedSmallInts", "(i64, i64)")),
         }
     }
 }
-impl derive_more::TryFrom<MixedInts> for (u32) {
-    type Error = &'static str;
+impl TryFrom<MixedInts> for (u32) {
+    type Error = derive_more::TryIntoError<MixedInts>;
     fn try_from(value: MixedInts) -> Result<Self, Self::Error> {
         match value {
             MixedInts::UnsignedOne(__0) | MixedInts::UnsignedTwo(__0) => Ok(__0),
-            _ => Err("Only UnsignedOne, UnsignedTwo can be converted to u32"),
+            _ => Err(derive_more::TryIntoError::new(value, "UnsignedOne", "u32")),
         }
     }
 }
@@ -161,21 +161,21 @@ Code like this will be generated:
 #     SmallInt(i32),
 #     Unit,
 # }
-impl derive_more::TryFrom<EnumWithUnit> for (i32) {
-    type Error = &'static str;
+impl TryFrom<EnumWithUnit> for (i32) {
+    type Error = derive_more::TryIntoError<EnumWithUnit>;
     fn try_from(value: EnumWithUnit) -> Result<Self, Self::Error> {
         match value {
             EnumWithUnit::SmallInt(__0) => Ok(__0),
-            _ => Err("Only SmallInt can be converted to i32"),
+            _ => Err(derive_more::TryIntoError::new(value, "SmallInt", "i32")),
         }
     }
 }
-impl derive_more::TryFrom<EnumWithUnit> for () {
-    type Error = &'static str;
+impl TryFrom<EnumWithUnit> for () {
+    type Error = derive_more::TryIntoError<EnumWithUnit>;
     fn try_from(value: EnumWithUnit) -> Result<Self, Self::Error> {
         match value {
             EnumWithUnit::Unit => Ok(()),
-            _ => Err("Only Unit can be converted to ()"),
+            _ => Err(derive_more::TryIntoError::new(value, "Unit", "()")),
         }
     }
 }

--- a/impl/src/add_assign_like.rs
+++ b/impl/src/add_assign_like.rs
@@ -29,7 +29,8 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics derive_more::core::ops::#trait_ident
+         for #input_type #ty_generics #where_clause {
             #[inline]
             #[track_caller]
             fn #method_ident(&mut self, rhs: #input_type #ty_generics) {

--- a/impl/src/add_like.rs
+++ b/impl/src/add_like.rs
@@ -42,7 +42,8 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics derive_more::core::ops::#trait_ident
+         for #input_type #ty_generics #where_clause {
             type Output = #output_type;
 
             #[inline]

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -240,7 +240,7 @@ impl<'a> ToTokens for Expansion<'a> {
             };
 
             let trait_ty = quote! {
-                derive_more::#trait_ident <#return_ty>
+                derive_more::core::convert::#trait_ident <#return_ty>
             };
 
             let generics = match &impl_kind {

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -40,7 +40,9 @@ pub fn expand(
         // Not using `#[inline]` here on purpose, since this is almost never part
         // of a hot codepath.
         quote! {
-            fn source(&self) -> Option<&(dyn derive_more::Error + 'static)> {
+            // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
+            //       stabilized.
+            fn source(&self) -> Option<&(dyn derive_more::with_trait::Error + 'static)> {
                 use derive_more::__private::AsDynError;
                 #source
             }
@@ -82,7 +84,9 @@ pub fn expand(
                 where #(
                     #bounds: derive_more::core::fmt::Debug
                              + derive_more::core::fmt::Display
-                             + derive_more::Error
+                             // TODO: Use `derive_more::core::error::Error` once `error_in_core`
+                             //       Rust feature is stabilized.
+                             + derive_more::with_trait::Error
                              + 'static
                 ),*
             },
@@ -93,7 +97,9 @@ pub fn expand(
 
     let render = quote! {
         #[automatically_derived]
-        impl #impl_generics derive_more::Error for #ident #ty_generics #where_clause {
+        // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
+        //       stabilized.
+        impl #impl_generics derive_more::with_trait::Error for #ident #ty_generics #where_clause {
             #source
             #provide
         }
@@ -217,7 +223,9 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
         let source_provider = self.source.map(|source| {
             let source_expr = &self.data.members[source];
             quote! {
-                derive_more::Error::provide(&#source_expr, request);
+                // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
+                //       stabilized.
+                derive_more::with_trait::Error::provide(&#source_expr, request);
             }
         });
         let backtrace_provider = self
@@ -247,7 +255,9 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
-                        derive_more::Error::provide(source, request);
+                        // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust
+                        //       feature is stabilized.
+                        derive_more::with_trait::Error::provide(source, request);
                     }
                 })
             }
@@ -259,7 +269,9 @@ impl<'input, 'state> ParsedFields<'input, 'state> {
                 Some(quote! {
                     #pattern => {
                         request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
-                        derive_more::Error::provide(source, request);
+                        // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust
+                        //       feature is stabilized.
+                        derive_more::with_trait::Error::provide(source, request);
                     }
                 })
             }

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -62,7 +62,7 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
-        impl #impl_gens derive_more::Debug for #ident #ty_gens #where_clause {
+        impl #impl_gens derive_more::core::fmt::Debug for #ident #ty_gens #where_clause {
             #[inline]
             fn fmt(
                 &self, __derive_more_f: &mut derive_more::core::fmt::Formatter<'_>
@@ -411,7 +411,7 @@ impl<'a> Expansion<'a> {
                         ));
                     }
                     Some(FieldAttribute::Left(_skip)) => {}
-                    None => out.extend([parse_quote! { #ty: derive_more::Debug }]),
+                    None => out.extend([parse_quote! { #ty: derive_more::core::fmt::Debug }]),
                 }
                 Ok(out)
             })

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -64,7 +64,7 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
     Ok(quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
-        impl #impl_gens derive_more::#trait_ident for #ident #ty_gens #where_clause {
+        impl #impl_gens derive_more::core::fmt::#trait_ident for #ident #ty_gens #where_clause {
             fn fmt(
                 &self, __derive_more_f: &mut derive_more::core::fmt::Formatter<'_>
             ) -> derive_more::core::fmt::Result {

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -165,7 +165,7 @@ impl<'a> Expansion<'a> {
                         let index = index.into_iter();
                         let from_ty = from_tys.next().unwrap_or_else(|| unreachable!());
                         quote! {
-                            #( #ident: )* <#ty as derive_more::From<#from_ty>>::from(
+                            #( #ident: )* <#ty as derive_more::core::convert::From<#from_ty>>::from(
                                 value #( .#index )*
                             ),
                         }
@@ -174,7 +174,8 @@ impl<'a> Expansion<'a> {
                     Ok(quote! {
                         #[allow(unreachable_code)] // omit warnings for `!` and unreachable types
                         #[automatically_derived]
-                        impl #impl_gens derive_more::From<#ty> for #ident #ty_gens #where_clause {
+                        impl #impl_gens derive_more::core::convert::From<#ty>
+                         for #ident #ty_gens #where_clause {
                             #[inline]
                             fn from(value: #ty) -> Self {
                                 #ident #( :: #variant )* #init
@@ -195,7 +196,8 @@ impl<'a> Expansion<'a> {
                 Ok(quote! {
                     #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
                     #[automatically_derived]
-                    impl #impl_gens derive_more::From<(#( #field_tys ),*)> for #ident #ty_gens #where_clause {
+                    impl #impl_gens derive_more::core::convert::From<(#( #field_tys ),*)>
+                     for #ident #ty_gens #where_clause {
                         #[inline]
                         fn from(value: (#( #field_tys ),*)) -> Self {
                             #ident #( :: #variant )* #init
@@ -211,7 +213,7 @@ impl<'a> Expansion<'a> {
                     let index = index.into_iter();
                     let gen_ident = format_ident!("__FromT{i}");
                     let out = quote! {
-                        #( #ident: )* <#ty as derive_more::From<#gen_ident>>::from(
+                        #( #ident: )* <#ty as derive_more::core::convert::From<#gen_ident>>::from(
                             value #( .#index )*
                         ),
                     };
@@ -227,7 +229,7 @@ impl<'a> Expansion<'a> {
                         generics
                             .make_where_clause()
                             .predicates
-                            .push(parse_quote! { #ty: derive_more::From<#ident> });
+                            .push(parse_quote! { #ty: derive_more::core::convert::From<#ident> });
                         generics
                             .params
                             .push(syn::TypeParam::from(ident.clone()).into());
@@ -239,7 +241,8 @@ impl<'a> Expansion<'a> {
                 Ok(quote! {
                     #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
                     #[automatically_derived]
-                    impl #impl_gens derive_more::From<(#( #gen_idents ),*)> for #ident #ty_gens #where_clause {
+                    impl #impl_gens derive_more::core::convert::From<(#( #gen_idents ),*)>
+                     for #ident #ty_gens #where_clause {
                         #[inline]
                         fn from(value: (#( #gen_idents ),*)) -> Self {
                             #ident #(:: #variant)* #init

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -37,7 +37,8 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
-        impl #impl_generics derive_more::#trait_ident for #input_type #ty_generics #where_clause {
+        impl #impl_generics derive_more::core::ops::#trait_ident
+         for #input_type #ty_generics #where_clause {
             type Output = #output_type;
 
             #[inline]

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -121,7 +121,8 @@ impl ToTokens for Expansion {
 
         quote! {
             #[automatically_derived]
-            impl #impl_generics derive_more::TryFrom<#repr_ty #ty_generics> for #ident #where_clause {
+            impl #impl_generics derive_more::core::convert::TryFrom<#repr_ty #ty_generics>
+             for #ident #where_clause {
                 type Error = derive_more::TryFromReprError<#repr_ty>;
 
                 #[allow(non_upper_case_globals)]

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -123,7 +123,8 @@ impl ToTokens for Expansion {
 
         quote! {
             #[automatically_derived]
-            impl #impl_generics derive_more::core::convert::TryFrom<#repr_ty #ty_generics> for #ident #where_clause {
+            impl #impl_generics derive_more::core::convert::TryFrom<#repr_ty #ty_generics>
+             for #ident #where_clause {
                 type Error = #error;
 
                 #[allow(non_upper_case_globals)]

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -372,7 +372,7 @@ impl<'input> State<'input> {
         let trait_name = trait_name.trim_end_matches("ToInner");
         let trait_ident = format_ident!("{trait_name}");
         let method_ident = format_ident!("{trait_attr}");
-        let trait_path = quote! { derive_more::#trait_ident };
+        let trait_path = quote! { derive_more::with_trait::#trait_ident };
         let (derive_type, fields, variants): (_, Vec<_>, Vec<_>) = match input.data {
             Data::Struct(ref data_struct) => match data_struct.fields {
                 Fields::Unnamed(ref fields) => {
@@ -513,7 +513,7 @@ impl<'input> State<'input> {
         let trait_name = trait_name.trim_end_matches("ToInner");
         let trait_ident = format_ident!("{trait_name}");
         let method_ident = format_ident!("{trait_attr}");
-        let trait_path = quote! { derive_more::#trait_ident };
+        let trait_path = quote! { derive_more::with_trait::#trait_ident };
         let (derive_type, fields): (_, Vec<_>) = match variant.fields {
             Fields::Unnamed(ref fields) => {
                 (DeriveType::Unnamed, unnamed_to_vec(fields))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,17 +66,6 @@ pub mod __private {
     pub use crate::vendor::thiserror::aserror::AsDynError;
 }
 
-/// Module containing macro definitions only, without corresponding traits.
-///
-/// Use it in your import paths, if you don't want to import traits, but only macros.
-pub mod derive {
-    // This can be unused if no feature is enabled. We already error in that case, but this warning
-    // distracts from that error. So we suppress the warning.
-    #[allow(unused_imports)]
-    #[doc(inline)]
-    pub use derive_more_impl::*;
-}
-
 // The modules containing error types and other helpers.
 
 #[cfg(feature = "add")]
@@ -119,303 +108,316 @@ mod try_unwrap;
 #[doc(inline)]
 pub use crate::try_unwrap::TryUnwrapError;
 
-// When re-exporting traits from std we need to do a pretty crazy trick, because we ONLY want
-// to re-export the traits and not derives that are called the same in the std module,
-// because those would conflict with our own. The way we do this is by first importing both
-// the trait and possible derive into a separate module and re-export them. Then we wildcard import
-// all the things from that module into the main module, but we also import our own derive by its
-// exact name. Due to the way wildcard imports work in rust, that results in our own derive taking
-// precedence over any derive from std. For some reason the named re-export of our own derive
-// cannot be in in this (or really any) macro too. It will somehow still consider it a wildcard
-// then and will result in this warning ambiguous_glob_reexports, and not actually exporting of our
-// derive.
-macro_rules! re_export_traits((
-    $feature:literal, $new_module_name:ident, $module:path $(, $traits:ident)* $(,)?) => {
-        #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
-        mod $new_module_name {
+// This can be unused if no feature is enabled. We already error in that case, but this warning
+// distracts from that error. So we suppress the warning.
+#[allow(unused_imports)]
+#[doc(inline)]
+pub use derive_more_impl::*;
+
+/// Module containing macro definitions with their corresponding traits along.
+///
+/// Use it in your import paths, if you do want to import macros along with their traits.
+pub mod with_trait {
+    // When re-exporting traits from `std` we need to do a pretty crazy trick, because we ONLY want
+    // to re-export the traits and not derives that are called the same in the `std` module, because
+    // those would conflict with our own ones. The way we do this is by first importing both the
+    // trait and possible derive into a separate module and re-export them. Then, we wildcard-import
+    // all the things from that module into the main module, but we also import our own derive by
+    // its exact name. Due to the way wildcard imports work in Rust, that results in our own derive
+    // taking precedence over any derive from `std`. For some reason the named re-export of our own
+    // derive cannot be in this (or really any) macro too. It will somehow still consider it a
+    // wildcard then and will result in this warning `ambiguous_glob_reexports`, and not actually
+    // exporting of our derive.
+    macro_rules! re_export_traits((
+        $feature:literal, $new_module_name:ident, $module:path $(, $traits:ident)* $(,)?) => {
+            #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
+            mod $new_module_name {
+                #[doc(hidden)]
+                pub use $module::{$($traits),*};
+            }
+
+            #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
             #[doc(hidden)]
-            pub use $module::{$($traits),*};
+            pub use crate::with_trait::all_traits_and_derives::$new_module_name::*;
         }
+    );
 
-        #[cfg(all(feature = $feature, any(not(docsrs), ci)))]
-        #[doc(hidden)]
-        pub use crate::all_traits_and_derives::$new_module_name::*;
+    mod all_traits_and_derives {
+        re_export_traits!(
+            "add",
+            add_traits,
+            core::ops,
+            Add,
+            BitAnd,
+            BitOr,
+            BitXor,
+            Sub,
+        );
+        re_export_traits!(
+            "add_assign",
+            add_assign_traits,
+            core::ops,
+            AddAssign,
+            BitAndAssign,
+            BitOrAssign,
+            BitXorAssign,
+            SubAssign,
+        );
+        re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
+        re_export_traits!("debug", debug_traits, core::fmt, Debug);
+        re_export_traits!("deref", deref_traits, core::ops, Deref);
+        re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
+        re_export_traits!(
+            "display",
+            display_traits,
+            core::fmt,
+            Binary,
+            Display,
+            LowerExp,
+            LowerHex,
+            Octal,
+            Pointer,
+            UpperExp,
+            UpperHex,
+        );
+
+        #[cfg(not(feature = "std"))]
+        re_export_traits!("error", error_traits, core::error, Error);
+        #[cfg(feature = "std")]
+        re_export_traits!("error", error_traits, std::error, Error);
+
+        re_export_traits!("from", from_traits, core::convert, From);
+
+        re_export_traits!("from_str", from_str_traits, core::str, FromStr);
+
+        re_export_traits!("index", index_traits, core::ops, Index);
+
+        re_export_traits!("index_mut", index_mut_traits, core::ops, IndexMut);
+
+        re_export_traits!("into", into_traits, core::convert, Into);
+
+        re_export_traits!(
+            "into_iterator",
+            into_iterator_traits,
+            core::iter,
+            IntoIterator,
+        );
+
+        re_export_traits!("mul", mul_traits, core::ops, Div, Mul, Rem, Shl, Shr);
+
+        #[cfg(feature = "mul_assign")]
+        re_export_traits!(
+            "mul_assign",
+            mul_assign_traits,
+            core::ops,
+            DivAssign,
+            MulAssign,
+            RemAssign,
+            ShlAssign,
+            ShrAssign,
+        );
+
+        re_export_traits!("not", not_traits, core::ops, Neg, Not);
+
+        re_export_traits!("sum", sum_traits, core::iter, Product, Sum);
+
+        re_export_traits!("try_from", try_from_traits, core::convert, TryFrom);
+
+        re_export_traits!("try_into", try_into_traits, core::convert, TryInto);
+
+        // Now re-export our own derives by their exact name to overwrite any derives that the trait
+        // re-exporting might inadvertently pull into scope.
+        #[cfg(feature = "add")]
+        pub use derive_more_impl::{Add, BitAnd, BitOr, BitXor, Sub};
+
+        #[cfg(feature = "add_assign")]
+        pub use derive_more_impl::{
+            AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, SubAssign,
+        };
+
+        #[cfg(feature = "as_ref")]
+        pub use derive_more_impl::{AsMut, AsRef};
+
+        #[cfg(feature = "constructor")]
+        pub use derive_more_impl::Constructor;
+
+        #[cfg(feature = "debug")]
+        pub use derive_more_impl::Debug;
+
+        #[cfg(feature = "deref")]
+        pub use derive_more_impl::Deref;
+
+        #[cfg(feature = "deref_mut")]
+        pub use derive_more_impl::DerefMut;
+
+        #[cfg(feature = "display")]
+        pub use derive_more_impl::{
+            Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+        };
+
+        #[cfg(feature = "error")]
+        pub use derive_more_impl::Error;
+
+        #[cfg(feature = "from")]
+        pub use derive_more_impl::From;
+
+        #[cfg(feature = "from_str")]
+        pub use derive_more_impl::FromStr;
+
+        #[cfg(feature = "index")]
+        pub use derive_more_impl::Index;
+
+        #[cfg(feature = "index_mut")]
+        pub use derive_more_impl::IndexMut;
+
+        #[cfg(feature = "into")]
+        pub use derive_more_impl::Into;
+
+        #[cfg(feature = "into_iterator")]
+        pub use derive_more_impl::IntoIterator;
+
+        #[cfg(feature = "is_variant")]
+        pub use derive_more_impl::IsVariant;
+
+        #[cfg(feature = "mul")]
+        pub use derive_more_impl::{Div, Mul, Rem, Shl, Shr};
+
+        #[cfg(feature = "mul_assign")]
+        pub use derive_more_impl::{
+            DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign,
+        };
+
+        #[cfg(feature = "not")]
+        pub use derive_more_impl::{Neg, Not};
+
+        #[cfg(feature = "sum")]
+        pub use derive_more_impl::{Product, Sum};
+
+        #[cfg(feature = "try_from")]
+        pub use derive_more_impl::TryFrom;
+
+        #[cfg(feature = "try_into")]
+        pub use derive_more_impl::TryInto;
+
+        #[cfg(feature = "try_unwrap")]
+        pub use derive_more_impl::TryUnwrap;
+
+        #[cfg(feature = "unwrap")]
+        pub use derive_more_impl::Unwrap;
     }
-);
 
-mod all_traits_and_derives {
-    re_export_traits!(
-        "add",
-        add_traits,
-        core::ops,
-        Add,
-        BitAnd,
-        BitOr,
-        BitXor,
-        Sub,
-    );
-    re_export_traits!(
-        "add_assign",
-        add_assign_traits,
-        core::ops,
-        AddAssign,
-        BitAndAssign,
-        BitOrAssign,
-        BitXorAssign,
-        SubAssign,
-    );
-    re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
-    re_export_traits!("debug", debug_traits, core::fmt, Debug);
-    re_export_traits!("deref", deref_traits, core::ops, Deref);
-    re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
-    re_export_traits!(
-        "display",
-        display_traits,
-        core::fmt,
-        Binary,
-        Display,
-        LowerExp,
-        LowerHex,
-        Octal,
-        Pointer,
-        UpperExp,
-        UpperHex,
-    );
-
-    #[cfg(not(feature = "std"))]
-    re_export_traits!("error", error_traits, core::error, Error);
-    #[cfg(feature = "std")]
-    re_export_traits!("error", error_traits, std::error, Error);
-
-    re_export_traits!("from", from_traits, core::convert, From);
-
-    re_export_traits!("from_str", from_str_traits, core::str, FromStr);
-
-    re_export_traits!("index", index_traits, core::ops, Index);
-
-    re_export_traits!("index_mut", index_mut_traits, core::ops, IndexMut);
-
-    re_export_traits!("into", into_traits, core::convert, Into);
-
-    re_export_traits!(
-        "into_iterator",
-        into_iterator_traits,
-        core::iter,
-        IntoIterator,
-    );
-
-    re_export_traits!("mul", mul_traits, core::ops, Div, Mul, Rem, Shl, Shr);
-
-    #[cfg(feature = "mul_assign")]
-    re_export_traits!(
-        "mul_assign",
-        mul_assign_traits,
-        core::ops,
-        DivAssign,
-        MulAssign,
-        RemAssign,
-        ShlAssign,
-        ShrAssign,
-    );
-
-    re_export_traits!("not", not_traits, core::ops, Neg, Not);
-
-    re_export_traits!("sum", sum_traits, core::iter, Product, Sum);
-
-    re_export_traits!("try_from", try_from_traits, core::convert, TryFrom);
-
-    re_export_traits!("try_into", try_into_traits, core::convert, TryInto);
-
-    // Now re-export our own derives by their exact name to overwrite any derives that the trait
-    // re-exporting might inadvertently pull into scope.
+    // Now re-export our own derives and the std traits by their exact name to make rust-analyzer
+    // recognize the #[doc(hidden)] flag.
+    // See issues:
+    // 1. https://github.com/rust-lang/rust-analyzer/issues/11698
+    // 2. https://github.com/rust-lang/rust-analyzer/issues/14079
     #[cfg(feature = "add")]
-    pub use derive_more_impl::{Add, BitAnd, BitOr, BitXor, Sub};
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{Add, BitAnd, BitOr, BitXor, Sub};
 
     #[cfg(feature = "add_assign")]
-    pub use derive_more_impl::{
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{
         AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, SubAssign,
     };
 
     #[cfg(feature = "as_ref")]
-    pub use derive_more_impl::{AsMut, AsRef};
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{AsMut, AsRef};
 
     #[cfg(feature = "constructor")]
-    pub use derive_more_impl::Constructor;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Constructor;
 
     #[cfg(feature = "debug")]
-    pub use derive_more_impl::Debug;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Debug;
 
     #[cfg(feature = "deref")]
-    pub use derive_more_impl::Deref;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Deref;
 
     #[cfg(feature = "deref_mut")]
-    pub use derive_more_impl::DerefMut;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::DerefMut;
 
     #[cfg(feature = "display")]
-    pub use derive_more_impl::{
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{
         Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
     };
 
     #[cfg(feature = "error")]
-    pub use derive_more_impl::Error;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Error;
 
     #[cfg(feature = "from")]
-    pub use derive_more_impl::From;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::From;
 
     #[cfg(feature = "from_str")]
-    pub use derive_more_impl::FromStr;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::FromStr;
 
     #[cfg(feature = "index")]
-    pub use derive_more_impl::Index;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Index;
 
     #[cfg(feature = "index_mut")]
-    pub use derive_more_impl::IndexMut;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::IndexMut;
 
     #[cfg(feature = "into")]
-    pub use derive_more_impl::Into;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Into;
 
     #[cfg(feature = "into_iterator")]
-    pub use derive_more_impl::IntoIterator;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::IntoIterator;
 
     #[cfg(feature = "is_variant")]
-    pub use derive_more_impl::IsVariant;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::IsVariant;
 
     #[cfg(feature = "mul")]
-    pub use derive_more_impl::{Div, Mul, Rem, Shl, Shr};
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{Div, Mul, Rem, Shl, Shr};
 
     #[cfg(feature = "mul_assign")]
-    pub use derive_more_impl::{DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign};
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{
+        DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign,
+    };
 
     #[cfg(feature = "not")]
-    pub use derive_more_impl::{Neg, Not};
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{Neg, Not};
 
     #[cfg(feature = "sum")]
-    pub use derive_more_impl::{Product, Sum};
+    #[doc(hidden)]
+    pub use all_traits_and_derives::{Product, Sum};
 
     #[cfg(feature = "try_from")]
-    pub use derive_more_impl::TryFrom;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::TryFrom;
 
     #[cfg(feature = "try_into")]
-    pub use derive_more_impl::TryInto;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::TryInto;
 
     #[cfg(feature = "try_unwrap")]
-    pub use derive_more_impl::TryUnwrap;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::TryUnwrap;
 
     #[cfg(feature = "unwrap")]
-    pub use derive_more_impl::Unwrap;
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Unwrap;
+
+    // Re-export the derive macros again to show docs for our derives (but not for traits). This is
+    // done using a glob import to not hit E0252.
+    #[allow(unused_imports)]
+    pub use derive_more_impl::*;
 }
-
-// Now re-export our own derives and the std traits by their exact name to make rust-analyzer
-// recognize the #[doc(hidden)] flag.
-// See issues:
-// 1. https://github.com/rust-lang/rust-analyzer/issues/11698
-// 2. https://github.com/rust-lang/rust-analyzer/issues/14079
-#[cfg(feature = "add")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{Add, BitAnd, BitOr, BitXor, Sub};
-
-#[cfg(feature = "add_assign")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{
-    AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, SubAssign,
-};
-
-#[cfg(feature = "as_ref")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{AsMut, AsRef};
-
-#[cfg(feature = "constructor")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Constructor;
-
-#[cfg(feature = "debug")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Debug;
-
-#[cfg(feature = "deref")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Deref;
-
-#[cfg(feature = "deref_mut")]
-#[doc(hidden)]
-pub use all_traits_and_derives::DerefMut;
-
-#[cfg(feature = "display")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{
-    Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
-};
-
-#[cfg(feature = "error")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Error;
-
-#[cfg(feature = "from")]
-#[doc(hidden)]
-pub use all_traits_and_derives::From;
-
-#[cfg(feature = "from_str")]
-#[doc(hidden)]
-pub use all_traits_and_derives::FromStr;
-
-#[cfg(feature = "index")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Index;
-
-#[cfg(feature = "index_mut")]
-#[doc(hidden)]
-pub use all_traits_and_derives::IndexMut;
-
-#[cfg(feature = "into")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Into;
-
-#[cfg(feature = "into_iterator")]
-#[doc(hidden)]
-pub use all_traits_and_derives::IntoIterator;
-
-#[cfg(feature = "is_variant")]
-#[doc(hidden)]
-pub use all_traits_and_derives::IsVariant;
-
-#[cfg(feature = "mul")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{Div, Mul, Rem, Shl, Shr};
-
-#[cfg(feature = "mul_assign")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{
-    DivAssign, MulAssign, RemAssign, ShlAssign, ShrAssign,
-};
-
-#[cfg(feature = "not")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{Neg, Not};
-
-#[cfg(feature = "sum")]
-#[doc(hidden)]
-pub use all_traits_and_derives::{Product, Sum};
-
-#[cfg(feature = "try_from")]
-#[doc(hidden)]
-pub use all_traits_and_derives::TryFrom;
-
-#[cfg(feature = "try_into")]
-#[doc(hidden)]
-pub use all_traits_and_derives::TryInto;
-
-#[cfg(feature = "try_unwrap")]
-#[doc(hidden)]
-pub use all_traits_and_derives::TryUnwrap;
-
-#[cfg(feature = "unwrap")]
-#[doc(hidden)]
-pub use all_traits_and_derives::Unwrap;
-
-// Re-export the derive macros again to show docs for our derives (but not for traits). This is
-// done using a glob import to not hit E0252.
-#[allow(unused_imports)]
-pub use derive_more_impl::*;
 
 // Check if any feature is enabled
 #[cfg(not(any(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,17 @@ pub use crate::try_unwrap::TryUnwrapError;
 #[doc(inline)]
 pub use derive_more_impl::*;
 
+/// Module containing derive definitions only, without their corresponding traits.
+///
+/// Use it in your import paths, if you don't want to import traits, but only macros.
+pub mod derive {
+    // This can be unused if no feature is enabled. We already error in that case, but this warning
+    // distracts from that error. So we suppress the warning.
+    #[allow(unused_imports)]
+    #[doc(inline)]
+    pub use derive_more_impl::*;
+}
+
 /// Module containing derive definitions with their corresponding traits along.
 ///
 /// Use it in your import paths, if you do want to import derives along with their traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,9 @@ pub use crate::try_unwrap::TryUnwrapError;
 #[doc(inline)]
 pub use derive_more_impl::*;
 
-/// Module containing macro definitions with their corresponding traits along.
+/// Module containing derive definitions with their corresponding traits along.
 ///
-/// Use it in your import paths, if you do want to import macros along with their traits.
+/// Use it in your import paths, if you do want to import derives along with their traits.
 pub mod with_trait {
     // When re-exporting traits from `std` we need to do a pretty crazy trick, because we ONLY want
     // to re-export the traits and not derives that are called the same in the `std` module, because

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, string::ToString};
 
-use derive_more::{
+use derive_more::with_trait::{
     Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
 };
 
@@ -2454,7 +2454,7 @@ mod type_variables {
     #[allow(unused_imports)]
     use our_alloc::Vec;
 
-    use derive_more::Display;
+    use derive_more::with_trait::Display;
 
     #[derive(Display, Debug)]
     #[display("{inner:?}")]

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,4 +1,4 @@
-use derive_more::Error;
+use derive_more::with_trait::Error;
 
 /// Derives `std::fmt::Display` for structs/enums.
 /// Derived implementation outputs empty string.

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![allow(dead_code)] // some code is tested for type checking only
 
-use derive_more::{
+use derive_more::with_trait::{
     Add, AddAssign, Constructor, Deref, DerefMut, Display, From, FromStr, Index,
     IndexMut, Into, IntoIterator, Mul, MulAssign, Not, Sum, TryInto,
 };

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -77,7 +77,8 @@ enum EnumWithUnit {
 
 #[rustversion::nightly]
 mod error {
-    use derive_more::{Display, Error, From};
+    use derive_more::with_trait::{Display, Error, From};
+
     #[derive(Default, Debug, Display, Error)]
     struct Simple;
 


### PR DESCRIPTION
Resolves #405

As was decided in #405, the crate's root should re-export only macros. Re-exporting of macros along with their corresponding traits should be moved to `with_trait` module.

## Checklist

- [x] Documentation is updated
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
