### PR TITLE
 fix: Ignore deprecation warnings on generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   implicit naming of unit enum variants or unit structs when deriving `Display`.
   ([#443](https://github.com/JelteF/derive_more/pull/443))
 
+### Fixed
+
+- Ignore deprecation warnings on generated code. ([#454](https://github.com/JelteF/derive_more/pull/454))
+
 ## 2.0.1 - 2025-02-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Ignore deprecation warnings on generated code. ([#454](https://github.com/JelteF/derive_more/pull/454))
+- Suppress deprecation warnings in generated code.
+  ([#454](https://github.com/JelteF/derive_more/pull/454))
 
 ## 2.0.1 - 2025-02-03
 

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -281,6 +281,7 @@ impl ToTokens for Expansion<'_> {
 
             quote! {
                 #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+                #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                 #[automatically_derived]
                 impl #impl_gens #trait_ty for #ty_ident #ty_gens #where_clause {
                     #[inline]

--- a/impl/src/as/mod.rs
+++ b/impl/src/as/mod.rs
@@ -280,8 +280,8 @@ impl ToTokens for Expansion<'_> {
             };
 
             quote! {
+                #[allow(deprecated)] // omit warnings on deprecated fields/variants
                 #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-                #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                 #[automatically_derived]
                 impl #impl_gens #trait_ty for #ty_ident #ty_gens #where_clause {
                     #[inline]

--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -27,6 +27,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
     quote! {
         #[allow(missing_docs)]
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
             #[inline]

--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -25,9 +25,9 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
     };
     let original_types = &get_field_types(&fields);
     quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(missing_docs)]
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
             #[inline]

--- a/impl/src/deref.rs
+++ b/impl/src/deref.rs
@@ -43,6 +43,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     Ok(quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             type Target = #target;

--- a/impl/src/deref.rs
+++ b/impl/src/deref.rs
@@ -42,8 +42,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             type Target = #target;

--- a/impl/src/deref_mut.rs
+++ b/impl/src/deref_mut.rs
@@ -33,8 +33,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]

--- a/impl/src/deref_mut.rs
+++ b/impl/src/deref_mut.rs
@@ -34,6 +34,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     Ok(quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics #trait_path for #input_type #ty_generics #where_clause {
             #[inline]

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -60,8 +60,8 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
     };
 
     Ok(quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_gens derive_more::core::fmt::Debug for #ident #ty_gens #where_clause {
             #[inline]

--- a/impl/src/fmt/debug.rs
+++ b/impl/src/fmt/debug.rs
@@ -61,6 +61,7 @@ pub fn expand(input: &syn::DeriveInput, _: &str) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_gens derive_more::core::fmt::Debug for #ident #ty_gens #where_clause {
             #[inline]

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -70,6 +70,7 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
 
     Ok(quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_gens derive_more::core::fmt::#trait_ident for #ident #ty_gens #where_clause {
             fn fmt(

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -69,8 +69,8 @@ pub fn expand(input: &syn::DeriveInput, trait_name: &str) -> syn::Result<TokenSt
     };
 
     Ok(quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_gens derive_more::core::fmt::#trait_ident for #ident #ty_gens #where_clause {
             fn fmt(

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -172,8 +172,8 @@ impl Expansion<'_> {
                     });
 
                     Ok(quote! {
+                        #[allow(deprecated)] // omit warnings on deprecated fields/variants
                         #[allow(unreachable_code)] // omit warnings for `!` and unreachable types
-                        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                         #[automatically_derived]
                         impl #impl_gens derive_more::core::convert::From<#ty>
                          for #ident #ty_gens #where_clause {
@@ -195,8 +195,8 @@ impl Expansion<'_> {
                 });
 
                 Ok(quote! {
+                    #[allow(deprecated)] // omit warnings on deprecated fields/variants
                     #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-                    #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                     #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<(#( #field_tys ),*)>
                      for #ident #ty_gens #where_clause {
@@ -241,8 +241,8 @@ impl Expansion<'_> {
                 let (impl_gens, _, where_clause) = generics.split_for_impl();
 
                 Ok(quote! {
+                    #[allow(deprecated)] // omit warnings on deprecated fields/variants
                     #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-                    #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                     #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<(#( #gen_idents ),*)>
                      for #ident #ty_gens #where_clause {

--- a/impl/src/from.rs
+++ b/impl/src/from.rs
@@ -173,6 +173,7 @@ impl Expansion<'_> {
 
                     Ok(quote! {
                         #[allow(unreachable_code)] // omit warnings for `!` and unreachable types
+                        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                         #[automatically_derived]
                         impl #impl_gens derive_more::core::convert::From<#ty>
                          for #ident #ty_gens #where_clause {
@@ -195,6 +196,7 @@ impl Expansion<'_> {
 
                 Ok(quote! {
                     #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+                    #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                     #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<(#( #field_tys ),*)>
                      for #ident #ty_gens #where_clause {
@@ -240,6 +242,7 @@ impl Expansion<'_> {
 
                 Ok(quote! {
                     #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+                    #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                     #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<(#( #gen_idents ),*)>
                      for #ident #ty_gens #where_clause {

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -179,6 +179,7 @@ impl Expansion<'_> {
 
                 Ok(quote! {
                     #[allow(clippy::unused_unit)]
+                    #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                     #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
                      for ( #( #r #lf #m #tys ),* ) #where_clause

--- a/impl/src/into.rs
+++ b/impl/src/into.rs
@@ -179,7 +179,7 @@ impl Expansion<'_> {
 
                 Ok(quote! {
                     #[allow(clippy::unused_unit)]
-                    #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
+                    #[allow(deprecated)] // omit warnings on deprecated fields/variants
                     #[automatically_derived]
                     impl #impl_gens derive_more::core::convert::From<#r #lf #m #input_ident #ty_gens>
                      for ( #( #r #lf #m #tys ),* ) #where_clause

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -53,8 +53,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/is_variant.rs
+++ b/impl/src/is_variant.rs
@@ -54,6 +54,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let imp = quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -35,8 +35,8 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
     };
 
     quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics derive_more::core::ops::#trait_ident
          for #input_type #ty_generics #where_clause {

--- a/impl/src/not_like.rs
+++ b/impl/src/not_like.rs
@@ -36,6 +36,7 @@ pub fn expand(input: &DeriveInput, trait_name: &str) -> TokenStream {
 
     quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #impl_generics derive_more::core::ops::#trait_ident
          for #input_type #ty_generics #where_clause {

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -128,6 +128,7 @@ impl ToTokens for Expansion {
                 type Error = #error;
 
                 #[allow(non_upper_case_globals)]
+                #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                 #[inline]
                 fn try_from(val: #repr_ty) -> derive_more::core::result::Result<Self, #error> {
                     #( const #consts: #repr_ty = #discriminants; )*

--- a/impl/src/try_from.rs
+++ b/impl/src/try_from.rs
@@ -127,8 +127,8 @@ impl ToTokens for Expansion {
              for #ident #where_clause {
                 type Error = #error;
 
+                #[allow(deprecated)] // omit warnings on deprecated fields/variants
                 #[allow(non_upper_case_globals)]
-                #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
                 #[inline]
                 fn try_from(val: #repr_ty) -> derive_more::core::result::Result<Self, #error> {
                     #( const #consts: #repr_ty = #discriminants; )*

--- a/impl/src/try_unwrap.rs
+++ b/impl/src/try_unwrap.rs
@@ -123,8 +123,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/try_unwrap.rs
+++ b/impl/src/try_unwrap.rs
@@ -124,6 +124,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let imp = quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/unwrap.rs
+++ b/impl/src/unwrap.rs
@@ -119,6 +119,7 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
 
     let imp = quote! {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/impl/src/unwrap.rs
+++ b/impl/src/unwrap.rs
@@ -118,8 +118,8 @@ pub fn expand(input: &DeriveInput, trait_name: &'static str) -> Result<TokenStre
     }
 
     let imp = quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-        #[allow(deprecated)] // Omit warnings on when a field or variant is deprecated
         #[automatically_derived]
         impl #imp_generics #enum_name #type_generics #where_clause {
             #(#funcs)*

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -432,6 +432,14 @@ mod single_field {
             #[derive(AsMut)]
             struct Nothing(!);
         }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(AsMut)]
+            #[deprecated(note = "reason")]
+            struct Deprecated(i32);
+        }
     }
 
     mod named {
@@ -898,6 +906,17 @@ mod single_field {
             #[derive(AsMut)]
             struct Nothing {
                 first: !,
+            }
+        }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(AsMut)]
+            #[deprecated(note = "reason")]
+            struct Deprecated {
+                #[deprecated(note = "reason")]
+                field: i32,
             }
         }
     }

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -437,8 +437,8 @@ mod single_field {
             use super::*;
 
             #[derive(AsMut)]
-            #[deprecated(note = "reason")]
-            struct Deprecated(i32);
+            #[deprecated(note = "struct")]
+            struct Deprecated(#[deprecated(note = "field")] i32);
         }
     }
 
@@ -913,9 +913,9 @@ mod single_field {
             use super::*;
 
             #[derive(AsMut)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "struct")]
             struct Deprecated {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "field")]
                 field: i32,
             }
         }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -425,6 +425,14 @@ mod single_field {
             #[derive(AsRef)]
             struct Nothing(!);
         }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(AsRef)]
+            #[deprecated(note = "reason")]
+            struct Deprecated(i32);
+        }
     }
 
     mod named {
@@ -891,6 +899,17 @@ mod single_field {
             #[derive(AsRef)]
             struct Nothing {
                 first: !,
+            }
+        }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(AsRef)]
+            #[deprecated(note = "reason")]
+            struct Deprecated {
+                #[deprecated(note = "reason")]
+                field: i32,
             }
         }
     }

--- a/tests/as_ref.rs
+++ b/tests/as_ref.rs
@@ -430,8 +430,8 @@ mod single_field {
             use super::*;
 
             #[derive(AsRef)]
-            #[deprecated(note = "reason")]
-            struct Deprecated(i32);
+            #[deprecated(note = "struct")]
+            struct Deprecated(#[deprecated(note = "field")] i32);
         }
     }
 
@@ -906,9 +906,9 @@ mod single_field {
             use super::*;
 
             #[derive(AsRef)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "struct")]
             struct Deprecated {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "field")]
                 field: i32,
             }
         }

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -58,13 +58,13 @@ mod deprecated {
     use super::*;
 
     #[derive(Constructor)]
-    #[deprecated(note = "reason")]
-    struct Tuple(i32);
+    #[deprecated(note = "struct")]
+    struct Tuple(#[deprecated(note = "field")] i32);
 
     #[derive(Constructor)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "struct")]
     struct Struct {
-        #[deprecated(note = "reason")]
+        #[deprecated(note = "field")]
         field: i32,
     }
 }

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -53,3 +53,18 @@ mod never {
         other: i32,
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(Constructor)]
+    #[deprecated(note = "reason")]
+    struct Tuple(i32);
+
+    #[derive(Constructor)]
+    #[deprecated(note = "reason")]
+    struct Struct {
+        #[deprecated(note = "reason")]
+        field: i32,
+    }
+}

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -514,13 +514,13 @@ mod structs {
             use derive_more::Debug;
 
             #[derive(Debug)]
-            #[deprecated(note = "reason")]
-            struct Tuple(i32);
+            #[deprecated(note = "struct")]
+            struct Tuple(#[deprecated(note = "field")] i32);
 
             #[derive(Debug)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "struct")]
             struct Struct {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "field")]
                 field: i32,
             }
         }
@@ -1198,11 +1198,11 @@ mod enums {
             use derive_more::Debug;
 
             #[derive(Debug)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "enum")]
             enum Enum {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "variant")]
                 Variant {
-                    #[deprecated(note = "reason")]
+                    #[deprecated(note = "field")]
                     field: i32,
                 },
             }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -509,6 +509,21 @@ mod structs {
                 field: !,
             }
         }
+
+        mod deprecated {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            #[deprecated(note = "reason")]
+            struct Tuple(i32);
+
+            #[derive(Debug)]
+            #[deprecated(note = "reason")]
+            struct Struct {
+                #[deprecated(note = "reason")]
+                field: i32,
+            }
+        }
     }
 
     mod multi_field {
@@ -1176,6 +1191,20 @@ mod enums {
             enum Enum {
                 Unnamed(!),
                 Named { field: ! },
+            }
+        }
+
+        mod deprecated {
+            use derive_more::Debug;
+
+            #[derive(Debug)]
+            #[deprecated(note = "reason")]
+            enum Enum {
+                #[deprecated(note = "reason")]
+                Variant {
+                    #[deprecated(note = "reason")]
+                    field: i32,
+                },
             }
         }
     }

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -87,3 +87,18 @@ mod never {
         field: !,
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(Deref)]
+    #[deprecated(note = "reason")]
+    struct Tuple(i32);
+
+    #[derive(Deref)]
+    #[deprecated(note = "reason")]
+    struct Struct {
+        #[deprecated(note = "reason")]
+        field: i32,
+    }
+}

--- a/tests/deref.rs
+++ b/tests/deref.rs
@@ -92,13 +92,13 @@ mod deprecated {
     use super::*;
 
     #[derive(Deref)]
-    #[deprecated(note = "reason")]
-    struct Tuple(i32);
+    #[deprecated(note = "struct")]
+    struct Tuple(#[deprecated(note = "field")] i32);
 
     #[derive(Deref)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "struct")]
     struct Struct {
-        #[deprecated(note = "reason")]
+        #[deprecated(note = "field")]
         field: i32,
     }
 }

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -167,3 +167,38 @@ mod never {
         }
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(DerefMut)]
+    #[deprecated(note = "reason")]
+    struct Tuple(i32);
+
+    // `Deref` implementation is required for `DerefMut`.
+    #[allow(deprecated)]
+    impl ::core::ops::Deref for Tuple {
+        type Target = i32;
+        #[inline]
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[derive(DerefMut)]
+    #[deprecated(note = "reason")]
+    struct Struct {
+        #[deprecated(note = "reason")]
+        field: i32,
+    }
+
+    // `Deref` implementation is required for `DerefMut`.
+    #[allow(deprecated)]
+    impl ::core::ops::Deref for Struct {
+        type Target = i32;
+        #[inline]
+        fn deref(&self) -> &Self::Target {
+            &self.field
+        }
+    }
+}

--- a/tests/deref_mut.rs
+++ b/tests/deref_mut.rs
@@ -172,23 +172,23 @@ mod deprecated {
     use super::*;
 
     #[derive(DerefMut)]
-    #[deprecated(note = "reason")]
-    struct Tuple(i32);
+    #[deprecated(note = "struct")]
+    struct Tuple(#[deprecated(note = "field")] i32);
 
     // `Deref` implementation is required for `DerefMut`.
     #[allow(deprecated)]
     impl ::core::ops::Deref for Tuple {
         type Target = i32;
-        #[inline]
+
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
 
     #[derive(DerefMut)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "struct")]
     struct Struct {
-        #[deprecated(note = "reason")]
+        #[deprecated(note = "field")]
         field: i32,
     }
 
@@ -196,7 +196,7 @@ mod deprecated {
     #[allow(deprecated)]
     impl ::core::ops::Deref for Struct {
         type Target = i32;
-        #[inline]
+
         fn deref(&self) -> &Self::Target {
             &self.field
         }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -621,13 +621,13 @@ mod structs {
             use super::*;
 
             #[derive(Display)]
-            #[deprecated(note = "reason")]
-            struct Tuple(i32);
+            #[deprecated(note = "struct")]
+            struct Tuple(#[deprecated(note = "field")] i32);
 
             #[derive(Display)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "struct")]
             struct Struct {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "field")]
                 field: i32,
             }
         }
@@ -1343,11 +1343,11 @@ mod enums {
             use super::*;
 
             #[derive(Display)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "enum")]
             enum Enum {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "variant")]
                 Deprecated {
-                    #[deprecated(note = "reason")]
+                    #[deprecated(note = "field")]
                     field: i32,
                 },
             }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -616,6 +616,21 @@ mod structs {
                 field: !,
             }
         }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(Display)]
+            #[deprecated(note = "reason")]
+            struct Tuple(i32);
+
+            #[derive(Display)]
+            #[deprecated(note = "reason")]
+            struct Struct {
+                #[deprecated(note = "reason")]
+                field: i32,
+            }
+        }
     }
 
     mod multi_field {
@@ -1321,6 +1336,20 @@ mod enums {
             enum Enum {
                 Unnamed(!),
                 Named { field: ! },
+            }
+        }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(Display)]
+            #[deprecated(note = "reason")]
+            enum Enum {
+                #[deprecated(note = "reason")]
+                Deprecated {
+                    #[deprecated(note = "reason")]
+                    field: i32,
+                },
             }
         }
     }

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -470,6 +470,23 @@ mod structs {
                 field2: i16,
             }
         }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(From)]
+            #[deprecated(note = "reason")]
+            struct Tuple(i32, i16);
+
+            #[derive(From)]
+            #[deprecated(note = "reason")]
+            struct Struct {
+                #[deprecated(note = "reason")]
+                field1: i32,
+                #[deprecated(note = "reason")]
+                field2: i16,
+            }
+        }
     }
 }
 
@@ -1811,6 +1828,20 @@ mod enums {
             enum Enum {
                 Tuple(i8, !),
                 Struct { field1: !, field2: i16 },
+            }
+        }
+
+        mod deprecated {
+            use super::*;
+
+            #[derive(From)]
+            #[deprecated(note = "reason")]
+            enum Enum {
+                #[deprecated(note = "reason")]
+                Deprecated {
+                    #[deprecated(note = "reason")]
+                    field: i32,
+                },
             }
         }
     }

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -475,15 +475,15 @@ mod structs {
             use super::*;
 
             #[derive(From)]
-            #[deprecated(note = "reason")]
-            struct Tuple(i32, i16);
+            #[deprecated(note = "struct")]
+            struct Tuple(i32, #[deprecated(note = "field")] i16);
 
             #[derive(From)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "struct")]
             struct Struct {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "field")]
                 field1: i32,
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "field")]
                 field2: i16,
             }
         }
@@ -1835,11 +1835,11 @@ mod enums {
             use super::*;
 
             #[derive(From)]
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "enum")]
             enum Enum {
-                #[deprecated(note = "reason")]
+                #[deprecated(note = "variant")]
                 Deprecated {
-                    #[deprecated(note = "reason")]
+                    #[deprecated(note = "field")]
                     field: i32,
                 },
             }

--- a/tests/is_variant.rs
+++ b/tests/is_variant.rs
@@ -180,13 +180,13 @@ mod deprecated {
     use super::*;
 
     #[derive(IsVariant)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "enum")]
     enum Enum {
-        #[deprecated(note = "reason")]
-        Tuple(i32),
-        #[deprecated(note = "reason")]
+        #[deprecated(note = "variant")]
+        Tuple(#[deprecated(note = "field")] i32),
+        #[deprecated(note = "variant")]
         Struct {
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "field")]
             field: i32,
         },
     }

--- a/tests/is_variant.rs
+++ b/tests/is_variant.rs
@@ -175,3 +175,19 @@ mod never {
         StructMulti { field: !, other: i32 },
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(IsVariant)]
+    #[deprecated(note = "reason")]
+    enum Enum {
+        #[deprecated(note = "reason")]
+        Tuple(i32),
+        #[deprecated(note = "reason")]
+        Struct {
+            #[deprecated(note = "reason")]
+            field: i32,
+        },
+    }
+}

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -58,3 +58,30 @@ mod never {
         StructMulti { field: !, other: i32 },
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(Not)]
+    #[deprecated(note = "reason")]
+    struct Tuple(i32);
+
+    #[derive(Not)]
+    #[deprecated(note = "reason")]
+    struct Struct {
+        #[deprecated(note = "reason")]
+        field: i32,
+    }
+
+    #[derive(Not)]
+    #[deprecated(note = "reason")]
+    enum Enum {
+        #[deprecated(note = "reason")]
+        Tuple(i32),
+        #[deprecated(note = "reason")]
+        Struct {
+            #[deprecated(note = "reason")]
+            field: i32,
+        },
+    }
+}

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -63,24 +63,24 @@ mod deprecated {
     use super::*;
 
     #[derive(Not)]
-    #[deprecated(note = "reason")]
-    struct Tuple(i32);
+    #[deprecated(note = "struct")]
+    struct Tuple(#[deprecated(note = "field")] i32);
 
     #[derive(Not)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "struct")]
     struct Struct {
-        #[deprecated(note = "reason")]
+        #[deprecated(note = "field")]
         field: i32,
     }
 
     #[derive(Not)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "enum")]
     enum Enum {
-        #[deprecated(note = "reason")]
-        Tuple(i32),
-        #[deprecated(note = "reason")]
+        #[deprecated(note = "variant")]
+        Tuple(#[deprecated(note = "field")] i32),
+        #[deprecated(note = "variant")]
         Struct {
-            #[deprecated(note = "reason")]
+            #[deprecated(note = "field")]
             field: i32,
         },
     }

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -145,11 +145,11 @@ mod deprecated {
     use super::*;
 
     #[derive(TryUnwrap)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "enum")]
     enum Enum {
-        #[deprecated(note = "reason")]
-        Tuple(i32),
-        #[deprecated(note = "reason")]
-        TupleMulti(i32, i32),
+        #[deprecated(note = "variant")]
+        Tuple(#[deprecated(note = "field")] i32),
+        #[deprecated(note = "variant")]
+        TupleMulti(i32, #[deprecated(note = "field")] i32),
     }
 }

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -140,3 +140,16 @@ mod never {
         TupleMulti(i32, !),
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(TryUnwrap)]
+    #[deprecated(note = "reason")]
+    enum Enum {
+        #[deprecated(note = "reason")]
+        Tuple(i32),
+        #[deprecated(note = "reason")]
+        TupleMulti(i32, i32),
+    }
+}

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -129,3 +129,16 @@ mod never {
         TupleMulti(i32, !),
     }
 }
+
+mod deprecated {
+    use super::*;
+
+    #[derive(Unwrap)]
+    #[deprecated(note = "reason")]
+    enum Enum {
+        #[deprecated(note = "reason")]
+        Tuple(i32),
+        #[deprecated(note = "reason")]
+        TupleMulti(i32, i32),
+    }
+}

--- a/tests/unwrap.rs
+++ b/tests/unwrap.rs
@@ -134,11 +134,11 @@ mod deprecated {
     use super::*;
 
     #[derive(Unwrap)]
-    #[deprecated(note = "reason")]
+    #[deprecated(note = "enum")]
     enum Enum {
-        #[deprecated(note = "reason")]
-        Tuple(i32),
-        #[deprecated(note = "reason")]
-        TupleMulti(i32, i32),
+        #[deprecated(note = "variant")]
+        Tuple(#[deprecated(note = "field")] i32),
+        #[deprecated(note = "variant")]
+        TupleMulti(i32, #[deprecated(note = "field")] i32),
     }
 }


### PR DESCRIPTION
Resolves #419

## Synopsis

Deprecating a field or variant doesn't produced un-ignorable warnings in the code generated  by derive_more (the only solution was to globally `#![allow(deprecated)]` in the whole module).

## Solution

Adds `allow(deprecated)` to the generated code.

## Checklist

- [x] ~Documentation is updated (if required)~
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
