### PR TITLE
fix: README feature `iterator` does not exist, now `into_iterator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You have to enable each type of derive as a feature in `Cargo.toml`:
 [dependencies]
 # You can specify the types of derives that you need for less time spent
 # compiling. For the full list of features see this crate its `Cargo.toml`.
-derive_more = { version = "1", features = ["from", "add", "iterator"] }
+derive_more = { version = "1", features = ["from", "add", "into_iterator"] }
 ```
 ```toml
 [dependencies]


### PR DESCRIPTION
Resolves <!-- paste issue reference -->
<!-- and/or -->
Part of <!-- paste issue/PR reference -->
<!-- and/or -->
Required for <!-- paste issues/PRs references -->
<!-- and/or -->
Requires <!-- paste issues/PRs references -->
<!-- and/or -->
Related to <!-- paste issues/PRs references -->

<!-- Remove the lines above if there are no related issues/PRs -->

## Synopsis

<!-- Give a brief overview of the problem -->

## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

## Checklist

- [ ] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [ ] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
