### PR TITLE
Fix compiling error on wasm32-none

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
         feature = "from",
         feature = "into"
     ),
-    doc = include_str!("../README.md")
+    doc = core::include_str!("../README.md")
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]


### PR DESCRIPTION
## Synopsis

When compiling on `wasm32-none` target, it fails with the error
```
  error[E0463]: can't find crate for `std`
    |
    = note: the `wasm32v1-none` target may not support the standard library
    = note: `std` is required by `derive_more` because it does not declare `#![no_std]`

  error: cannot find macro `include_str` in this scope
    --> /Users/jasl/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/derive_more-1.0.0/src/lib.rs:42:11
     |
  42 |     doc = include_str!("../README.md")
     |           ^^^^^^^^^^^
     |
  help: consider importing one of these macros
     |
  53 + use crate::core::include_str;
     |
  53 + use core::include_str;
```

## Solution

Follow the help suggestion

## Checklist

- [ ] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [ ] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
