### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.1 - 2025-02-03
+
+### Added
+
+- Add crate metadata for the Rust Playground. This makes sure that the Rust
+Playground will have all derive_more features available once [selectors](https://docs.rs/selectors/latest/selectors/)
+updates their derive_more version.
+([#445](https://github.com/JelteF/derive_more/pull/445))
 
 ## 2.0.0 - 2025-02-03
 
@@ -40,6 +48,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Incorrect dereferencing of unsized fields in `Debug` and `Display` expansions.
   ([#440](https://github.com/JelteF/derive_more/pull/440))
 
+## 0.99.19 - 2025-02-03
+
+- Add Rust Playground metadata
 
 ## 1.0.0 - 2024-08-07
 
@@ -167,6 +178,11 @@ to call out, but there are many more changes that are documented below:
   `Debug`. Also document weirdness around `Pointer` formatting when using
   expressions, due to field variables being references.
   ([#381](https://github.com/JelteF/derive_more/pull/381))
+
+## 0.99.18 - 2024-06-15
+
+- Update syn to version 2.x
+- Bump minimum supported rust version to 1.65
 
 ## 0.99.10 - 2020-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add crate metadata for the Rust Playground. This makes sure that the Rust
-Playground will have all derive_more features available once [selectors](https://docs.rs/selectors/latest/selectors/)
-updates their derive_more version.
+Playground will have all `derive_more` features available once
+[`selectors`](https://docs.rs/selectors/latest/selectors) crate updates its
+`derive_more` version.
 ([#445](https://github.com/JelteF/derive_more/pull/445))
 
 ## 2.0.0 - 2025-02-03
@@ -50,7 +51,7 @@ updates their derive_more version.
 
 ## 0.99.19 - 2025-02-03
 
-- Add Rust Playground metadata
+- Add crate metadata for the Rust Playground.
 
 ## 1.0.0 - 2024-08-07
 
@@ -181,8 +182,8 @@ to call out, but there are many more changes that are documented below:
 
 ## 0.99.18 - 2024-06-15
 
-- Update syn to version 2.x
-- Bump minimum supported rust version to 1.65
+- Upgrade to `syn` 2.0.
+- The minimum supported Rust version (MSRV) is now Rust 1.65.
 
 ## 0.99.10 - 2020-09-11
 


### PR DESCRIPTION
This starts including 0.99.18, 0.99.19, and 2.0.1 changelogs.
