### PR TITLE
Fix raw identifiers usage in `Display`/`Debug` derives (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Top-level `#[display("...")]` attribute on an enum being incorrectly treated
   as transparent or wrapping.
   ([#395](https://github.com/JelteF/derive_more/pull/395))
+- Omitted raw identifiers in `Debug` and `Display` expansions.
+  ([#431](https://github.com/JelteF/derive_more/pull/431))
 
 
 ## 1.0.0 - 2024-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#395](https://github.com/JelteF/derive_more/pull/395))
 - Omitted raw identifiers in `Debug` and `Display` expansions.
   ([#431](https://github.com/JelteF/derive_more/pull/431))
+- Incorrect rendering of raw identifiers as field names in `Debug` expansions.
+  ([#431](https://github.com/JelteF/derive_more/pull/431))
 
 
 ## 1.0.0 - 2024-08-07

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -339,7 +339,7 @@ impl Expansion<'_> {
                     let field_ident = field.ident.as_ref().unwrap_or_else(|| {
                         unreachable!("`syn::Fields::Named`");
                     });
-                    let field_str = field_ident.to_string();
+                    let field_str = field_ident.unraw().to_string();
                     match FieldAttribute::parse_attrs(&field.attrs, self.attr_name)?
                         .map(Spanning::into_inner)
                     {

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -292,12 +292,15 @@ impl Expansion<'_> {
 
                     quote! { &derive_more::core::format_args!(#fmt, #(#deref_args),*) }
                 } else if let Some((expr, trait_ident)) = fmt.transparent_call() {
-                    let expr =
-                        if self.fields.fmt_args_idents().any(|field| expr == field) {
-                            quote! { #expr }
-                        } else {
-                            quote! { &(#expr) }
-                        };
+                    let expr = if let Some(field) = self
+                        .fields
+                        .fmt_args_idents()
+                        .find(|field| expr == *field || expr == field.unraw())
+                    {
+                        quote! { #field }
+                    } else {
+                        quote! { &(#expr) }
+                    };
 
                     quote! { derive_more::core::fmt::#trait_ident::fmt(#expr, __derive_more_f) }
                 } else {

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -8,10 +8,6 @@ pub(crate) mod debug;
 pub(crate) mod display;
 mod parsing;
 
-use crate::{
-    parsing::Expr,
-    utils::{attr, Either, Spanning},
-};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{
@@ -20,6 +16,11 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned as _,
     token,
+};
+
+use crate::{
+    parsing::Expr,
+    utils::{attr, Either, Spanning},
 };
 
 /// Representation of a `bound` macro attribute, expressing additional trait bounds.

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -8,18 +8,18 @@ pub(crate) mod debug;
 pub(crate) mod display;
 mod parsing;
 
+use crate::{
+    parsing::Expr,
+    utils::{attr, Either, Spanning},
+};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{
+    ext::IdentExt as _,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned as _,
     token,
-};
-
-use crate::{
-    parsing::Expr,
-    utils::{attr, Either, Spanning},
 };
 
 /// Representation of a `bound` macro attribute, expressing additional trait bounds.
@@ -140,7 +140,7 @@ impl FmtAttribute {
     /// Checks whether this [`FmtAttribute`] can be replaced with a transparent delegation (calling
     /// a formatting trait directly instead of interpolation syntax).
     ///
-    /// If such transparent call is possible, the returns an [`Ident`] of the delegated trait and
+    /// If such transparent call is possible, then returns an [`Ident`] of the delegated trait and
     /// the [`Expr`] to pass into the call, otherwise [`None`].
     ///
     /// [`Ident`]: struct@syn::Ident
@@ -228,7 +228,10 @@ impl FmtAttribute {
                     f.unnamed.iter().nth(i).map(|f| &f.ty)
                 }
                 (syn::Fields::Named(f), None) => f.named.iter().find_map(|f| {
-                    f.ident.as_ref().filter(|s| **s == name).map(|_| &f.ty)
+                    f.ident
+                        .as_ref()
+                        .filter(|s| s.unraw() == name)
+                        .map(|_| &f.ty)
                 }),
                 _ => None,
             }?;
@@ -291,7 +294,7 @@ impl FmtAttribute {
             .collect::<Vec<_>>();
 
         fields.fmt_args_idents().filter_map(move |field_name| {
-            (used_args.iter().any(|arg| field_name == arg)
+            (used_args.iter().any(|arg| field_name.unraw() == arg)
                 && !self.args.iter().any(|arg| {
                     arg.alias.as_ref().map_or(false, |(n, _)| n == &field_name)
                 }))

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1840,11 +1840,11 @@ mod generic {
         fn assert() {
             assert_eq!(
                 format!("{:?}", StructOne::<u8> { r#thing: 8 }),
-                "StructOne { r#thing: 8 }"
+                "StructOne { thing: 8 }"
             );
             assert_eq!(
                 format!("{:?}", Enum::<u8>::One { r#thing: 8 }),
-                "One { r#thing: 8 }"
+                "One { thing: 8 }"
             );
         }
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1832,19 +1832,37 @@ mod generic {
         }
 
         #[derive(Debug)]
+        struct StructOneKeyword<T> {
+            r#struct: T,
+        }
+
+        #[derive(Debug)]
         enum Enum<T> {
             One { r#thing: T },
+        }
+
+        #[derive(Debug)]
+        enum EnumKeyword<T> {
+            One { r#struct: T },
         }
 
         #[test]
         fn assert() {
             assert_eq!(
                 format!("{:?}", StructOne::<u8> { r#thing: 8 }),
-                "StructOne { thing: 8 }"
+                "StructOne { thing: 8 }",
+            );
+            assert_eq!(
+                format!("{:?}", StructOneKeyword::<u8> { r#struct: 8 }),
+                "StructOneKeyword { struct: 8 }",
             );
             assert_eq!(
                 format!("{:?}", Enum::<u8>::One { r#thing: 8 }),
-                "One { thing: 8 }"
+                "One { thing: 8 }",
+            );
+            assert_eq!(
+                format!("{:?}", EnumKeyword::<u8>::One { r#struct: 8 }),
+                "One { struct: 8 }",
             );
         }
 
@@ -1861,9 +1879,21 @@ mod generic {
             }
 
             #[derive(Debug)]
+            #[debug("{struct}")]
+            struct StructOneKeyword<T> {
+                r#struct: T,
+            }
+
+            #[derive(Debug)]
             enum Enum1<T> {
                 #[debug("{thing}")]
                 One { r#thing: T },
+            }
+
+            #[derive(Debug)]
+            enum Enum1Keyword<T> {
+                #[debug("{struct}")]
+                One { r#struct: T },
             }
 
             #[derive(Debug)]
@@ -1874,21 +1904,50 @@ mod generic {
             }
 
             #[derive(Debug)]
+            #[debug("{pub}:{b}")]
+            struct StructTwoKeyword<A, B> {
+                r#pub: A,
+                b: B,
+            }
+
+            #[derive(Debug)]
             enum Enum2<A, B> {
                 #[debug("{a}:{b}")]
                 Two { r#a: A, b: B },
             }
 
+            #[derive(Debug)]
+            enum Enum2Keyword<A, B> {
+                #[debug("{pub}:{b}")]
+                Two { r#pub: A, b: B },
+            }
+
             #[test]
             fn assert() {
                 assert_eq!(format!("{:?}", StructOne::<u8> { r#thing: 8 }), "8");
+                assert_eq!(
+                    format!("{:?}", StructOneKeyword::<u8> { r#struct: 8 }),
+                    "8",
+                );
                 assert_eq!(format!("{:?}", Enum1::<u8>::One { r#thing: 8 }), "8");
+                assert_eq!(
+                    format!("{:?}", Enum1Keyword::<u8>::One { r#struct: 8 }),
+                    "8",
+                );
                 assert_eq!(
                     format!("{:?}", StructTwo::<u8, u16> { r#a: 8, b: 16 }),
                     "8:16",
                 );
                 assert_eq!(
+                    format!("{:?}", StructTwoKeyword::<u8, u16> { r#pub: 8, b: 16 }),
+                    "8:16",
+                );
+                assert_eq!(
                     format!("{:?}", Enum2::<u8, u16>::Two { r#a: 8, b: 16 }),
+                    "8:16",
+                );
+                assert_eq!(
+                    format!("{:?}", Enum2Keyword::<u8, u16>::Two { r#pub: 8, b: 16 }),
                     "8:16",
                 );
             }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1820,6 +1820,75 @@ mod generic {
         }
     }
 
+    mod raw {
+        use derive_more::Debug;
+
+        #[derive(Debug)]
+        struct StructOne<T> {
+            r#thing: T,
+        }
+
+        #[derive(Debug)]
+        enum Enum<T> {
+            One { r#thing: T },
+        }
+
+        #[test]
+        fn assert() {
+            assert_eq!(
+                format!("{:?}", StructOne::<u8> { r#thing: 8 }),
+                "StructOne { r#thing: 8 }"
+            );
+            assert_eq!(
+                format!("{:?}", Enum::<u8>::One { r#thing: 8 }),
+                "One { r#thing: 8 }"
+            );
+        }
+
+        mod interpolated {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            #[debug("{thing}")]
+            struct StructOne<T> {
+                r#thing: T,
+            }
+
+            #[derive(Debug)]
+            enum Enum1<T> {
+                #[debug("{thing}")]
+                One { r#thing: T },
+            }
+
+            #[derive(Debug)]
+            #[debug("{a}:{b}")]
+            struct StructTwo<A, B> {
+                r#a: A,
+                b: B,
+            }
+
+            #[derive(Debug)]
+            enum Enum2<A, B> {
+                #[debug("{a}:{b}")]
+                Two { r#a: A, b: B },
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(format!("{:?}", StructOne::<u8> { r#thing: 8 }), "8");
+                assert_eq!(format!("{:?}", Enum1::<u8>::One { r#thing: 8 }), "8");
+                assert_eq!(
+                    format!("{:?}", StructTwo::<u8, u16> { r#a: 8, b: 16 }),
+                    "8:16",
+                );
+                assert_eq!(
+                    format!("{:?}", Enum2::<u8, u16>::Two { r#a: 8, b: 16 }),
+                    "8:16",
+                );
+            }
+        }
+    }
+
     mod bound {
         #[cfg(not(feature = "std"))]
         use alloc::format;

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1821,6 +1821,9 @@ mod generic {
     }
 
     mod raw {
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
         use derive_more::Debug;
 
         #[derive(Debug)]
@@ -1846,6 +1849,9 @@ mod generic {
         }
 
         mod interpolated {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+
             use derive_more::Debug;
 
             #[derive(Debug)]

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2021,13 +2021,19 @@ mod generic {
         use super::*;
 
         #[derive(Display)]
-        struct One<T> {
+        struct StructOne<T> {
             r#thing: T,
+        }
+
+        #[derive(Display)]
+        enum Enum<T> {
+            One { r#thing: T },
         }
 
         #[test]
         fn assert() {
-            assert_eq!(One::<u8> { r#thing: 8 }.to_string(), "8");
+            assert_eq!(StructOne::<u8> { r#thing: 8 }.to_string(), "8");
+            assert_eq!(Enum::<u8>::One { r#thing: 8 }.to_string(), "8");
         }
 
         mod interpolated {
@@ -2035,21 +2041,52 @@ mod generic {
 
             #[derive(Display)]
             #[display("{thing}")]
-            struct One<T> {
+            struct StructOne<T> {
                 r#thing: T,
             }
 
             #[derive(Display)]
+            enum Enum1<T> {
+                #[display("{thing}")]
+                One { r#thing: T },
+            }
+
+            #[derive(Display)]
+            #[display("{thing}")]
+            enum Enum1Top<T> {
+                One { r#thing: T },
+            }
+
+            #[derive(Display)]
             #[display("{a}:{b}")]
-            struct Two<A, B> {
+            struct StructTwo<A, B> {
                 r#a: A,
                 b: B,
             }
 
+            #[derive(Display)]
+            enum Enum2<A, B> {
+                #[display("{a}:{b}")]
+                Two { r#a: A, b: B },
+            }
+
+            #[derive(Display)]
+            #[display("{a}:{b}")]
+            enum Enum2Shared<A, B> {
+                Two { r#a: A, b: B },
+            }
+
             #[test]
             fn assert() {
-                assert_eq!(One::<u8> { r#thing: 8 }.to_string(), "8");
-                assert_eq!(Two::<u8, u16> { r#a: 8, b: 16 }.to_string(), "8:16");
+                assert_eq!(StructOne::<u8> { r#thing: 8 }.to_string(), "8");
+                assert_eq!(Enum1::<u8>::One { r#thing: 8 }.to_string(), "8");
+                assert_eq!(Enum1Top::<u8>::One { r#thing: 8 }.to_string(), "8");
+                assert_eq!(StructTwo::<u8, u16> { r#a: 8, b: 16 }.to_string(), "8:16");
+                assert_eq!(Enum2::<u8, u16>::Two { r#a: 8, b: 16 }.to_string(), "8:16");
+                assert_eq!(
+                    Enum2Shared::<u8, u16>::Two { r#a: 8, b: 16 }.to_string(),
+                    "8:16",
+                );
             }
         }
     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2017,6 +2017,43 @@ mod generic {
         }
     }
 
+    mod raw {
+        use super::*;
+
+        #[derive(Display)]
+        struct One<T> {
+            r#thing: T,
+        }
+
+        #[test]
+        fn assert() {
+            assert_eq!(One::<u8> { r#thing: 8 }.to_string(), "8");
+        }
+
+        mod interpolated {
+            use super::*;
+
+            #[derive(Display)]
+            #[display("{thing}")]
+            struct One<T> {
+                r#thing: T,
+            }
+
+            #[derive(Display)]
+            #[display("{a}:{b}")]
+            struct Two<A, B> {
+                r#a: A,
+                b: B,
+            }
+
+            #[test]
+            fn assert() {
+                assert_eq!(One::<u8> { r#thing: 8 }.to_string(), "8");
+                assert_eq!(Two::<u8, u16> { r#a: 8, b: 16 }.to_string(), "8:16");
+            }
+        }
+    }
+
     mod bound {
         use super::*;
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -2026,6 +2026,11 @@ mod generic {
         }
 
         #[derive(Display)]
+        struct StructOneKeyword<T> {
+            r#struct: T,
+        }
+
+        #[derive(Display)]
         enum Enum<T> {
             One { r#thing: T },
         }
@@ -2033,6 +2038,7 @@ mod generic {
         #[test]
         fn assert() {
             assert_eq!(StructOne::<u8> { r#thing: 8 }.to_string(), "8");
+            assert_eq!(StructOneKeyword::<u8> { r#struct: 8 }.to_string(), "8");
             assert_eq!(Enum::<u8>::One { r#thing: 8 }.to_string(), "8");
         }
 
@@ -2046,15 +2052,33 @@ mod generic {
             }
 
             #[derive(Display)]
+            #[display("{struct}")]
+            struct StructOneKeyword<T> {
+                r#struct: T,
+            }
+
+            #[derive(Display)]
             enum Enum1<T> {
                 #[display("{thing}")]
                 One { r#thing: T },
             }
 
             #[derive(Display)]
+            enum Enum1Keyword<T> {
+                #[display("{struct}")]
+                One { r#struct: T },
+            }
+
+            #[derive(Display)]
             #[display("{thing}")]
             enum Enum1Top<T> {
                 One { r#thing: T },
+            }
+
+            #[derive(Display)]
+            #[display("{struct}")]
+            enum Enum1TopKeyword<T> {
+                One { r#struct: T },
             }
 
             #[derive(Display)]
@@ -2065,9 +2089,22 @@ mod generic {
             }
 
             #[derive(Display)]
+            #[display("{pub}:{b}")]
+            struct StructTwoKeyword<A, B> {
+                r#pub: A,
+                b: B,
+            }
+
+            #[derive(Display)]
             enum Enum2<A, B> {
                 #[display("{a}:{b}")]
                 Two { r#a: A, b: B },
+            }
+
+            #[derive(Display)]
+            enum Enum2Keyword<A, B> {
+                #[display("{pub}:{b}")]
+                Two { r#pub: A, b: B },
             }
 
             #[derive(Display)]
@@ -2076,15 +2113,36 @@ mod generic {
                 Two { r#a: A, b: B },
             }
 
+            #[derive(Display)]
+            #[display("{pub}:{b}")]
+            enum Enum2SharedKeyword<A, B> {
+                Two { r#pub: A, b: B },
+            }
+
             #[test]
             fn assert() {
                 assert_eq!(StructOne::<u8> { r#thing: 8 }.to_string(), "8");
+                assert_eq!(StructOneKeyword::<u8> { r#struct: 8 }.to_string(), "8");
                 assert_eq!(Enum1::<u8>::One { r#thing: 8 }.to_string(), "8");
+                assert_eq!(Enum1Keyword::<u8>::One { r#struct: 8 }.to_string(), "8");
                 assert_eq!(Enum1Top::<u8>::One { r#thing: 8 }.to_string(), "8");
+                assert_eq!(Enum1TopKeyword::<u8>::One { r#struct: 8 }.to_string(), "8");
                 assert_eq!(StructTwo::<u8, u16> { r#a: 8, b: 16 }.to_string(), "8:16");
+                assert_eq!(
+                    StructTwoKeyword::<u8, u16> { r#pub: 8, b: 16 }.to_string(),
+                    "8:16",
+                );
                 assert_eq!(Enum2::<u8, u16>::Two { r#a: 8, b: 16 }.to_string(), "8:16");
                 assert_eq!(
+                    Enum2Keyword::<u8, u16>::Two { r#pub: 8, b: 16 }.to_string(),
+                    "8:16",
+                );
+                assert_eq!(
                     Enum2Shared::<u8, u16>::Two { r#a: 8, b: 16 }.to_string(),
+                    "8:16",
+                );
+                assert_eq!(
+                    Enum2SharedKeyword::<u8, u16>::Two { r#pub: 8, b: 16 }.to_string(),
                     "8:16",
                 );
             }


### PR DESCRIPTION
Resolves #431


## Synopsis

See https://github.com/JelteF/derive_more/issues/431#issue-2761055237:
> Both of the following generate a working impl:
> 
> ```rust
> #[derive(Display)]
> #[display("{thing}")]
> struct Struct<T> {
>     thing: T,  // generic
> }
> ```
> 
> ```rust
> #[derive(Display)]
> #[display("{thing}")]
> struct Struct {
>     r#thing: i32,  // raw
> }
> ```
> 
> but this generates an impl that does not compile.
> 
> ```rust
> #[derive(Display)]
> #[display("{thing}")]
> struct Struct<T> {
>     r#thing: T,  // raw, generic
> }
> ```
> 
> ```
> error[E0277]: `T` doesn't implement `derive_more::Display`
>  --> src/main.rs:3:10
>   |
> 3 | #[derive(Display)]
>   |          ^^^^^^^ `T` cannot be formatted with the default formatter
>   |
>   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
>   = note: required for `&T` to implement `derive_more::Display`
>   = note: this error originates in the derive macro `Display` (in Nightly builds, run with -Z macro-backtrace for more info)
> help: consider restricting type parameter `T` with trait `Display`
>   |
> 5 | struct Struct<T: derive_more::Display> {
>   |                ++++++++++++++++++++++
> ```


## Solution

Consider field with raw identifiers correctly in transparency checks and dereferencing.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
