### PR TITLE
Prepare 2.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## master
+## 2.1.1 - 2025-12-19
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_more"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.81.0"
 description = "Adds #[derive(x)] macros for more traits"
@@ -27,7 +27,7 @@ include = [
 members = ["impl"]
 
 [dependencies]
-derive_more-impl = { version = "=2.1.0", path = "impl" }
+derive_more-impl = { version = "=2.1.1", path = "impl" }
 
 [build-dependencies]
 rustc_version = { version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Changing [MSRV] (minimum supported Rust version) of this crate is treated as a *
 - However, if [MSRV] changes are concerning for your project, then use the [tilde requirement] to **pin to a specific minor version**:
   ```toml
   [dependencies]
-  derive_more = "~2.1" # or "~2.1.0"
+  derive_more = "~2.1" # or "~2.1.1"
   ```
 
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_more-impl"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.81.0"
 description = "Internal implementation of `derive_more` crate"


### PR DESCRIPTION
Includes hygienic fix for `derive(Error)`.