### PR TITLE
Satisfy new `mismatched-lifetime-syntaxes` lint

### DIFF
--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -280,7 +280,7 @@ pub(crate) fn format(input: &str) -> Option<(LeftToParse<'_>, Format<'_>)> {
 /// ```
 ///
 /// [0]: std::fmt#syntax
-fn argument(input: &str) -> Option<(LeftToParse<'_>, Argument)> {
+fn argument(input: &str) -> Option<(LeftToParse<'_>, Argument<'_>)> {
     alt(&mut [
         &mut map(identifier, |(i, ident)| (i, Argument::Identifier(ident))),
         &mut map(integer, |(i, int)| (i, Argument::Integer(int))),


### PR DESCRIPTION
## Synopsis

A new `mismatched-lifetime-syntaxes` lint was introduced in rust-lang/rust#138677.

## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

## Checklist

- [x] Documentation is updated (not required)
- [x] Tests are added/updated (not required)
- [x] [CHANGELOG entry](/CHANGELOG.md) is added (not required)
