### PR TITLE
Test `full` feature separately on CI

### DIFF
--- a/ci/test_all_features.sh
+++ b/ci/test_all_features.sh
@@ -7,6 +7,6 @@ fi
 
 set -euxo pipefail
 
-for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|full\|testing-helpers'); do
+for feature in $(tomljson Cargo.toml | jq --raw-output '.features | keys[]' | grep -v 'default\|std\|testing-helpers'); do
     RUSTFLAGS='-D warnings' cargo +nightly test -p derive_more --tests --no-default-features --features "$feature$std,testing-helpers"
 done

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::ToString as _, vec::Vec};
+
 use derive_more::{
     Add, AddAssign, Binary, BitAnd, BitOr, BitXor, Constructor, Deref, DerefMut,
     Display, Div, From, FromStr, Index, IndexMut, Into, IntoIterator, Mul, MulAssign,


### PR DESCRIPTION
Resolves #420

## Synopsis

`cargo test --no-default-features --features=full` fails imposing problems on other CIs.

See #420 for more context.

## Solution

- Consider testing `full` Cargo feature in `test-features` CI job to handle such regressions.
- Update the relevant tests to run under `no_std` too.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] ~~[CHANGELOG entry](/CHANGELOG.md) is added~~ (not required)
