### PR TITLE
Fix `From` tests

### DIFF
--- a/tests/from.rs
+++ b/tests/from.rs
@@ -13,14 +13,13 @@ use alloc::{
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 
-use derive_more::From;
 use static_assertions::assert_not_impl_any;
 
 mod structs {
     use super::*;
 
     mod unit {
-        use super::*;
+        use derive_more::From;
 
         #[derive(Debug, From, PartialEq)]
         struct Unit;
@@ -39,7 +38,7 @@ mod structs {
         }
 
         mod generic {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             struct Unit<const N: usize>;
@@ -61,6 +60,7 @@ mod structs {
 
     mod single_field {
         use super::*;
+        use derive_more::From;
 
         #[derive(Debug, From, PartialEq)]
         struct Tuple(i32);
@@ -78,6 +78,7 @@ mod structs {
 
         mod types {
             use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             #[from(i8)]
@@ -114,6 +115,7 @@ mod structs {
 
         mod forward {
             use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             #[from(forward)]
@@ -146,7 +148,7 @@ mod structs {
         }
 
         mod generic {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             struct Tuple<T>(T);
@@ -163,7 +165,7 @@ mod structs {
             }
 
             mod reference {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct Tuple<'a, T>(&'a T);
@@ -181,7 +183,7 @@ mod structs {
             }
 
             mod indirect {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct Tuple<T: 'static>(&'static T);
@@ -199,7 +201,7 @@ mod structs {
             }
 
             mod bounded {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct Tuple<T: Clone>(T);
@@ -217,7 +219,7 @@ mod structs {
             }
 
             mod r#const {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct Tuple<const N: usize, T>(T);
@@ -238,6 +240,7 @@ mod structs {
 
     mod multi_field {
         use super::*;
+        use derive_more::From;
 
         #[derive(Debug, From, PartialEq)]
         struct Tuple(i32, i16);
@@ -262,6 +265,7 @@ mod structs {
 
         mod types {
             use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             #[from((i16, i16))]
@@ -291,7 +295,7 @@ mod structs {
         }
 
         mod forward {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             #[from(forward)]
@@ -358,7 +362,7 @@ mod structs {
         }
 
         mod generic {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             struct Tuple<A, B>(A, B);
@@ -382,7 +386,7 @@ mod structs {
             }
 
             mod reference {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct Tuple<'a, A, B>(&'a A, &'a B);
@@ -407,7 +411,7 @@ mod structs {
             }
 
             mod bounded {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct Tuple<A: Clone, B>(A, B);
@@ -432,7 +436,7 @@ mod structs {
             }
 
             mod r#const {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 struct ConstTuple<const N: usize, A, B>(A, B);
@@ -459,7 +463,7 @@ mod structs {
 
         #[cfg(nightly)]
         mod never {
-            use super::*;
+            use derive_more::From;
 
             #[derive(From)]
             struct Tuple(i32, !);
@@ -472,7 +476,7 @@ mod structs {
         }
 
         mod deprecated {
-            use super::*;
+            use derive_more::From;
 
             #[derive(From)]
             #[deprecated(note = "struct")]
@@ -495,6 +499,7 @@ mod enums {
 
     mod unit_variant {
         use super::*;
+        use derive_more::From;
 
         #[derive(Debug, From, PartialEq)]
         enum Enum {
@@ -511,6 +516,7 @@ mod enums {
 
         mod generic {
             use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Unit {
@@ -533,6 +539,7 @@ mod enums {
 
             mod r#const {
                 use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Unit<const N: usize> {
@@ -556,7 +563,7 @@ mod enums {
         }
 
         mod from {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Unit {
@@ -587,7 +594,7 @@ mod enums {
             }
 
             mod r#const {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Unit<const N: usize> {
@@ -619,6 +626,7 @@ mod enums {
 
     mod single_field_variant {
         use super::*;
+        use derive_more::From;
 
         #[derive(Debug, From, PartialEq)]
         enum Enum {
@@ -633,7 +641,7 @@ mod enums {
         }
 
         mod generic {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Tuple<T> {
@@ -652,7 +660,7 @@ mod enums {
             }
 
             mod reference {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<'a, T> {
@@ -672,7 +680,7 @@ mod enums {
             }
 
             mod indirect {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<T: 'static> {
@@ -692,7 +700,7 @@ mod enums {
             }
 
             mod bounded {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<T: Clone> {
@@ -712,7 +720,7 @@ mod enums {
             }
 
             mod r#const {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<T, const N: usize> {
@@ -733,7 +741,7 @@ mod enums {
         }
 
         mod from {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Tuple {
@@ -761,7 +769,7 @@ mod enums {
         }
 
         mod skip {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Enum {
@@ -784,7 +792,7 @@ mod enums {
             }
 
             mod generic {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<T> {
@@ -811,7 +819,7 @@ mod enums {
                 }
 
                 mod reference {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<'a, T> {
@@ -839,7 +847,7 @@ mod enums {
                 }
 
                 mod indirect {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<T: 'static> {
@@ -867,7 +875,7 @@ mod enums {
                 }
 
                 mod bounded {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<T: Clone> {
@@ -895,7 +903,7 @@ mod enums {
                 }
 
                 mod r#const {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<T, const N: usize> {
@@ -923,7 +931,7 @@ mod enums {
                 }
 
                 mod concrete {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<T> {
@@ -950,7 +958,7 @@ mod enums {
                     }
 
                     mod reference {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<'a, T> {
@@ -981,7 +989,7 @@ mod enums {
                     }
 
                     mod indirect {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<T: 'static> {
@@ -1012,7 +1020,7 @@ mod enums {
                     }
 
                     mod bounded {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<T: Clone> {
@@ -1040,7 +1048,7 @@ mod enums {
                     }
 
                     mod r#const {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<T, const N: usize> {
@@ -1075,6 +1083,7 @@ mod enums {
 
         mod types {
             use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Enum {
@@ -1096,7 +1105,7 @@ mod enums {
         }
 
         mod forward {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Unnamed {
@@ -1130,6 +1139,7 @@ mod enums {
 
     mod multi_field_variant {
         use super::*;
+        use derive_more::From;
 
         #[derive(Debug, From, PartialEq)]
         enum Enum {
@@ -1150,7 +1160,7 @@ mod enums {
         }
 
         mod generic {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Tuple<A, B> {
@@ -1175,7 +1185,7 @@ mod enums {
             }
 
             mod reference {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<'a, A, B> {
@@ -1201,7 +1211,7 @@ mod enums {
             }
 
             mod indirect {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<A: 'static, B: 'static> {
@@ -1230,7 +1240,7 @@ mod enums {
             }
 
             mod bounded {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<A: Clone, B> {
@@ -1256,7 +1266,7 @@ mod enums {
             }
 
             mod r#const {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<const N: usize, A, B> {
@@ -1283,7 +1293,7 @@ mod enums {
         }
 
         mod from {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Tuple {
@@ -1319,7 +1329,7 @@ mod enums {
         }
 
         mod skip {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Enum {
@@ -1350,7 +1360,7 @@ mod enums {
             }
 
             mod generic {
-                use super::*;
+                use derive_more::From;
 
                 #[derive(Debug, From, PartialEq)]
                 enum Tuple<A, B> {
@@ -1385,7 +1395,7 @@ mod enums {
                 }
 
                 mod reference {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<'a, A, B> {
@@ -1421,7 +1431,7 @@ mod enums {
                 }
 
                 mod indirect {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<A: 'static, B: 'static> {
@@ -1457,7 +1467,7 @@ mod enums {
                 }
 
                 mod bounded {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<A: Clone, B> {
@@ -1493,7 +1503,7 @@ mod enums {
                 }
 
                 mod r#const {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<const N: usize, A, B> {
@@ -1532,7 +1542,7 @@ mod enums {
                 }
 
                 mod concrete {
-                    use super::*;
+                    use derive_more::From;
 
                     #[derive(Debug, From, PartialEq)]
                     enum Tuple<A, B> {
@@ -1570,7 +1580,7 @@ mod enums {
                     }
 
                     mod reference {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<'a, A, B> {
@@ -1609,7 +1619,7 @@ mod enums {
                     }
 
                     mod indirect {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<A: 'static, B: 'static> {
@@ -1648,7 +1658,7 @@ mod enums {
                     }
 
                     mod bounded {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<A: Clone, B> {
@@ -1687,7 +1697,7 @@ mod enums {
                     }
 
                     mod r#const {
-                        use super::*;
+                        use derive_more::From;
 
                         #[derive(Debug, From, PartialEq)]
                         enum Tuple<const N: usize, A, B> {
@@ -1730,6 +1740,7 @@ mod enums {
 
         mod types {
             use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Enum {
@@ -1761,7 +1772,7 @@ mod enums {
         }
 
         mod forward {
-            use super::*;
+            use derive_more::From;
 
             #[derive(Debug, From, PartialEq)]
             enum Unnamed {
@@ -1822,7 +1833,7 @@ mod enums {
 
         #[cfg(nightly)]
         mod never {
-            use super::*;
+            use derive_more::From;
 
             #[derive(From)]
             enum Enum {
@@ -1832,7 +1843,7 @@ mod enums {
         }
 
         mod deprecated {
-            use super::*;
+            use derive_more::From;
 
             #[derive(From)]
             #[deprecated(note = "enum")]


### PR DESCRIPTION
Required for #527   
Related to #525

## Synopsis

Rust nightly 1.94 has regression around glob imports of `From` derive.

See:
- https://github.com/JelteF/derive_more/issues/525
- https://github.com/rust-lang/rust/issues/145524#issuecomment-3656525862

## Solution

Fix `From` derive tests to pass CI by removing glob importing.
