### PR TITLE
Error when no `#[try_from(repr)]` is provided (#457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Suppress deprecation warnings in generated code.
   ([#454](https://github.com/JelteF/derive_more/pull/454))
 - Silent no-op when `#[try_from(repr)]` attribute is not specified for `TryFrom` derive.
-  ([#457](https://github.com/JelteF/derive_more/pull/457))
+  ([#458](https://github.com/JelteF/derive_more/pull/458))
 
 ## 2.0.1 - 2025-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Suppress deprecation warnings in generated code.
   ([#454](https://github.com/JelteF/derive_more/pull/454))
+- Silent no-op when `#[try_from(repr)]` attribute is not specified for `TryFrom` derive.
+  ([#457](https://github.com/JelteF/derive_more/pull/457))
 
 ## 2.0.1 - 2025-02-03
 

--- a/tests/compile_fail/try_from/invalid_repr.rs
+++ b/tests/compile_fail/try_from/invalid_repr.rs
@@ -1,4 +1,5 @@
 #[derive(derive_more::TryFrom)]
+#[try_from(repr)]
 #[repr(a + b)]
 enum Enum {
     Variant

--- a/tests/compile_fail/try_from/invalid_repr.stderr
+++ b/tests/compile_fail/try_from/invalid_repr.stderr
@@ -1,11 +1,11 @@
 error: expected `,`
- --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+ --> tests/compile_fail/try_from/invalid_repr.rs:3:10
   |
-2 | #[repr(a + b)]
+3 | #[repr(a + b)]
   |          ^
 
 error: expected one of `(`, `,`, `::`, or `=`, found `+`
- --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+ --> tests/compile_fail/try_from/invalid_repr.rs:3:10
   |
-2 | #[repr(a + b)]
+3 | #[repr(a + b)]
   |          ^ expected one of `(`, `,`, `::`, or `=`

--- a/tests/compile_fail/try_from/no_repr.rs
+++ b/tests/compile_fail/try_from/no_repr.rs
@@ -1,0 +1,6 @@
+#[derive(derive_more::TryFrom)]
+enum Enum {
+    Variant
+}
+
+fn main() {}

--- a/tests/compile_fail/try_from/no_repr.stderr
+++ b/tests/compile_fail/try_from/no_repr.stderr
@@ -1,0 +1,11 @@
+error: expected `,`
+ --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+  |
+2 | #[repr(a + b)]
+  |          ^
+
+error: expected one of `(`, `,`, `::`, or `=`, found `+`
+ --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+  |
+2 | #[repr(a + b)]
+  |          ^ expected one of `(`, `,`, `::`, or `=`

--- a/tests/compile_fail/try_from/no_repr.stderr
+++ b/tests/compile_fail/try_from/no_repr.stderr
@@ -1,11 +1,5 @@
-error: expected `,`
- --> tests/compile_fail/try_from/invalid_repr.rs:2:10
+error: `#[try_from(repr)]` attribute is expected here
+ --> tests/compile_fail/try_from/no_repr.rs:2:6
   |
-2 | #[repr(a + b)]
-  |          ^
-
-error: expected one of `(`, `,`, `::`, or `=`, found `+`
- --> tests/compile_fail/try_from/invalid_repr.rs:2:10
-  |
-2 | #[repr(a + b)]
-  |          ^ expected one of `(`, `,`, `::`, or `=`
+2 | enum Enum {
+  |      ^^^^


### PR DESCRIPTION
Resolves #457

## Synopsis

See https://github.com/JelteF/derive_more/issues/457#issue-3014360584:
> If the attribute is required, its absence should generate a compile error. If it's not required, then omitting it should not result in doing nothing.

## Solution

Error if no `#[try_from(repr)]` is provided on enum.

## Checklist

- [x] ~~Documentation is updated~~ (not required)
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
