### PR TITLE
Use `core::error::Error` in codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.81.0"]
         os:
           - ubuntu
           - macOS
@@ -62,12 +61,18 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Parse MSRV
+        id: msrv
+        run: echo "version=$(grep -m1 'rust-version = "' Cargo.toml | cut -d '"' -f2)"
+             >> $GITHUB_OUTPUT
+
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ matrix.msrv }}
+          toolchain: ${{ steps.msrv.outputs.version }}
 
       - name: Install minimal dependencies versions
         run: cargo +nightly update -Z minimal-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Parse MSRV
+      - uses: SebRollen/toml-action@v1.2.0
         id: msrv
-        run: echo "version=$(grep -m1 'rust-version = "' Cargo.toml | cut -d '"' -f2)"
-             >> $GITHUB_OUTPUT
+        with:
+          file: Cargo.toml
+          field: package.rust-version
 
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ steps.msrv.outputs.version }}
+          toolchain: ${{ steps.msrv.outputs.value }}
 
       - name: Install minimal dependencies versions
         run: cargo +nightly update -Z minimal-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.75.0"]
+        msrv: ["1.81.0"]
         os:
           - ubuntu
           - macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking changes
 
 - The minimum supported Rust version (MSRV) is now Rust 1.81.
+  ([#466](https://github.com/JelteF/derive_more/pull/466))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### Breaking changes
-
-- The minimum supported Rust version (MSRV) is now Rust 1.81.
-  ([#466](https://github.com/JelteF/derive_more/pull/466))
-
 ### Added
 
 - Support `#[display(rename_all = "<casing>")]` attribute to change output for
@@ -19,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#443](https://github.com/JelteF/derive_more/pull/443))
 - Support `Option` fields for `Error::source()` in `Error` derive.
   ([#459](https://github.com/JelteF/derive_more/pull/459))
+
+### Changed
+
+- The minimum supported Rust version (MSRV) is now Rust 1.81.
+  ([#466](https://github.com/JelteF/derive_more/pull/466))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Breaking changes
+
+- The minimum supported Rust version (MSRV) is now Rust 1.81.
+
 ### Added
 
 - Support `#[display(rename_all = "<casing>")]` attribute to change output for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive_more"
 version = "2.0.1"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 description = "Adds #[derive(x)] macros for more traits"
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Version](https://img.shields.io/crates/v/derive_more.svg)](https://crates.io/crates/derive_more)
 [![Rust Documentation](https://docs.rs/derive_more/badge.svg)](https://docs.rs/derive_more)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/JelteF/derive_more/master/LICENSE)
-[![Rust 1.75+](https://img.shields.io/badge/rustc-1.75+-lightgray.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
+[![Rust 1.81+](https://img.shields.io/badge/rustc-1.81+-lightgray.svg)](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0)
 [![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance)
 
 Rust has lots of builtin traits that are implemented for its basic types, such
@@ -216,7 +216,7 @@ extern crate derive_more;
 
 ## [MSRV] policy
 
-This library requires Rust 1.75 or higher.
+This library requires Rust 1.81 or higher.
 
 Changing [MSRV] (minimum supported Rust version) of this crate is treated as a **minor version change** in terms of [Semantic Versioning].
 - So, if [MSRV] changes are **NOT concerning** for your project, just use the default [caret requirement]:

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive_more-impl"
 version = "2.0.1"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 description = "Internal implementation of `derive_more` crate"
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -44,7 +44,7 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 
 ### What works in `no_std`?
 
-`Error` derive fully work on `no_std` environments except the `provide()`
+`Error` derive fully works on `no_std` environments, except the `provide()`
 method usage, because the `Backtrace` type is only available in `std`.
 
 

--- a/impl/doc/error.md
+++ b/impl/doc/error.md
@@ -2,7 +2,7 @@
 
 Deriving `Error` will generate an `Error` implementation, that contains
 (depending on the type) a `source()` and a `provide()` method. Please note,
-at the time of writing `provide()` is only supported on nightly rust. So you
+at the time of writing `provide()` is only supported on nightly Rust. So you
 have to use that to make use of it.
 
 For a struct, these methods always do the same. For an `enum` they have separate
@@ -44,12 +44,8 @@ ignored for one of these methods by using `#[error(not(backtrace))]` or
 
 ### What works in `no_std`?
 
-If you want to use the `Error` derive on `no_std` environments, then
-you need to compile with nightly, or wait until Rust 1.81 when `Error`
-in `core` is expected to be stabilized.
-
-Backtraces don't work though, because the `Backtrace` type is only available in
-`std`.
+`Error` derive fully work on `no_std` environments except the `provide()`
+method usage, because the `Backtrace` type is only available in `std`.
 
 
 ### `Option`al fields

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -40,9 +40,7 @@ pub fn expand(
         // Not using `#[inline]` here on purpose, since this is almost never part
         // of a hot codepath.
         quote! {
-            // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
-            //       stabilized.
-            fn source(&self) -> Option<&(dyn derive_more::with_trait::Error + 'static)> {
+            fn source(&self) -> Option<&(dyn derive_more::core::error::Error + 'static)> {
                 use derive_more::__private::AsDynError as _;
                 #source
             }
@@ -84,9 +82,7 @@ pub fn expand(
                 where #(
                     #bounds: derive_more::core::fmt::Debug
                              + derive_more::core::fmt::Display
-                             // TODO: Use `derive_more::core::error::Error` once `error_in_core`
-                             //       Rust feature is stabilized.
-                             + derive_more::with_trait::Error
+                             + derive_more::core::error::Error
                              + 'static
                 ),*
             },
@@ -97,9 +93,7 @@ pub fn expand(
 
     let render = quote! {
         #[automatically_derived]
-        // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
-        //       stabilized.
-        impl #impl_generics derive_more::with_trait::Error for #ident #ty_generics #where_clause {
+        impl #impl_generics derive_more::core::error::Error for #ident #ty_generics #where_clause {
             #source
             #provide
         }
@@ -229,9 +223,7 @@ impl ParsedFields<'_, '_> {
         let source_provider = self.source.map(|source| {
             let source_expr = &self.data.members[source];
             quote! {
-                // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
-                //       stabilized.
-                derive_more::with_trait::Error::provide(&#source_expr, request);
+                derive_more::core::error::Error::provide(&#source_expr, request);
             }
         });
         let backtrace_provider = self
@@ -261,9 +253,7 @@ impl ParsedFields<'_, '_> {
                 let pattern = self.data.matcher(&[source], &[quote! { source }]);
                 Some(quote! {
                     #pattern => {
-                        // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust
-                        //       feature is stabilized.
-                        derive_more::with_trait::Error::provide(source, request);
+                        derive_more::core::error::Error::provide(source, request);
                     }
                 })
             }
@@ -275,9 +265,7 @@ impl ParsedFields<'_, '_> {
                 Some(quote! {
                     #pattern => {
                         request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
-                        // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust
-                        //       feature is stabilized.
-                        derive_more::with_trait::Error::provide(source, request);
+                        derive_more::core::error::Error::provide(source, request);
                     }
                 })
             }

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,6 +1,6 @@
 //! Definitions used in derived implementations of [`core::ops::Add`]-like traits.
 
-use core::{fmt, error::Error};
+use core::{error::Error, fmt};
 
 use crate::UnitError;
 

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,6 +1,6 @@
 //! Definitions used in derived implementations of [`core::ops::Add`]-like traits.
 
-use core::fmt;
+use core::{fmt, error::Error};
 
 use crate::UnitError;
 
@@ -30,8 +30,7 @@ impl fmt::Display for WrongVariantError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for WrongVariantError {}
+impl Error for WrongVariantError {}
 
 /// Possible errors returned by the derived implementations of binary
 /// arithmetic or logic operations.
@@ -53,9 +52,8 @@ impl fmt::Display for BinaryError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BinaryError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl Error for BinaryError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::Mismatch(e) => e.source(),
             Self::Unit(e) => e.source(),

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -7,7 +7,7 @@ pub use self::try_into::TryIntoError;
 
 #[cfg(feature = "try_from")]
 mod try_from {
-    use core::fmt;
+    use core::{fmt, error::Error};
 
     /// Error returned by the derived [`TryFrom`] implementation on enums to
     /// convert from their repr.
@@ -42,14 +42,13 @@ mod try_from {
         }
     }
 
-    #[cfg(feature = "std")]
-    // `T` should only be an integer type and therefore be debug
-    impl<T: fmt::Debug> std::error::Error for TryFromReprError<T> {}
+    // `T` should only be an integer type and therefore be `Debug`.
+    impl<T: fmt::Debug> Error for TryFromReprError<T> {}
 }
 
 #[cfg(feature = "try_into")]
 mod try_into {
-    use core::fmt;
+    use core::{fmt, error::Error};
 
     /// Error returned by the derived [`TryInto`] implementation.
     ///
@@ -91,7 +90,6 @@ mod try_into {
             )
         }
     }
-
-    #[cfg(feature = "std")]
-    impl<T: fmt::Debug> std::error::Error for TryIntoError<T> {}
+    
+    impl<T: fmt::Debug> Error for TryIntoError<T> {}
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -7,7 +7,7 @@ pub use self::try_into::TryIntoError;
 
 #[cfg(feature = "try_from")]
 mod try_from {
-    use core::{fmt, error::Error};
+    use core::{error::Error, fmt};
 
     /// Error returned by the derived [`TryFrom`] implementation on enums to
     /// convert from their repr.
@@ -48,7 +48,7 @@ mod try_from {
 
 #[cfg(feature = "try_into")]
 mod try_into {
-    use core::{fmt, error::Error};
+    use core::{error::Error, fmt};
 
     /// Error returned by the derived [`TryInto`] implementation.
     ///
@@ -90,6 +90,6 @@ mod try_into {
             )
         }
     }
-    
+
     impl<T: fmt::Debug> Error for TryIntoError<T> {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,10 +192,7 @@ pub mod with_trait {
             UpperHex,
         );
 
-        #[cfg(not(feature = "std"))]
         re_export_traits!("error", error_traits, core::error, Error);
-        #[cfg(feature = "std")]
-        re_export_traits!("error", error_traits, std::error, Error);
 
         re_export_traits!("from", from_traits, core::convert, From);
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,6 @@
 //! Definitions used in derived implementations of [`core::ops`] traits.
 
-use core::{fmt, error::Error};
+use core::{error::Error, fmt};
 
 /// Error returned by the derived implementations when an arithmetic or logic
 /// operation is invoked on a unit-like variant of an enum.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,6 @@
 //! Definitions used in derived implementations of [`core::ops`] traits.
 
-use core::fmt;
+use core::{fmt, error::Error};
 
 /// Error returned by the derived implementations when an arithmetic or logic
 /// operation is invoked on a unit-like variant of an enum.
@@ -24,5 +24,4 @@ impl fmt::Display for UnitError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for UnitError {}
+impl Error for UnitError {}

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,4 +1,4 @@
-use core::{fmt, error::Error};
+use core::{error::Error, fmt};
 
 /// Error of parsing an enum value its string representation.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use core::{fmt, error::Error};
 
 /// Error of parsing an enum value its string representation.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -21,5 +21,4 @@ impl fmt::Display for FromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FromStrError {}
+impl Error for FromStrError {}

--- a/src/try_unwrap.rs
+++ b/src/try_unwrap.rs
@@ -1,4 +1,4 @@
-use core::{fmt, error::Error};
+use core::{error::Error, fmt};
 
 /// Error returned by the derived [`TryUnwrap`] implementation.
 ///

--- a/src/try_unwrap.rs
+++ b/src/try_unwrap.rs
@@ -1,3 +1,5 @@
+use core::{fmt, error::Error};
+
 /// Error returned by the derived [`TryUnwrap`] implementation.
 ///
 /// [`TryUnwrap`]: macro@crate::TryUnwrap
@@ -32,8 +34,8 @@ impl<T> TryUnwrapError<T> {
     }
 }
 
-impl<T> core::fmt::Display for TryUnwrapError<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl<T> fmt::Display for TryUnwrapError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "Attempt to call `{enum_name}::{func_name}()` on a `{enum_name}::{variant_name}` value",
@@ -44,5 +46,4 @@ impl<T> core::fmt::Display for TryUnwrapError<T> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: core::fmt::Debug> std::error::Error for TryUnwrapError<T> {}
+impl<T: fmt::Debug> Error for TryUnwrapError<T> {}

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,9 +1,4 @@
-#[cfg(not(feature = "std"))]
-use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
-
-use core::panic::UnwindSafe;
+use core::{panic::UnwindSafe, error::Error};
 
 #[doc(hidden)]
 pub trait AsDynError<'a>: Sealed {

--- a/src/vendor/thiserror/aserror.rs
+++ b/src/vendor/thiserror/aserror.rs
@@ -1,4 +1,4 @@
-use core::{panic::UnwindSafe, error::Error};
+use core::{error::Error, panic::UnwindSafe};
 
 #[doc(hidden)]
 pub trait AsDynError<'a>: Sealed {

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -15,7 +15,6 @@ enum TestErr {
         source: SimpleErr,
         field: i32,
     },
-    #[cfg(feature = "std")]
     NamedImplicitBoxedSource {
         source: Box<dyn Error + Send + 'static>,
         field: i32,
@@ -24,7 +23,6 @@ enum TestErr {
         source: Option<SimpleErr>,
         field: i32,
     },
-    #[cfg(feature = "std")]
     NamedImplicitOptionalBoxedSource {
         source: Option<Box<dyn Error + Send + 'static>>,
         field: i32,
@@ -49,7 +47,6 @@ enum TestErr {
         explicit_source: RenamedOption<SimpleErr>,
         field: i32,
     },
-    #[cfg(feature = "std")]
     NamedExplicitRenamedOptionalBoxedSource {
         #[error(source(optional))]
         explicit_source: RenamedOption<Box<dyn Error + Send + 'static>>,
@@ -84,7 +81,6 @@ enum TestErr {
         #[error(source(optional))] RenamedOption<SimpleErr>,
         i32,
     ),
-    #[cfg(feature = "std")]
     UnnamedExplicitRenamedOptionalBoxedSource(
         #[error(source(optional))] RenamedOption<Box<dyn Error + Send + 'static>>,
         i32,
@@ -154,7 +150,6 @@ fn named_implicit_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_implicit_boxed_source() {
     let err = TestErr::NamedImplicitBoxedSource {
@@ -166,7 +161,6 @@ fn named_implicit_boxed_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_implicit_optional_boxed_source() {
     let err = TestErr::NamedImplicitOptionalBoxedSource {
@@ -221,7 +215,6 @@ fn named_explicit_renamed_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_explicit_renamed_optional_boxed_source() {
     let err = TestErr::NamedExplicitRenamedOptionalBoxedSource {
@@ -325,7 +318,6 @@ fn unnamed_explicit_renamed_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn unnamed_explicit_renamed_optional_boxed_source() {
     let err = TestErr::UnnamedExplicitRenamedOptionalBoxedSource(

--- a/tests/error/derives_for_enums_with_source.rs
+++ b/tests/error/derives_for_enums_with_source.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)] // some code is tested for type checking only
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use super::*;
 
 type RenamedOption<T> = Option<T>;

--- a/tests/error/derives_for_structs_with_source.rs
+++ b/tests/error/derives_for_structs_with_source.rs
@@ -35,7 +35,6 @@ fn named_implicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_implicit_boxed_source() {
     derive_display!(TestErr);
@@ -72,7 +71,6 @@ fn named_implicit_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_implicit_optional_boxed_source() {
     derive_display!(TestErr);
@@ -120,7 +118,6 @@ fn named_explicit_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_explicit_boxed_source() {
     derive_display!(TestErr);
@@ -159,7 +156,6 @@ fn named_explicit_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_explicit_optional_boxed_source() {
     derive_display!(TestErr);
@@ -198,7 +194,6 @@ fn named_explicit_renamed_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn named_explicit_renamed_optional_boxed_source() {
     derive_display!(TestErr);
@@ -365,7 +360,6 @@ fn unnamed_explicit_renamed_optional_source() {
     assert!(err.source().unwrap().is::<SimpleErr>());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn unnamed_explicit_renamed_optional_boxed_source() {
     derive_display!(TestErr);

--- a/tests/error/derives_for_structs_with_source.rs
+++ b/tests/error/derives_for_structs_with_source.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)] // some code is tested for type checking only
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use super::*;
 
 type RenamedOption<T> = Option<T>;

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use derive_more::with_trait::Error;
 
 /// Derives `std::fmt::Display` for structs/enums.

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::string::ToString;
+use alloc::string::ToString as _;
 
 use derive_more::TryInto;
 

--- a/tests/try_unwrap.rs
+++ b/tests/try_unwrap.rs
@@ -6,7 +6,7 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::string::ToString;
+use alloc::string::ToString as _;
 
 use derive_more::TryUnwrap;
 


### PR DESCRIPTION
## Synopsis

We had [TODOs across the code](https://github.com/JelteF/derive_more/blob/v2.0.1/impl/src/error.rs#L43-L44):
> ```rust
> // TODO: Use `derive_more::core::error::Error` once `error_in_core` Rust feature is
> //       stabilized.
> ```

The `feature(error_in_core)` was [stabilized in 1.81 Rust](https://github.com/rust-lang/rust/pull/125951).
It's long enough, so we can bump up our MSRV.


## Solution

- Use `core::error::Error` in codebase and remove `feature = "std"` gating for it.
- Bump up MSRV to 1.81.

## Checklist

- [x] Documentation is updated
- [x] Tests are added/updated
- [x] [CHANGELOG entry](/CHANGELOG.md) is added
