### PR TITLE
Add attribute too_many_arguments to the new method for Construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#469](https://github.com/JelteF/derive_more/pull/469))
 - Add `PartialEq` derive similar to `std`'s one, but considering generics correctly.
   ([#473](https://github.com/JelteF/derive_more/pull/473))
-- Add `#[allow(clippy::too_many_arguments)]` add attribute to the new method for Construct.
-  ([#397](https://github.com/JelteF/derive_more/issues/397))
+- Proxy-pass `#[allow]`/`#[expect]` attributes of the type in `Constructor` derive.
+  ([#477](https://github.com/JelteF/derive_more/pull/477))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#469](https://github.com/JelteF/derive_more/pull/469))
 - Add `PartialEq` derive similar to `std`'s one, but considering generics correctly.
   ([#473](https://github.com/JelteF/derive_more/pull/473))
+- Add `#[allow(clippy::too_many_arguments)]` add attribute to the new method for Construct.
+  ([#397](https://github.com/JelteF/derive_more/issues/397))
 
 ### Changed
 

--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -30,6 +30,7 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
+            #[allow(clippy::too_many_arguments)]
             #[inline]
             pub const fn new(#(#vars: #original_types),*) -> #input_type #ty_generics {
                 #body

--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -24,17 +24,18 @@ pub fn expand(input: &DeriveInput, _: &str) -> TokenStream {
         _ => panic!("Only structs can derive a constructor"),
     };
 
-    let allow_attributes = input
-        .attrs
-        .iter()
-        .filter(|attr| attr.path().get_ident().is_some_and(|name| name == "allow"));
+    let inherited_lint_attrs = input.attrs.iter().filter(|attr| {
+        attr.path()
+            .get_ident()
+            .is_some_and(|name| name == "allow" || name == "expect")
+    });
 
     let original_types = &get_field_types(&fields);
     quote! {
-        #(#allow_attributes)*      // proxy-pass any `#[allow]` attributes from input type
         #[allow(deprecated)]       // omit warnings on deprecated fields/variants
         #[allow(missing_docs)]
         #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #(#inherited_lint_attrs)*  // proxy-pass any `#[allow]`/`#[expect]` attributes
         #[automatically_derived]
         impl #impl_generics #input_type #ty_generics #where_clause {
             #[inline]

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -100,6 +100,6 @@ mod proxy_lint_attr {
     #[expect(non_snake_case)]
     #[derive(Constructor)]
     struct User {
-        Name: String,
+        Num: i32,
     }
 }

--- a/tests/constructor.rs
+++ b/tests/constructor.rs
@@ -68,3 +68,38 @@ mod deprecated {
         field: i32,
     }
 }
+
+mod proxy_lint_attr {
+    #![deny(non_snake_case, clippy::too_many_arguments)]
+
+    use super::*;
+
+    #[allow(clippy::too_many_arguments)]
+    #[derive(Constructor)]
+    struct ManyArguments(
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+        u8,
+    );
+
+    #[expect(non_snake_case)]
+    #[derive(Constructor)]
+    struct User {
+        Name: String,
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/JelteF/derive_more/issues/397

## Synopsis

Clippy emits a too_many_arguments warning for the new method generated by the Constructor derive.
Clippy attributes currently have no effect in this context.

## Solution

Add #[allow(clippy::too_many_arguments)] to the generated new method to suppress the warning without affecting other code.