### PR TITLE
Add Rust Playground metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ github = { repository = "JelteF/derive_more", workflow = "CI" }
 features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.playground]
+features = ["full", "std"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(nightly)"] }
 


### PR DESCRIPTION
derive_more is being pulled into the playground due to being a
dependency of some other crate in the top 100 crates, probably
<https://docs.rs/selectors>.

This adds metadata so that it gets installed with all features once
selectors updates to derive_more 2.0
