### PR TITLE
Fix unsized fields usage in `derive(Display)` (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Top-level `#[display("...")]` attribute on an enum not working transparently
   for directly specified fields.
   ([#438](https://github.com/JelteF/derive_more/pull/438))
+- Incorrect dereferencing of unsized fields in `Debug` and `Display` expansions.
+  ([#440](https://github.com/JelteF/derive_more/pull/440))
 
 
 ## 1.0.0 - 2024-08-07

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -306,7 +306,9 @@ impl FmtAttribute {
 
     /// Returns an [`Iterator`] over the additional formatting arguments doing the dereferencing
     /// replacement in this [`FmtAttribute`] for those [`Placeholder`] representing the provided
-    /// [`syn::Fields`] and requiring it
+    /// [`syn::Fields`] and requiring it ([`fmt::Pointer`] ones).
+    ///
+    /// [`fmt::Pointer`]: std::fmt::Pointer
     fn additional_deref_args<'fmt: 'ret, 'fields: 'ret, 'ret>(
         &'fmt self,
         fields: &'fields syn::Fields,
@@ -314,7 +316,7 @@ impl FmtAttribute {
         let used_args = Placeholder::parse_fmt_string(&self.lit.value())
             .into_iter()
             .filter_map(|placeholder| match placeholder.arg {
-                Parameter::Named(name) => Some(name),
+                Parameter::Named(name) if placeholder.trait_name == "Pointer" => Some(name),
                 _ => None,
             })
             .collect::<Vec<_>>();

--- a/impl/src/fmt/mod.rs
+++ b/impl/src/fmt/mod.rs
@@ -316,7 +316,9 @@ impl FmtAttribute {
         let used_args = Placeholder::parse_fmt_string(&self.lit.value())
             .into_iter()
             .filter_map(|placeholder| match placeholder.arg {
-                Parameter::Named(name) if placeholder.trait_name == "Pointer" => Some(name),
+                Parameter::Named(name) if placeholder.trait_name == "Pointer" => {
+                    Some(name)
+                }
                 _ => None,
             })
             .collect::<Vec<_>>();

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -419,6 +419,84 @@ mod structs {
             }
         }
 
+        mod r#unsized {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+            use core::ptr;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            struct Tuple(str);
+
+            #[derive(Debug)]
+            struct Struct {
+                tail: str,
+            }
+
+            #[test]
+            fn assert() {
+                let dat = "14";
+
+                let t =
+                    unsafe { &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple) };
+                assert_eq!(format!("{t:?}"), r#"Tuple("14")"#);
+                let s =
+                    unsafe { &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct) };
+                assert_eq!(format!("{s:?}"), r#"Struct { tail: "14" }"#);
+            }
+
+            mod interpolated {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+                use core::ptr;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                #[debug("{}.", _0)]
+                struct Tuple1(str);
+
+                #[derive(Debug)]
+                #[debug("{_0}.")]
+                struct Tuple2(str);
+
+                #[derive(Debug)]
+                #[debug("{}.", tail)]
+                struct Struct1 {
+                    tail: str,
+                }
+
+                #[derive(Debug)]
+                #[debug("{tail}.")]
+                struct Struct2 {
+                    tail: str,
+                }
+
+                #[test]
+                fn assert() {
+                    let dat = "14";
+
+                    let t1 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple1)
+                    };
+                    assert_eq!(format!("{t1:?}"), "14.");
+                    let t2 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple2)
+                    };
+                    assert_eq!(format!("{t2:?}"), "14.");
+                    let s1 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct1)
+                    };
+                    assert_eq!(format!("{s1:?}"), "14.");
+                    let s2 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct2)
+                    };
+                    assert_eq!(format!("{s2:?}"), "14.");
+                }
+            }
+        }
+
         #[cfg(nightly)]
         mod never {
             use derive_more::Debug;
@@ -688,6 +766,87 @@ mod structs {
                     format!("{:.1?}", StructLowerExp { a: 7, b: 3.15 }),
                     "3.1e0",
                 );
+            }
+        }
+
+        mod r#unsized {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+            use core::ptr;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            struct Tuple(char, str);
+
+            #[derive(Debug)]
+            struct Struct {
+                head: char,
+                tail: str,
+            }
+
+            #[test]
+            fn assert() {
+                let dat = [51i32, 3028017];
+
+                let t =
+                    unsafe { &*(ptr::addr_of!(dat) as *const [i32] as *const Tuple) };
+                assert_eq!(format!("{t:?}"), r#"Tuple('3', "14")"#);
+                let s =
+                    unsafe { &*(ptr::addr_of!(dat) as *const [i32] as *const Struct) };
+                assert_eq!(format!("{s:?}"), r#"Struct { head: '3', tail: "14" }"#);
+            }
+
+            mod interpolated {
+                #[cfg(not(feature = "std"))]
+                use alloc::format;
+                use core::ptr;
+
+                use derive_more::Debug;
+
+                #[derive(Debug)]
+                #[debug("{}.{}", _0, _1)]
+                struct Tuple1(char, str);
+
+                #[derive(Debug)]
+                #[debug("{_0}.{_1}")]
+                struct Tuple2(char, str);
+
+                #[derive(Debug)]
+                #[debug("{}.{}", head, tail)]
+                struct Struct1 {
+                    head: char,
+                    tail: str,
+                }
+
+                #[derive(Debug)]
+                #[debug("{head}.{tail}")]
+                struct Struct2 {
+                    head: char,
+                    tail: str,
+                }
+
+                #[test]
+                fn assert() {
+                    let dat = [51i32, 3028017];
+
+                    let t1 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Tuple1)
+                    };
+                    assert_eq!(format!("{t1:?}"), "3.14");
+                    let t2 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Tuple2)
+                    };
+                    assert_eq!(format!("{t2:?}"), "3.14");
+                    let s1 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Struct1)
+                    };
+                    assert_eq!(format!("{s1:?}"), "3.14");
+                    let s2 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Struct2)
+                    };
+                    assert_eq!(format!("{s2:?}"), "3.14");
+                }
             }
         }
 
@@ -2175,6 +2334,85 @@ mod generic {
                         "1.23457",
                     );
                 }
+            }
+        }
+    }
+
+    mod r#unsized {
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+        use core::ptr;
+
+        use derive_more::Debug;
+
+        #[derive(Debug)]
+        struct Tuple<T: ?Sized>(T);
+
+        #[derive(Debug)]
+        struct Struct<T: ?Sized> {
+            tail: T,
+        }
+
+        #[test]
+        fn assert() {
+            let dat = "14";
+
+            let t =
+                unsafe { &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple<str>) };
+            assert_eq!(format!("{t:?}"), r#"Tuple("14")"#);
+            let s = unsafe {
+                &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct<str>)
+            };
+            assert_eq!(format!("{s:?}"), r#"Struct { tail: "14" }"#);
+        }
+
+        mod interpolated {
+            #[cfg(not(feature = "std"))]
+            use alloc::format;
+            use core::ptr;
+
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            #[debug("{}.", _0)]
+            struct Tuple1<T: ?Sized>(T);
+
+            #[derive(Debug)]
+            #[debug("{_0}.")]
+            struct Tuple2<T: ?Sized>(T);
+
+            #[derive(Debug)]
+            #[debug("{}.", tail)]
+            struct Struct1<T: ?Sized> {
+                tail: T,
+            }
+
+            #[derive(Debug)]
+            #[debug("{tail}.")]
+            struct Struct2<T: ?Sized> {
+                tail: T,
+            }
+
+            #[test]
+            fn assert() {
+                let dat = "14";
+
+                let t1 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple1<str>)
+                };
+                assert_eq!(format!("{t1:?}"), "14.");
+                let t2 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple2<str>)
+                };
+                assert_eq!(format!("{t2:?}"), "14.");
+                let s1 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct1<str>)
+                };
+                assert_eq!(format!("{s1:?}"), "14.");
+                let s2 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct2<str>)
+                };
+                assert_eq!(format!("{s2:?}"), "14.");
             }
         }
     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -697,6 +697,54 @@ mod structs {
             }
         }
 
+        mod r#unsized {
+            use super::*;
+
+            mod interpolated {
+                use super::*;
+
+                #[derive(Display)]
+                #[display("{}.{}", _0, _1)]
+                struct Tuple1(char, str);
+
+                #[derive(Display)]
+                #[display("{_0}.{_1}")]
+                struct Tuple2(char, str);
+
+                #[derive(Display)]
+                #[display("{}.{}", head, tail)]
+                struct Struct1 {
+                    head: char,
+                    tail: str,
+                }
+
+                #[derive(Display)]
+                #[display("{head}.{tail}")]
+                struct Struct2 {
+                    head: char,
+                    tail: str,
+                }
+
+                #[test]
+                fn assert() {
+                    let dat = [51i32, 3028017];
+
+                    let t1 =
+                        unsafe { &*(&raw const dat as *const [i32] as *const Tuple1) };
+                    assert_eq!(t1.to_string(), "3.14");
+                    let t2 =
+                        unsafe { &*(&raw const dat as *const [i32] as *const Tuple2) };
+                    assert_eq!(t2.to_string(), "3.14");
+                    let s1 =
+                        unsafe { &*(&raw const dat as *const [i32] as *const Struct1) };
+                    assert_eq!(s1.to_string(), "3.14");
+                    let s2 =
+                        unsafe { &*(&raw const dat as *const [i32] as *const Struct2) };
+                    assert_eq!(s2.to_string(), "3.14");
+                }
+            }
+        }
+
         #[cfg(nightly)]
         mod never {
             use super::*;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -701,6 +701,8 @@ mod structs {
             use super::*;
 
             mod interpolated {
+                use core::ptr;
+
                 use super::*;
 
                 #[derive(Display)]
@@ -729,17 +731,21 @@ mod structs {
                 fn assert() {
                     let dat = [51i32, 3028017];
 
-                    let t1 =
-                        unsafe { &*(&raw const dat as *const [i32] as *const Tuple1) };
+                    let t1 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Tuple1)
+                    };
                     assert_eq!(t1.to_string(), "3.14");
-                    let t2 =
-                        unsafe { &*(&raw const dat as *const [i32] as *const Tuple2) };
+                    let t2 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Tuple2)
+                    };
                     assert_eq!(t2.to_string(), "3.14");
-                    let s1 =
-                        unsafe { &*(&raw const dat as *const [i32] as *const Struct1) };
+                    let s1 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Struct1)
+                    };
                     assert_eq!(s1.to_string(), "3.14");
-                    let s2 =
-                        unsafe { &*(&raw const dat as *const [i32] as *const Struct2) };
+                    let s2 = unsafe {
+                        &*(ptr::addr_of!(dat) as *const [i32] as *const Struct2)
+                    };
                     assert_eq!(s2.to_string(), "3.14");
                 }
             }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -530,6 +530,80 @@ mod structs {
             }
         }
 
+        mod r#unsized {
+            use core::ptr;
+
+            use super::*;
+
+            #[derive(Display)]
+            struct Tuple(str);
+
+            #[derive(Display)]
+            struct Struct {
+                tail: str,
+            }
+
+            #[test]
+            fn assert() {
+                let dat = "14";
+
+                let t =
+                    unsafe { &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple) };
+                assert_eq!(t.to_string(), "14");
+                let s =
+                    unsafe { &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct) };
+                assert_eq!(s.to_string(), "14");
+            }
+
+            mod interpolated {
+                use core::ptr;
+
+                use super::*;
+
+                #[derive(Display)]
+                #[display("{}.", _0)]
+                struct Tuple1(str);
+
+                #[derive(Display)]
+                #[display("{_0}.")]
+                struct Tuple2(str);
+
+                #[derive(Display)]
+                #[display("{}.", tail)]
+                struct Struct1 {
+                    tail: str,
+                }
+
+                #[derive(Display)]
+                #[display("{tail}.")]
+                struct Struct2 {
+                    tail: str,
+                }
+
+                #[test]
+                fn assert() {
+                    let dat = "14";
+
+                    let t1 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple1)
+                    };
+                    assert_eq!(t1.to_string(), "14.");
+                    let t2 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple2)
+                    };
+                    assert_eq!(t2.to_string(), "14.");
+                    let s1 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct1)
+                    };
+                    assert_eq!(s1.to_string(), "14.");
+                    let s2 = unsafe {
+                        &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct2)
+                    };
+                    assert_eq!(s2.to_string(), "14.");
+                }
+            }
+        }
+
         #[cfg(nightly)]
         mod never {
             use super::*;
@@ -3020,6 +3094,81 @@ mod generic {
                         "1.23457",
                     );
                 }
+            }
+        }
+    }
+
+    mod r#unsized {
+        use core::ptr;
+
+        use super::*;
+
+        #[derive(Display)]
+        struct Tuple<T: ?Sized>(T);
+
+        #[derive(Display)]
+        struct Struct<T: ?Sized> {
+            tail: T,
+        }
+
+        #[test]
+        fn assert() {
+            let dat = "14";
+
+            let t =
+                unsafe { &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple<str>) };
+            assert_eq!(t.to_string(), "14");
+            let s = unsafe {
+                &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct<str>)
+            };
+            assert_eq!(s.to_string(), "14");
+        }
+
+        mod interpolated {
+            use core::ptr;
+
+            use super::*;
+
+            #[derive(Display)]
+            #[display("{}.", _0)]
+            struct Tuple1<T: ?Sized>(T);
+
+            #[derive(Display)]
+            #[display("{_0}.")]
+            struct Tuple2<T: ?Sized>(T);
+
+            #[derive(Display)]
+            #[display("{}.", tail)]
+            struct Struct1<T: ?Sized> {
+                tail: T,
+            }
+
+            #[derive(Display)]
+            #[display("{tail}.")]
+            struct Struct2<T: ?Sized> {
+                tail: T,
+            }
+
+            #[test]
+            fn assert() {
+                let dat = "14";
+
+                let t1 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple1<str>)
+                };
+                assert_eq!(t1.to_string(), "14.");
+                let t2 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Tuple2<str>)
+                };
+                assert_eq!(t2.to_string(), "14.");
+                let s1 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct1<str>)
+                };
+                assert_eq!(s1.to_string(), "14.");
+                let s2 = unsafe {
+                    &*(ptr::addr_of!(*dat) as *const [i32] as *const Struct2<str>)
+                };
+                assert_eq!(s2.to_string(), "14.");
             }
         }
     }


### PR DESCRIPTION
Resolves #432

## Synopsis

See https://github.com/JelteF/derive_more/issues/432#issue-2761083580:
> ```rust
> use derive_more::Display;
> 
> #[derive(Display, Debug)]
> #[display("{head}.{tail}")]
> struct Struct {
>     head: char,
>     tail: str,
> }
> 
> fn main() {
>     let dat = [51i32, 3028017];
>     let s = unsafe { &*(&raw const dat as *const [i32] as *const Struct) };
>     println!("{:?}", s);
>     println!("{}", s);
> }
> ```
> 
> The derived Debug impl prints `Struct { head: '3', tail: "14" }` but the Display impl does not compile.
> 
> ```
> error[E0277]: the size for values of type `str` cannot be known at compilation time
>    --> src/main.rs:3:10
>     |
> 3   | #[derive(Display, Debug)]
>     |          ^^^^^^^ doesn't have a size known at compile-time
> 4   | #[display("{head}.{tail}")]
>     |                   ------ required by a bound introduced by this call
>     |
>     = help: the trait `Sized` is not implemented for `str`
> note: required by an implicit `Sized` bound in `derive_more::core::fmt::rt::Argument::<'_>::new_display`
>    --> $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/rt.rs:113:24
>     |
> 113 |     pub fn new_display<T: Display>(x: &T) -> Argument<'_> {
>     |                        ^ required by the implicit `Sized` requirement on this type parameter in `Argument::<'_>::new_display`
>     = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the derive macro `Display` (in Nightly builds, run with -Z macro-backtrace for more info)
> ```

The problem is introduced by #381, and its cause is that the [`FmtAttribute::additional_deref_args()`](https://github.com/JelteF/derive_more/blob/v1.0.0/impl/src/fmt/mod.rs#L281-L300) implementation is too aggressive and is enabled for any `fmt` trait, not just `fmt::Pointer`.
```rust
#[allow(unreachable_code)]
#[automatically_derived]
impl derive_more::core::fmt::Display for Struct2 {
    fn fmt(&self, __derive_more_f: &mut derive_more::core::fmt::Formatter<'_>) -> derive_more::core::fmt::Result {
        let head = &self.head;
        let tail = &self.tail;
        derive_more::core::write!(__derive_more_f, "{head}.{tail}", head = *head, tail = *tail)
    }
}
```




## Solution

Apply `FmtAttribute::additional_deref_args()` only for `fmt::Pointer` placeholders.




## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
