### PR TITLE
Support optional `Error::source` (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support `#[display(rename_all = "<casing>")]` attribute to change output for
   implicit naming of unit enum variants or unit structs when deriving `Display`.
   ([#443](https://github.com/JelteF/derive_more/pull/443))
+- Support `Option` fields for `Error::source()` in `Error` derive.
+  ([#459](https://github.com/JelteF/derive_more/pull/459))
 
 ### Fixed
 

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -13,9 +13,18 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
+    NamedImplicitOptionalSource {
+        source: Option<SimpleErr>,
+        field: i32,
+    },
     #[cfg(feature = "std")]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
+        field: i32,
+    },
+    #[cfg(feature = "std")]
+    NamedImplicitOptionalBoxedSource {
+        source: Option<Box<dyn Error + Send + 'static>>,
         field: i32,
     },
     NamedExplicitNoSource {
@@ -28,6 +37,11 @@ enum TestErr {
         explicit_source: SimpleErr,
         field: i32,
     },
+    NamedExplicitOptionalSource {
+        #[error(source)]
+        explicit_source: Option<SimpleErr>,
+        field: i32,
+    },
     NamedExplicitNoSourceRedundant {
         #[error(not(source))]
         field: i32,
@@ -37,20 +51,33 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
+    NamedExplicitOptionalSourceRedundant {
+        #[error(source)]
+        source: Option<SimpleErr>,
+        field: i32,
+    },
     NamedExplicitSuppressesImplicit {
         source: i32,
         #[error(source)]
         field: SimpleErr,
     },
+    NamedExplicitSuppressesOptionalImplicit {
+        source: i32,
+        #[error(source)]
+        field: Option<SimpleErr>,
+    },
     UnnamedImplicitNoSource(i32, i32),
     UnnamedImplicitSource(SimpleErr),
+    UnnamedImplicitOptionalSource(Option<SimpleErr>),
     UnnamedExplicitNoSource(#[error(not(source))] SimpleErr),
     UnnamedExplicitSource(#[error(source)] SimpleErr, i32),
+    UnnamedExplicitOptionalSource(#[error(source)] Option<SimpleErr>, i32),
     UnnamedExplicitNoSourceRedundant(
         #[error(not(source))] i32,
         #[error(not(source))] i32,
     ),
     UnnamedExplicitSourceRedundant(#[error(source)] SimpleErr),
+    UnnamedExplicitOptionalSourceRedundant(#[error(source)] Option<SimpleErr>),
     NamedIgnore {
         #[error(ignore)]
         source: SimpleErr,
@@ -100,11 +127,34 @@ fn named_implicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
+#[test]
+fn named_implicit_optional_source() {
+    let err = TestErr::NamedImplicitOptionalSource {
+        source: Some(SimpleErr),
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn named_implicit_boxed_source() {
     let err = TestErr::NamedImplicitBoxedSource {
         source: Box::new(SimpleErr),
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn named_implicit_optional_boxed_source() {
+    let err = TestErr::NamedImplicitOptionalBoxedSource {
+        source: Some(Box::new(SimpleErr)),
         field: 0,
     };
 
@@ -134,6 +184,17 @@ fn named_explicit_source() {
 }
 
 #[test]
+fn named_explicit_optional_source() {
+    let err = TestErr::NamedExplicitOptionalSource {
+        explicit_source: Some(SimpleErr),
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn named_explicit_no_source_redundant() {
     let err = TestErr::NamedExplicitNoSourceRedundant { field: 0 };
 
@@ -144,6 +205,17 @@ fn named_explicit_no_source_redundant() {
 fn named_explicit_source_redundant() {
     let err = TestErr::NamedExplicitSourceRedundant {
         source: SimpleErr,
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_source_redundant() {
+    let err = TestErr::NamedExplicitOptionalSourceRedundant {
+        source: Some(SimpleErr),
         field: 0,
     };
 
@@ -163,6 +235,17 @@ fn named_explicit_suppresses_implicit() {
 }
 
 #[test]
+fn named_explicit_suppresses_optional_implicit() {
+    let err = TestErr::NamedExplicitSuppressesOptionalImplicit {
+        source: 0,
+        field: Some(SimpleErr),
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn unnamed_implicit_no_source() {
     assert!(TestErr::UnnamedImplicitNoSource(0, 0).source().is_none());
 }
@@ -170,6 +253,14 @@ fn unnamed_implicit_no_source() {
 #[test]
 fn unnamed_implicit_source() {
     let err = TestErr::UnnamedImplicitSource(SimpleErr);
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_implicit_optional_source() {
+    let err = TestErr::UnnamedImplicitOptionalSource(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -191,6 +282,14 @@ fn unnamed_explicit_source() {
 }
 
 #[test]
+fn unnamed_explicit_optional_source() {
+    let err = TestErr::UnnamedExplicitOptionalSource(Some(SimpleErr), 0);
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn unnamed_explicit_no_source_redundant() {
     let err = TestErr::UnnamedExplicitNoSourceRedundant(0, 0);
 
@@ -200,6 +299,14 @@ fn unnamed_explicit_no_source_redundant() {
 #[test]
 fn unnamed_explicit_source_redundant() {
     let err = TestErr::UnnamedExplicitSourceRedundant(SimpleErr);
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_explicit_optional_source_redundant() {
+    let err = TestErr::UnnamedExplicitOptionalSourceRedundant(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -61,7 +61,7 @@ enum TestErr {
         #[error(source)]
         field: SimpleErr,
     },
-    NamedExplicitSuppressesOptionalImplicit {
+    NamedExplicitOptionalSuppressesImplicit {
         source: i32,
         #[error(source)]
         field: Option<SimpleErr>,
@@ -235,8 +235,8 @@ fn named_explicit_suppresses_implicit() {
 }
 
 #[test]
-fn named_explicit_suppresses_optional_implicit() {
-    let err = TestErr::NamedExplicitSuppressesOptionalImplicit {
+fn named_explicit_optional_suppresses_implicit() {
+    let err = TestErr::NamedExplicitOptionalSuppressesImplicit {
         source: 0,
         field: Some(SimpleErr),
     };

--- a/tests/error/derives_for_generic_enums_with_source.rs
+++ b/tests/error/derives_for_generic_enums_with_source.rs
@@ -13,6 +13,10 @@ enum TestErr<E, T> {
         source: E,
         field: T,
     },
+    NamedImplicitOptionalSource {
+        source: Option<E>,
+        field: T,
+    },
     NamedExplicitNoSource {
         #[error(not(source))]
         source: E,
@@ -21,6 +25,11 @@ enum TestErr<E, T> {
     NamedExplicitSource {
         #[error(source)]
         explicit_source: E,
+        field: T,
+    },
+    NamedExplicitOptionalSource {
+        #[error(source)]
+        explicit_source: Option<E>,
         field: T,
     },
     NamedExplicitNoSourceRedundant {
@@ -32,17 +41,30 @@ enum TestErr<E, T> {
         source: E,
         field: T,
     },
+    NamedExplicitOptionalSourceRedundant {
+        #[error(source)]
+        source: Option<E>,
+        field: T,
+    },
     NamedExplicitSuppressesImplicit {
         source: T,
         #[error(source)]
         field: E,
     },
+    NamedExplicitOptionalSuppressesImplicit {
+        source: T,
+        #[error(source)]
+        field: Option<E>,
+    },
     UnnamedImplicitNoSource(T, T),
     UnnamedImplicitSource(E),
+    UnnamedImplicitOptionalSource(Option<E>),
     UnnamedExplicitNoSource(#[error(not(source))] E),
     UnnamedExplicitSource(#[error(source)] E, T),
+    UnnamedExplicitOptionalSource(#[error(source)] Option<E>, T),
     UnnamedExplicitNoSourceRedundant(#[error(not(source))] T, #[error(not(source))] T),
     UnnamedExplicitSourceRedundant(#[error(source)] E),
+    UnnamedExplicitOptionalSourceRedundant(#[error(source)] Option<E>),
     NamedIgnore {
         #[error(ignore)]
         source: E,
@@ -93,6 +115,17 @@ fn named_implicit_source() {
 }
 
 #[test]
+fn named_implicit_optional_source() {
+    let err = TestErr::NamedImplicitOptionalSource {
+        source: Some(SimpleErr),
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn named_explicit_no_source() {
     let err = TestErr::NamedExplicitNoSource {
         source: SimpleErr,
@@ -106,6 +139,17 @@ fn named_explicit_no_source() {
 fn named_explicit_source() {
     let err = TestErr::NamedExplicitSource {
         explicit_source: SimpleErr,
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_source() {
+    let err = TestErr::NamedExplicitOptionalSource {
+        explicit_source: Some(SimpleErr),
         field: 0,
     };
 
@@ -132,10 +176,32 @@ fn named_explicit_source_redundant() {
 }
 
 #[test]
+fn named_explicit_optional_source_redundant() {
+    let err = TestErr::NamedExplicitOptionalSourceRedundant {
+        source: Some(SimpleErr),
+        field: 0,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn named_explicit_suppresses_implicit() {
     let err = TestErr::NamedExplicitSuppressesImplicit {
         source: 0,
         field: SimpleErr,
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_suppresses_implicit() {
+    let err = TestErr::NamedExplicitOptionalSuppressesImplicit {
+        source: 0,
+        field: Some(SimpleErr),
     };
 
     assert!(err.source().is_some());
@@ -158,6 +224,14 @@ fn unnamed_implicit_source() {
 }
 
 #[test]
+fn unnamed_implicit_optional_source() {
+    let err = TestErr::<_, i32>::UnnamedImplicitOptionalSource(Some(SimpleErr));
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn unnamed_explicit_no_source() {
     let err = TestErr::<_, i32>::UnnamedExplicitNoSource(SimpleErr);
 
@@ -173,6 +247,14 @@ fn unnamed_explicit_source() {
 }
 
 #[test]
+fn unnamed_explicit_optional_source() {
+    let err = TestErr::UnnamedExplicitOptionalSource(Some(SimpleErr), 0);
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn unnamed_explicit_no_source_redundant() {
     let err = TestErr::<SimpleErr, _>::UnnamedExplicitNoSourceRedundant(0, 0);
 
@@ -180,8 +262,9 @@ fn unnamed_explicit_no_source_redundant() {
 }
 
 #[test]
-fn unnamed_explicit_source_redundant() {
-    let err = TestErr::<_, i32>::UnnamedExplicitSourceRedundant(SimpleErr);
+fn unnamed_explicit_optional_source_redundant() {
+    let err =
+        TestErr::<_, i32>::UnnamedExplicitOptionalSourceRedundant(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());

--- a/tests/error/derives_for_generic_structs_with_source.rs
+++ b/tests/error/derives_for_generic_structs_with_source.rs
@@ -37,8 +37,10 @@ fn named_implicit_optional_source() {
         field: T,
     }
 
-    let mut err = TestErr::<SimpleErr, i32>::default();
-    err.source = Some(SimpleErr::default());
+    let err = TestErr::<_, i32> {
+        source: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -85,8 +87,10 @@ fn named_explicit_optional_source() {
         field: T,
     }
 
-    let mut err = TestErr::<SimpleErr, i32>::default();
-    err.explicit_source = Some(SimpleErr::default());
+    let err = TestErr::<_, i32> {
+        explicit_source: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -130,8 +134,10 @@ fn named_explicit_optional_source_redundant() {
         field: T,
     }
 
-    let mut err = TestErr::<SimpleErr, i32>::default();
-    err.source = Some(SimpleErr::default());
+    let err = TestErr::<_, i32> {
+        source: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -163,8 +169,10 @@ fn named_explicit_optional_suppresses_implicit() {
         field: Option<T>,
     }
 
-    let mut err = TestErr::<i32, SimpleErr>::default();
-    err.field = Some(SimpleErr::default());
+    let err = TestErr::<i32, _> {
+        field: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -197,8 +205,7 @@ fn unnamed_implicit_optional_source() {
     #[derive(Default, Debug, Error)]
     struct TestErr<E>(Option<E>);
 
-    let mut err = TestErr::<SimpleErr>::default();
-    err.0 = Some(SimpleErr::default());
+    let err = TestErr(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -231,8 +238,10 @@ fn unnamed_explicit_optional_source() {
     #[derive(Default, Debug, Error)]
     struct TestErr<E, T>(#[error(source)] Option<E>, T);
 
-    let mut err = TestErr::<SimpleErr, i32>::default();
-    err.0 = Some(SimpleErr::default());
+    let err = TestErr::<_, i32> {
+        0: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -265,8 +274,7 @@ fn unnamed_explicit_optional_source_redundant() {
     #[derive(Default, Debug, Error)]
     struct TestErr<E>(#[error(source)] Option<E>);
 
-    let mut err = TestErr::<SimpleErr>::default();
-    err.0 = Some(SimpleErr::default());
+    let err = TestErr(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());

--- a/tests/error/derives_for_generic_structs_with_source.rs
+++ b/tests/error/derives_for_generic_structs_with_source.rs
@@ -23,6 +23,23 @@ fn named_implicit_source() {
     }
 
     let err = TestErr::<SimpleErr, i32>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_implicit_optional_source() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T> {
+        source: Option<E>,
+        field: T,
+    }
+
+    let mut err = TestErr::<SimpleErr, i32>::default();
+    err.source = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -38,6 +55,7 @@ fn named_explicit_no_source() {
     }
 
     let err = TestErr::<SimpleErr, i32>::default();
+
     assert!(err.source().is_none());
 }
 
@@ -52,6 +70,24 @@ fn named_explicit_source() {
     }
 
     let err = TestErr::<SimpleErr, i32>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_source() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T> {
+        #[error(source)]
+        explicit_source: Option<E>,
+        field: T,
+    }
+
+    let mut err = TestErr::<SimpleErr, i32>::default();
+    err.explicit_source = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -79,6 +115,24 @@ fn named_explicit_source_redundant() {
     }
 
     let err = TestErr::<SimpleErr, i32>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_source_redundant() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T> {
+        #[error(source)]
+        source: Option<E>,
+        field: T,
+    }
+
+    let mut err = TestErr::<SimpleErr, i32>::default();
+    err.source = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -94,6 +148,24 @@ fn named_explicit_suppresses_implicit() {
     }
 
     let err = TestErr::<i32, SimpleErr>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_suppresses_implicit() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T> {
+        source: E,
+        #[error(source)]
+        field: Option<T>,
+    }
+
+    let mut err = TestErr::<i32, SimpleErr>::default();
+    err.field = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -114,6 +186,20 @@ fn unnamed_implicit_source() {
     struct TestErr<E>(E);
 
     let err = TestErr::<SimpleErr>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_implicit_optional_source() {
+    derive_display!(TestErr, E);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E>(Option<E>);
+
+    let mut err = TestErr::<SimpleErr>::default();
+    err.0 = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -134,6 +220,20 @@ fn unnamed_explicit_source() {
     struct TestErr<E, T>(#[error(source)] E, T);
 
     let err = TestErr::<SimpleErr, i32>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_explicit_optional_source() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T>(#[error(source)] Option<E>, T);
+
+    let mut err = TestErr::<SimpleErr, i32>::default();
+    err.0 = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -154,6 +254,20 @@ fn unnamed_explicit_source_redundant() {
     struct TestErr<E>(#[error(source)] E);
 
     let err = TestErr::<SimpleErr>::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_explicit_optional_source_redundant() {
+    derive_display!(TestErr, E);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E>(#[error(source)] Option<E>);
+
+    let mut err = TestErr::<SimpleErr>::default();
+    err.0 = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }

--- a/tests/error/derives_for_structs_with_source.rs
+++ b/tests/error/derives_for_structs_with_source.rs
@@ -42,8 +42,10 @@ fn named_implicit_optional_source() {
         field: i32,
     }
 
-    let mut err = TestErr::default();
-    err.source = Some(SimpleErr::default());
+    let err = TestErr {
+        source: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -88,8 +90,10 @@ fn named_explicit_optional_source() {
         field: i32,
     }
 
-    let mut err = TestErr::default();
-    err.explicit_source = Some(SimpleErr::default());
+    let err = TestErr {
+        explicit_source: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -133,8 +137,10 @@ fn named_explicit_optional_source_redundant() {
         field: i32,
     }
 
-    let mut err = TestErr::default();
-    err.source = Some(SimpleErr::default());
+    let err = TestErr {
+        source: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -166,8 +172,10 @@ fn named_explicit_optional_suppresses_implicit() {
         field: Option<SimpleErr>,
     }
 
-    let mut err = TestErr::default();
-    err.field = Some(SimpleErr::default());
+    let err = TestErr {
+        field: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -200,8 +208,7 @@ fn unnamed_implicit_optional_source() {
     #[derive(Default, Debug, Error)]
     struct TestErr(Option<SimpleErr>);
 
-    let mut err = TestErr::default();
-    err.0 = Some(SimpleErr::default());
+    let err = TestErr(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -234,8 +241,10 @@ fn unnamed_explicit_optional_source() {
     #[derive(Default, Debug, Error)]
     struct TestErr(#[error(source)] Option<SimpleErr>, i32);
 
-    let mut err = TestErr::default();
-    err.0 = Some(SimpleErr::default());
+    let err = TestErr {
+        0: Some(SimpleErr),
+        ..TestErr::default()
+    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -268,8 +277,7 @@ fn unnamed_explicit_optional_source_redundant() {
     #[derive(Default, Debug, Error)]
     struct TestErr(#[error(source)] Option<SimpleErr>);
 
-    let mut err = TestErr::default();
-    err.0 = Some(SimpleErr::default());
+    let err = TestErr(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());

--- a/tests/error/derives_for_structs_with_source.rs
+++ b/tests/error/derives_for_structs_with_source.rs
@@ -28,6 +28,23 @@ fn named_implicit_source() {
     }
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_implicit_optional_source() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr {
+        source: Option<SimpleErr>,
+        field: i32,
+    }
+
+    let mut err = TestErr::default();
+    err.source = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -56,6 +73,24 @@ fn named_explicit_source() {
     }
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_source() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr {
+        #[error(source)]
+        explicit_source: Option<SimpleErr>,
+        field: i32,
+    }
+
+    let mut err = TestErr::default();
+    err.explicit_source = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -83,6 +118,24 @@ fn named_explicit_source_redundant() {
     }
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_source_redundant() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr {
+        #[error(source)]
+        source: Option<SimpleErr>,
+        field: i32,
+    }
+
+    let mut err = TestErr::default();
+    err.source = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -98,6 +151,24 @@ fn named_explicit_suppresses_implicit() {
     }
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn named_explicit_optional_suppresses_implicit() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr {
+        source: i32,
+        #[error(source)]
+        field: Option<SimpleErr>,
+    }
+
+    let mut err = TestErr::default();
+    err.field = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -118,6 +189,20 @@ fn unnamed_implicit_source() {
     struct TestErr(SimpleErr);
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_implicit_optional_source() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr(Option<SimpleErr>);
+
+    let mut err = TestErr::default();
+    err.0 = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -138,6 +223,20 @@ fn unnamed_explicit_source() {
     struct TestErr(#[error(source)] SimpleErr, i32);
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_explicit_optional_source() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr(#[error(source)] Option<SimpleErr>, i32);
+
+    let mut err = TestErr::default();
+    err.0 = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
@@ -158,6 +257,20 @@ fn unnamed_explicit_source_redundant() {
     struct TestErr(#[error(source)] SimpleErr);
 
     let err = TestErr::default();
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
+fn unnamed_explicit_optional_source_redundant() {
+    derive_display!(TestErr);
+    #[derive(Default, Debug, Error)]
+    struct TestErr(#[error(source)] Option<SimpleErr>);
+
+    let mut err = TestErr::default();
+    err.0 = Some(SimpleErr::default());
+
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
 }


### PR DESCRIPTION
Resolves #426

## Synopsis

See https://github.com/JelteF/derive_more/issues/426#issue-2688714756:
> I’d like to be able to use `derive_more` with optional sources, like:
> ```rust
> #[derive(derive_more::Error, derive_more::Display, Debug)]
> #[display("it’s an error")]
> struct MyErr {
>     source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
> }
> ```

## Solution

The way, the `thiserror` does it, is by [checking](https://docs.rs/thiserror-impl/2.0.12/src/thiserror_impl/expand.rs.html#50) the [type name to contain `Option`](https://docs.rs/thiserror-impl/2.0.12/src/thiserror_impl/expand.rs.html#559-583). Relying on type could be fragile, as the call site could introduce its own type named `Option` in the scope where macro is called. Ideally, we need to aid this case with type machinery.

For supporting this via type machinery, we obviously need some sort of specialization to specialize case `Option<E: Error>` over `E: Error`, since vanilla Rust coherence naturally hits the wall of "upstream crates may add a new impl of trait `std::error::Error` for type `Option<_>` in future versions". The usual solution is to use [autoref-based specialization](https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html) as [we do for `AsRef`](https://docs.rs/derive_more/2.0.1/src/derive_more/as.rs.html). However, autoref-based specialization doesn't work in a generic context (i.e. `MyError<E1, E2>`), since it requires trait bounds to work, and we cannot describe conditional trait bounds in Rust, which leads to the situation that this case could not be supported at all:
```rust
struct MyError<E> {
    source: Option<E>,
}
```

So, choosing between checking the field's type syntactically (and so loosing support for renamed types) and not supporting optional `source` in generic contexts, I would definitely choose to support generics despite having naming issues in edge cases. As the result, this PR implements the similar syntactically-based solution as the `thiserror` crate does. The implications of this are warned and described in the documentation.

## Future possibilities

Additionally, we may support `#[error(source(optional))]` attribute, which will allow using renamed types naturally:
```rust
use derive_more::{Display, Error};

#[derive(Debug, Display, Error)]
struct Simple;

#[derive(Debug, Display, Error)]
#[display("Oops!")]
struct Generic(#[error(source(optional))] RenamedOption<Simple>); // forces recognizing as `Option`
type RenamedOption<T> = Option<T>;
```
However, it's better to be implemented as a separate PR, to not overcomplicate this one.

## Checklist

- [x] Documentation is updated
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
