### PR TITLE
Implemented `#[skip]` for the `Add` derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#459](https://github.com/JelteF/derive_more/pull/459))
 - Support structs with no fields in `FromStr` derive.
   ([#469](https://github.com/JelteF/derive_more/pull/469))
+- Support `#[skip]` attribute for the `Add` derive to allow skipping zero sized
+  fields. ([#472](https://github.com/JelteF/derive_more/pull/472))
 
 ### Changed
 

--- a/impl/doc/add.md
+++ b/impl/doc/add.md
@@ -76,6 +76,26 @@ The behaviour is similar for more or less fields.
 
 
 
+## Skipping fields
+Sometimes the struct needs to hold a zero sized field, most commonly
+`PhantomData`. A field containing a ZST can be skipped using the `#[skip]`
+attribute like this:
+
+```rust
+#[derive(Add)]
+struct TupleWithZst<T>(i32, #[skip] PhantomData<T>);
+
+#[derive(Add)]
+struct StructWithZst<T> {
+    x: i32,
+    #[skip]
+    _marker: PhantomData<T>,
+}
+```
+
+
+
+
 ## Enums
 
 There's a big difference between the code that is generated for the two struct

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -107,11 +107,11 @@ macro_rules! create_derive(
     }
 );
 
-create_derive!("add", add_like, Add, add_derive);
-create_derive!("add", add_like, Sub, sub_derive);
-create_derive!("add", add_like, BitAnd, bit_and_derive);
-create_derive!("add", add_like, BitOr, bit_or_derive);
-create_derive!("add", add_like, BitXor, bit_xor_derive);
+create_derive!("add", add_like, Add, add_derive, skip);
+create_derive!("add", add_like, Sub, sub_derive, skip);
+create_derive!("add", add_like, BitAnd, bit_and_derive, skip);
+create_derive!("add", add_like, BitOr, bit_or_derive, skip);
+create_derive!("add", add_like, BitXor, bit_xor_derive, skip);
 
 create_derive!("add_assign", add_assign_like, AddAssign, add_assign_derive,);
 create_derive!("add_assign", add_assign_like, SubAssign, sub_assign_derive,);

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)] // some code is tested for type checking only
 
+use core::marker::PhantomData;
+
 use derive_more::Add;
 
 #[derive(Add)]
@@ -10,6 +12,16 @@ struct MyInts(i32, i32);
 struct Point2D {
     x: i32,
     y: i32,
+}
+
+#[derive(Add)]
+struct TupleWithZst<T>(i32, #[skip] PhantomData<T>);
+
+#[derive(Add)]
+struct StructWithZst<T> {
+    x: i32,
+    #[skip]
+    _marker: PhantomData<T>,
 }
 
 #[derive(Add)]


### PR DESCRIPTION
Resolves #437

## Synopsis

As outlined in #437 it isn't possible to derive `Add` for structs containing zero sized fields

Example:
```rust
#[derive(Add)] // method not found in `PhantomData<T>`
struct TupleWithZst<T>(i32, PhantomData<T>);

#[derive(Add)] // method not found in `PhantomData<T>`
struct StructWithZst<T> {
    x: i32
    _marker: PhantomData<T>,
}
```

## Solution

Added a `#[skip]` attribute that allows to skip zero sized fields like so:
```rust
#[derive(Add)]
struct TupleWithZst<T>(i32, #[skip] PhantomData<T>);

#[derive(Add)]
struct StructWithZst<T> {
    x: i32,
    #[skip]
    _marker: PhantomData<T>,
}
```

## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
