### PR TITLE
Support `#[error(source(optional))]` attribute (#426)

### DIFF
--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -83,6 +83,20 @@ Deriving `source()` is supported naturally for `Option<_>`-typed fields.
 >   struct Option<T>(T);
 >   ```
 
+> **TIP**: If `std::option::Option` for some reason needs to be renamed,
+> annotate the field with the `#[error(source(optional))]` attribute:
+> ```rust
+> # use derive_more::{Display, Error};
+> #
+> #[derive(Debug, Display, Error)]
+> struct Simple;
+>
+> #[derive(Debug, Display, Error)]
+> #[display("Oops!")]
+> struct Generic(#[error(source(optional))] RenamedOption<Simple>);
+> type RenamedOption<T> = Option<T>;
+>  ```
+
 
 
 
@@ -90,17 +104,19 @@ Deriving `source()` is supported naturally for `Option<_>`-typed fields.
 
 ```rust
 # #![cfg_attr(nightly, feature(error_generic_member_access))]
-// Nightly requires enabling this feature:
-// #![feature(error_generic_member_access)]
+# // Nightly requires enabling this feature:
+# // #![feature(error_generic_member_access)]
 # #[cfg(not(nightly))] fn main() {}
 # #[cfg(nightly)] fn main() {
 # use core::error::{request_ref, request_value, Error as __};
 # use std::backtrace::Backtrace;
 #
 # use derive_more::{Display, Error, From};
-
-// std::error::Error requires std::fmt::Debug and std::fmt::Display,
-// so we can also use derive_more::Display for fully declarative
+#
+# type RenamedOption<T> = Option<T>;
+#
+// `std::error::Error` requires `std::fmt::Debug` and `std::fmt::Display`,
+// so we can also use `derive_more::Display` for fully declarative
 // error-type definitions.
 
 #[derive(Default, Debug, Display, Error)]
@@ -125,6 +141,12 @@ struct WithExplicitSource {
 struct WithExplicitOptionalSource {
     #[error(source)]
     explicit_source: Option<Simple>,
+}
+#[derive(Default, Debug, Display, Error)]
+#[display("WithExplicitOptionalSource")]
+struct WithExplicitRenamedOptionalSource {
+    #[error(source(optional))]
+    explicit_source: RenamedOption<Simple>,
 }
 
 #[derive(Default, Debug, Display, Error)]
@@ -170,6 +192,11 @@ enum CompoundError {
         #[error(source)]
         explicit_source: Option<WithSource>,
     },
+    #[display("WithExplicitRenamedOptionalSource")]
+    WithExplicitOptionalSource {
+        #[error(source(optional))]
+        explicit_source: RenamedOption<WithExplicitRenamedOptionalSource>,
+    },
     #[from(ignore)]
     WithBacktraceFromExplicitSource {
         #[error(backtrace, source)]
@@ -189,6 +216,7 @@ assert!(WithOptionalSource { source: Some(Simple) }.source().is_some());
 
 assert!(WithExplicitSource::default().source().is_some());
 assert!(WithExplicitOptionalSource { explicit_source: Some(Simple) }.source().is_some());
+assert!(WithExplicitRenamedOptionalSource { explicit_source: Some(Simple) }.source().is_some());
 
 assert!(Tuple::default().source().is_some());
 
@@ -211,6 +239,7 @@ assert!(CompoundError::from(Some(WithSource::default())).source().is_some());
 
 assert!(CompoundError::from(WithExplicitSource::default()).source().is_some());
 assert!(CompoundError::from(Some(WithExplicitSource::default())).source().is_some());
+assert!(CompoundError::from(Some(WithExplicitRenamedOptionalSource { explicit_source: Some(Simple) })).source().is_some());
 
 assert!(CompoundError::from(Tuple::default()).source().is_none());
 # }

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -193,7 +193,7 @@ enum CompoundError {
         explicit_source: Option<WithSource>,
     },
     #[display("WithExplicitRenamedOptionalSource")]
-    WithExplicitOptionalSource {
+    WithExplicitRenamedOptionalSource {
         #[error(source(optional))]
         explicit_source: RenamedOption<WithExplicitRenamedOptionalSource>,
     },

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -920,7 +920,7 @@ fn parse_punctuated_nested_meta(
                     (None, "owned") => info.owned = Some(true),
                     (None, "ref") => info.ref_ = Some(true),
                     (None, "ref_mut") => info.ref_mut = Some(true),
-                    
+
                     (None, "source") => info.source = Some(true),
 
                     #[cfg(any(feature = "from", feature = "into"))]

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -920,6 +920,8 @@ fn parse_punctuated_nested_meta(
                     (None, "owned") => info.owned = Some(true),
                     (None, "ref") => info.ref_ = Some(true),
                     (None, "ref_mut") => info.ref_mut = Some(true),
+                    
+                    (None, "source") => info.source = Some(true),
 
                     #[cfg(any(feature = "from", feature = "into"))]
                     (None, "types")
@@ -1022,6 +1024,7 @@ fn parse_punctuated_nested_meta(
                     (None, "ref_mut") => info.ref_mut = Some(true),
                     (None, "source") => info.source = Some(true),
                     (Some("not"), "source") => info.source = Some(false),
+                    (Some("source"), "optional") => info.source_optional = Some(true),
                     (None, "backtrace") => info.backtrace = Some(true),
                     (Some("not"), "backtrace") => info.backtrace = Some(false),
                     _ => {
@@ -1218,6 +1221,7 @@ pub struct MetaInfo {
     pub ref_: Option<bool>,
     pub ref_mut: Option<bool>,
     pub source: Option<bool>,
+    pub source_optional: Option<bool>,
     pub backtrace: Option<bool>,
     #[cfg(any(feature = "from", feature = "into"))]
     pub types: HashMap<RefType, HashSet<syn::Type>>,

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -325,6 +325,7 @@ fn unnamed_explicit_renamed_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn unnamed_explicit_renamed_optional_boxed_source() {
     let err = TestErr::UnnamedExplicitRenamedOptionalBoxedSource(

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -15,13 +15,13 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
-    NamedImplicitOptionalSource {
-        source: Option<SimpleErr>,
-        field: i32,
-    },
     #[cfg(feature = "std")]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
+        field: i32,
+    },
+    NamedImplicitOptionalSource {
+        source: Option<SimpleErr>,
         field: i32,
     },
     #[cfg(feature = "std")]
@@ -327,7 +327,10 @@ fn unnamed_explicit_renamed_optional_source() {
 
 #[test]
 fn unnamed_explicit_renamed_optional_boxed_source() {
-    let err = TestErr::UnnamedExplicitRenamedOptionalBoxedSource(Some(Box::new(SimpleErr)), 0);
+    let err = TestErr::UnnamedExplicitRenamedOptionalBoxedSource(
+        Some(Box::new(SimpleErr)),
+        0,
+    );
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());

--- a/tests/error/derives_for_generic_structs_with_source.rs
+++ b/tests/error/derives_for_generic_structs_with_source.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 
+type RenamedOption<T> = Option<T>;
+
 #[test]
 fn named_implicit_no_source() {
     derive_display!(TestErr, T);
@@ -97,6 +99,25 @@ fn named_explicit_optional_source() {
 }
 
 #[test]
+fn named_explicit_renamed_optional_source() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T> {
+        #[error(source(optional))]
+        explicit_source: RenamedOption<E>,
+        field: T,
+    }
+
+    let err = TestErr::<_, i32> {
+        explicit_source: Some(SimpleErr),
+        ..TestErr::default()
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn named_explicit_no_source_redundant() {
     derive_display!(TestErr, T);
     #[derive(Default, Debug, Error)]
@@ -119,25 +140,6 @@ fn named_explicit_source_redundant() {
     }
 
     let err = TestErr::<SimpleErr, i32>::default();
-
-    assert!(err.source().is_some());
-    assert!(err.source().unwrap().is::<SimpleErr>());
-}
-
-#[test]
-fn named_explicit_optional_source_redundant() {
-    derive_display!(TestErr, E, T);
-    #[derive(Default, Debug, Error)]
-    struct TestErr<E, T> {
-        #[error(source)]
-        source: Option<E>,
-        field: T,
-    }
-
-    let err = TestErr::<_, i32> {
-        source: Some(SimpleErr),
-        ..TestErr::default()
-    };
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());
@@ -248,6 +250,21 @@ fn unnamed_explicit_optional_source() {
 }
 
 #[test]
+fn unnamed_explicit_renamed_optional_source() {
+    derive_display!(TestErr, E, T);
+    #[derive(Default, Debug, Error)]
+    struct TestErr<E, T>(#[error(source(optional))] RenamedOption<E>, T);
+
+    let err = TestErr::<_, i32> {
+        0: Some(SimpleErr),
+        ..TestErr::default()
+    };
+
+    assert!(err.source().is_some());
+    assert!(err.source().unwrap().is::<SimpleErr>());
+}
+
+#[test]
 fn unnamed_explicit_no_source_redundant() {
     derive_display!(TestErr, T);
     #[derive(Default, Debug, Error)]
@@ -263,18 +280,6 @@ fn unnamed_explicit_source_redundant() {
     struct TestErr<E>(#[error(source)] E);
 
     let err = TestErr::<SimpleErr>::default();
-
-    assert!(err.source().is_some());
-    assert!(err.source().unwrap().is::<SimpleErr>());
-}
-
-#[test]
-fn unnamed_explicit_optional_source_redundant() {
-    derive_display!(TestErr, E);
-    #[derive(Default, Debug, Error)]
-    struct TestErr<E>(#[error(source)] Option<E>);
-
-    let err = TestErr(Some(SimpleErr));
 
     assert!(err.source().is_some());
     assert!(err.source().unwrap().is::<SimpleErr>());


### PR DESCRIPTION
Resolves #426    
Follows #459

## Synopsis

See #459:
> Additionally, we may support `#[error(source(optional))]` attribute, which will allow using renamed types naturally:
> ```rust
> use derive_more::{Display, Error};
>
> #[derive(Debug, Display, Error)]
> struct Simple;
>
> #[derive(Debug, Display, Error)]
> #[display("Oops!")]
> struct Generic(#[error(source(optional))] RenamedOption<Simple>); // forces recognizing as `Option`
> type RenamedOption<T> = Option<T>;
> ```



## Solution

Adds support for `#[error(source(optional))]` attribute.

## Checklist

- [x] Documentation is updated
- [x] Tests are added/updated
- [x] ~~[CHANGELOG entry](/CHANGELOG.md) is added~~ (not required)
