### PR TITLE
Make strings in error types public

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -8,7 +8,7 @@ use crate::UnitError;
 /// operation is invoked on mismatched enum variants.
 #[derive(Clone, Copy, Debug)]
 pub struct WrongVariantError {
-    operation_name: &'static str,
+    pub operation_name: &'static str,
 }
 
 impl WrongVariantError {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -61,8 +61,8 @@ mod try_into {
         ///
         /// [`TryInto`]: macro@crate::TryInto
         pub input: T,
-        variant_names: &'static str,
-        output_type: &'static str,
+        pub variant_names: &'static str,
+        pub output_type: &'static str,
     }
 
     impl<T> TryIntoError<T> {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -6,7 +6,7 @@ use core::fmt;
 /// operation is invoked on a unit-like variant of an enum.
 #[derive(Clone, Copy, Debug)]
 pub struct UnitError {
-    operation_name: &'static str,
+    pub operation_name: &'static str,
 }
 
 impl UnitError {

--- a/src/str.rs
+++ b/src/str.rs
@@ -3,7 +3,7 @@ use core::fmt;
 /// Error of parsing an enum value its string representation.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FromStrError {
-    type_name: &'static str,
+    pub type_name: &'static str,
 }
 
 impl FromStrError {

--- a/src/try_unwrap.rs
+++ b/src/try_unwrap.rs
@@ -8,9 +8,9 @@ pub struct TryUnwrapError<T> {
     ///
     /// [`TryUnwrap`]: macro@crate::TryUnwrap
     pub input: T,
-    enum_name: &'static str,
-    variant_name: &'static str,
-    func_name: &'static str,
+    pub enum_name: &'static str,
+    pub variant_name: &'static str,
+    pub func_name: &'static str,
 }
 
 impl<T> TryUnwrapError<T> {


### PR DESCRIPTION
## Synopsis

Can't access strings in error types, useful for mapping to another error type or if you want to change the Display impl

## Solution

Make strings in the dedicated error type structs (FromStrError, TryIntoError etc.) public.

## Checklist

none are applicable, I think

- [ ] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [ ] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
