### PR TITLE
Remove unstable feature requirement when deriving backtraced `Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Erroneous code generated in `Try`/`TryInto` derives when `Self` type is present in
   the struct or enum definition.
   ([#489](https://github.com/JelteF/derive_more/pull/489))
-- Dependency on unstable `error_generic_member_access` feature in `Error` derive when
-  using backtraces on a non-nightly toolchain.
-  ([#513](https://github.com/JelteF/derive_more/pull/512))
+- Dependency on unstable `feature(error_generic_member_access)` in `Error` derive when
+  using `Backtrace` on a non-nightly toolchain.
+  ([#513](https://github.com/JelteF/derive_more/pull/513))
 
 ## 2.0.1 - 2025-02-03
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -30,7 +30,7 @@ convert_case = { version = "0.8", optional = true }
 unicode-xid = { version = "0.2.2", optional = true }
 
 [build-dependencies]
-rustc_version = { version = "0.4" }
+rustc_version = "0.4"
 
 [dev-dependencies]
 derive_more = { path = "..", features = ["full"] }
@@ -44,7 +44,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(nightly)", "cfg(error_generic_member_access)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ci)", "cfg(error_generic_member_access)", "cfg(nightly)"] }
 
 [features]
 default = []

--- a/impl/build.rs
+++ b/impl/build.rs
@@ -1,5 +1,12 @@
 use rustc_version::{version_meta, Channel};
 
+fn detect_error_generic_member_access() {
+    // Error backtraces require `feature(error_generic_member_access)`.
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=error_generic_member_access");
+    }
+}
+
 #[cfg(not(feature = "testing-helpers"))]
 fn detect_nightly() {}
 
@@ -10,14 +17,7 @@ fn detect_nightly() {
     }
 }
 
-fn detect_error_generic_member_access() {
-    // Error backtraces require the unstable generic member access API
-    if version_meta().unwrap().channel == Channel::Nightly {
-        println!("cargo:rustc-cfg=error_generic_member_access");
-    }
-}
-
 fn main() {
-    detect_nightly();
     detect_error_generic_member_access();
+    detect_nightly();
 }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -109,11 +109,9 @@ fn render_struct(
     let parsed_fields = parse_fields(type_params, state)?;
 
     let source = parsed_fields.render_source_as_struct();
-    let provide = if cfg!(error_generic_member_access) {
-        parsed_fields.render_provide_as_struct()
-    } else {
-        None
-    };
+    let provide = cfg!(error_generic_member_access)
+        .then(|| parsed_fields.render_provide_as_struct())
+        .flatten();
 
     Ok((parsed_fields.bounds, source, provide))
 }


### PR DESCRIPTION
Resolves #512.

## Synopsis

The standard library `Error` provider API is available only in nightly, locked behind the unstable `error_generic_member_access` feature. Deriving `Error` when a `backtrace` field is present generates implementations for these API methods, resulting in:

    error[E0658]: use of unstable library feature `error_generic_member_access`

## Solution

This change stops these trait methods from being rendered when deriving the `Error` trait on a non-nightly toolchain.

## Checklist

- [x] Documentation is updated (not required)
- [x] Tests are added/updated (not required)
- [x] [CHANGELOG entry](/CHANGELOG.md) is added