### PR TITLE
Run tests dependent on endianess under `cfg` (#451)

### DIFF
--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -769,6 +769,7 @@ mod structs {
             }
         }
 
+        #[cfg(target_endian = "little")]
         mod r#unsized {
             #[cfg(not(feature = "std"))]
             use alloc::format;

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -771,6 +771,7 @@ mod structs {
             }
         }
 
+        #[cfg(target_endian = "little")]
         mod r#unsized {
             use super::*;
 


### PR DESCRIPTION
Resolves #451

## Synopsis

See https://github.com/JelteF/derive_more/issues/451#issue-2944740767:

> I am working on updating the Fedora Linux packages for this crate, and encountered some new test failures on the s390x-unknown-linux-gnu build target (our only supported big-endian architecture).
> 
> From `tests/debug.rs`:
> 
> ```
> ---- structs::multi_field::r#unsized::assert stdout ----
> thread 'structs::multi_field::r#unsized::assert' panicked at tests/debug.rs:794:17:
> assertion `left == right` failed
>   left: "Tuple('3', \"\\0.\")"
>  right: "Tuple('3', \"14\")"
> 
> ---- structs::multi_field::r#unsized::interpolated::assert stdout ----
> thread 'structs::multi_field::r#unsized::interpolated::assert' panicked at tests/debug.rs:836:21:
> assertion `left == right` failed
>   left: "3.\0."
>  right: "3.14"
> ```
> 
> And from `tests/display.rs`:
> 
> ```
> ---- structs::multi_field::r#unsized::interpolated::assert stdout ----
> thread 'structs::multi_field::r#unsized::interpolated::assert' panicked at tests/display.rs:811:21:
> assertion `left == right` failed
>   left: "3.\0."
>  right: "3.14"
> ```

> These all have some fixed "bytes" as input for tests which appear to be hard-coded in little-endian byte order.

## Solution

Let's just gate those tests under `#[cfg(target_endian = "little")]` was suggested in the issue.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] ~~[CHANGELOG entry](/CHANGELOG.md) is added~~ (not required)
