### PR TITLE
Add support for custom equality functions in Eq/PartialEq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Hash` derive similar to `std`'s one, but considering generics correctly,
   and supporting custom hash functions per field or skipping fields.
   ([#532](https://github.com/JelteF/derive_more/pull/532))
+- Add support for custom eq functions in `PartialEq` derive.
+  ([#535](https://github.com/JelteF/derive_more/pull/535))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Hash` derive similar to `std`'s one, but considering generics correctly,
   and supporting custom hash functions per field or skipping fields.
   ([#532](https://github.com/JelteF/derive_more/pull/532))
-- Add support for custom eq functions in `PartialEq` derive.
+- Add support for custom eq functions in `PartialEq`/`Eq` derive.
   ([#535](https://github.com/JelteF/derive_more/pull/535))
 
 ### Fixed

--- a/impl/doc/eq.md
+++ b/impl/doc/eq.md
@@ -286,3 +286,58 @@ impl PartialEq for Enum {
     }
 }
 ```
+
+### Custom comparison with `with`
+
+Both `#[eq(with(...))]` and  `#[partial_eq(with(...))]` attribute allows specifying a custom comparison function
+for a field. The function must have the signature `fn(&T, &T) -> bool` where `T` is the field type.
+
+```rust
+# use derive_more::{Eq, PartialEq};
+
+mod custom_eq {
+   #[derive(Debug)]
+   pub struct NotPartialEq(pub i32);
+   
+   pub fn compare(a: &NotPartialEq, b: &NotPartialEq) -> bool {
+       a.0 == b.0
+   }
+}
+use custom_eq::NotPartialEq;
+
+#[derive(Debug, PartialEq, Eq)]
+struct Foo(#[partial_eq(with(custom_eq::compare))] NotPartialEq);
+
+assert_eq!(Foo(NotPartialEq(42)), Foo(NotPartialEq(42)));
+assert_ne!(Foo(NotPartialEq(42)), Foo(NotPartialEq(73)));
+```
+
+This generates code equivalent to:
+
+```rust
+#
+# mod custom_eq {
+#    #[derive(Debug)]
+#    pub struct NotPartialEq(i32);
+# 
+#    pub fn compare(a: &NotPartialEq, b: &NotPartialEq) -> bool {
+#       a.0 == b.0
+#    }
+# }
+# use custom_eq::NotPartialEq;
+#
+# struct Foo(NotPartialEq);
+# 
+impl PartialEq for Foo {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self(self_0), Self(other_0)) => custom_eq::compare(self_0, other_0)
+        }
+    }
+    fn ne(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self(self_0), Self(other_0)) => !custom_eq::compare(self_0, other_0)
+        }
+    }
+}
+```

--- a/impl/doc/eq.md
+++ b/impl/doc/eq.md
@@ -289,8 +289,9 @@ impl PartialEq for Enum {
 
 ### Custom comparison with `with`
 
-Both `#[eq(with(...))]` and `#[partial_eq(with(...))]` attributes allows specifying a custom comparison function
-for a field. The function must have the signature `fn(&T, &T) -> bool` where `T` is the field type.
+The `#[partial_eq(with(...))]` attribute allows specifying a custom comparison function for a field.
+The function must have the signature `fn(&T, &T) -> bool` where `T` is the field type. `derive(Eq)` honors
+`#[partial_eq(with(...))]` by not requiring an `Eq` bound on that field's type.
 
 ```rust
 # use derive_more::{Eq, PartialEq};

--- a/impl/doc/eq.md
+++ b/impl/doc/eq.md
@@ -289,7 +289,7 @@ impl PartialEq for Enum {
 
 ### Custom comparison with `with`
 
-Both `#[eq(with(...))]` and  `#[partial_eq(with(...))]` attribute allows specifying a custom comparison function
+Both `#[eq(with(...))]` and `#[partial_eq(with(...))]` attributes allows specifying a custom comparison function
 for a field. The function must have the signature `fn(&T, &T) -> bool` where `T` is the field type.
 
 ```rust

--- a/impl/doc/hash.md
+++ b/impl/doc/hash.md
@@ -272,3 +272,7 @@ impl Hash for Foo {
 
 This is useful for types that don't implement `Hash` but can be hashed in a custom way, or when you need different
 hashing behavior than the default.
+
+Note: if a field carries `#[partial_eq(with(...))]`, then `#[derive(Hash)]` requires either
+`#[hash(with(...))]` or `#[hash(skip)]` on the same field. Otherwise the default per-field hashing
+may disagree with the custom equality and break the `k1 == k2 -> hash(k1) == hash(k2)` invariant.

--- a/impl/src/cmp/eq.rs
+++ b/impl/src/cmp/eq.rs
@@ -28,7 +28,12 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
             if !is_skipped {
                 'fields: for field in &data.fields {
                     for attr_name in [&attr_name, &secondary_attr_name] {
-                        if attr::Skip::parse_attrs(&field.attrs, attr_name)?.is_some() {
+                        if attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)?
+                            .is_some()
+                        {
+                            // if skipped, we don't want to add a bound on the field type
+                            // if a with function is provided, then adding a bound is counterproductive
+                            // as the with function may handle types that do not implement Eq
                             continue 'fields;
                         }
                     }
@@ -45,7 +50,12 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 }
                 'fields: for field in &variant.fields {
                     for attr_name in [&attr_name, &secondary_attr_name] {
-                        if attr::Skip::parse_attrs(&field.attrs, attr_name)?.is_some() {
+                        if attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)?
+                            .is_some()
+                        {
+                            // if skipped, we don't want to add a bound on the field type
+                            // if a with function is provided, then adding a bound is counterproductive
+                            // as the with function may handle types that do not implement Eq
                             continue 'fields;
                         }
                     }

--- a/impl/src/cmp/eq.rs
+++ b/impl/src/cmp/eq.rs
@@ -27,15 +27,18 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
             }
             if !is_skipped {
                 'fields: for field in &data.fields {
-                    for attr_name in [&attr_name, &secondary_attr_name] {
-                        if attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)?
-                            .is_some()
-                        {
-                            // if skipped, we don't want to add a bound on the field type
-                            // if a with function is provided, then adding a bound is counterproductive
-                            // as the with function may handle types that do not implement Eq
-                            continue 'fields;
-                        }
+                    if attr::Skip::parse_attrs(&field.attrs, &attr_name)?.is_some()
+                        || attr::WithOrSkip::parse_attrs(
+                            &field.attrs,
+                            &secondary_attr_name,
+                        )?
+                        .is_some()
+                    {
+                        // If skipped, we don't want to add a bound on the field type.
+                        // If a `with` function is provided for `PartialEq`, then adding a bound is
+                        // counterproductive as the `with` function may handle types that do not
+                        // implement `Eq`.
+                        continue 'fields;
                     }
                     _ = fields_types.insert(&field.ty);
                 }
@@ -49,15 +52,18 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     }
                 }
                 'fields: for field in &variant.fields {
-                    for attr_name in [&attr_name, &secondary_attr_name] {
-                        if attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)?
-                            .is_some()
-                        {
-                            // if skipped, we don't want to add a bound on the field type
-                            // if a with function is provided, then adding a bound is counterproductive
-                            // as the with function may handle types that do not implement Eq
-                            continue 'fields;
-                        }
+                    if attr::Skip::parse_attrs(&field.attrs, &attr_name)?.is_some()
+                        || attr::WithOrSkip::parse_attrs(
+                            &field.attrs,
+                            &secondary_attr_name,
+                        )?
+                        .is_some()
+                    {
+                        // If skipped, we don't want to add a bound on the field type.
+                        // If a `with` function is provided for `PartialEq`, then adding a bound is
+                        // counterproductive as the `with` function may handle types that do not
+                        // implement `Eq`.
+                        continue 'fields;
                     }
                     _ = fields_types.insert(&field.ty);
                 }

--- a/impl/src/cmp/partial_eq.rs
+++ b/impl/src/cmp/partial_eq.rs
@@ -36,24 +36,28 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 let mut alternate_eq_functions =
                     FieldsWithAlternateEqFunction::default();
                 'fields: for (n, field) in data.fields.iter().enumerate() {
-                    for attr_name in [&attr_name, &secondary_attr_name] {
-                        match attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)? {
-                            Some(Spanning {
-                                item: attr::WithOrSkip::Skip,
-                                ..
-                            }) => {
-                                _ = skipped_fields.insert(n);
-                                continue 'fields;
-                            }
-                            Some(Spanning {
-                                item: attr::WithOrSkip::With(with),
-                                ..
-                            }) => {
-                                alternate_eq_functions.insert(n, with.func);
-                                continue 'fields;
-                            }
-                            None => {}
+                    match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
+                        Some(Spanning {
+                            item: attr::WithOrSkip::Skip,
+                            ..
+                        }) => {
+                            _ = skipped_fields.insert(n);
+                            continue 'fields;
                         }
+                        Some(Spanning {
+                            item: attr::WithOrSkip::With(with),
+                            ..
+                        }) => {
+                            alternate_eq_functions.insert(n, with.func);
+                            continue 'fields;
+                        }
+                        None => {}
+                    }
+                    if attr::Skip::parse_attrs(&field.attrs, &secondary_attr_name)?
+                        .is_some()
+                    {
+                        _ = skipped_fields.insert(n);
+                        continue 'fields;
                     }
                 }
                 variants.push((
@@ -76,24 +80,28 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 let mut alternate_eq_functions =
                     FieldsWithAlternateEqFunction::default();
                 'fields: for (n, field) in variant.fields.iter().enumerate() {
-                    for attr_name in [&attr_name, &secondary_attr_name] {
-                        match attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)? {
-                            Some(Spanning {
-                                item: attr::WithOrSkip::Skip,
-                                ..
-                            }) => {
-                                _ = skipped_fields.insert(n);
-                                continue 'fields;
-                            }
-                            Some(Spanning {
-                                item: attr::WithOrSkip::With(with),
-                                ..
-                            }) => {
-                                alternate_eq_functions.insert(n, with.func);
-                                continue 'fields;
-                            }
-                            None => {}
+                    match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
+                        Some(Spanning {
+                            item: attr::WithOrSkip::Skip,
+                            ..
+                        }) => {
+                            _ = skipped_fields.insert(n);
+                            continue 'fields;
                         }
+                        Some(Spanning {
+                            item: attr::WithOrSkip::With(with),
+                            ..
+                        }) => {
+                            alternate_eq_functions.insert(n, with.func);
+                            continue 'fields;
+                        }
+                        None => {}
+                    }
+                    if attr::Skip::parse_attrs(&field.attrs, &secondary_attr_name)?
+                        .is_some()
+                    {
+                        _ = skipped_fields.insert(n);
+                        continue 'fields;
                     }
                 }
                 variants.push((

--- a/impl/src/cmp/partial_eq.rs
+++ b/impl/src/cmp/partial_eq.rs
@@ -12,7 +12,7 @@ use crate::utils::{
     attr::{self, ParseMultiple as _},
     pattern_matching::FieldsExt as _,
     structural_inclusion::TypeExt as _,
-    GenericsSearch, HashSet,
+    GenericsSearch, HashMap, HashSet, Spanning,
 };
 
 /// Expands a [`PartialEq`] derive macro.
@@ -33,15 +33,35 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
             }
             if !has_skipped_variants {
                 let mut skipped_fields = SkippedFields::default();
+                let mut alternate_eq_functions =
+                    FieldsWithAlternateEqFunction::default();
                 'fields: for (n, field) in data.fields.iter().enumerate() {
                     for attr_name in [&attr_name, &secondary_attr_name] {
-                        if attr::Skip::parse_attrs(&field.attrs, attr_name)?.is_some() {
-                            _ = skipped_fields.insert(n);
-                            continue 'fields;
+                        match attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)? {
+                            Some(Spanning {
+                                item: attr::WithOrSkip::Skip,
+                                ..
+                            }) => {
+                                _ = skipped_fields.insert(n);
+                                continue 'fields;
+                            }
+                            Some(Spanning {
+                                item: attr::WithOrSkip::With(with),
+                                ..
+                            }) => {
+                                alternate_eq_functions.insert(n, with.func);
+                                continue 'fields;
+                            }
+                            None => {}
                         }
                     }
                 }
-                variants.push((None, &data.fields, skipped_fields));
+                variants.push((
+                    None,
+                    &data.fields,
+                    skipped_fields,
+                    alternate_eq_functions,
+                ));
             }
         }
         syn::Data::Enum(data) => {
@@ -53,15 +73,35 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     }
                 }
                 let mut skipped_fields = SkippedFields::default();
+                let mut alternate_eq_functions =
+                    FieldsWithAlternateEqFunction::default();
                 'fields: for (n, field) in variant.fields.iter().enumerate() {
                     for attr_name in [&attr_name, &secondary_attr_name] {
-                        if attr::Skip::parse_attrs(&field.attrs, attr_name)?.is_some() {
-                            _ = skipped_fields.insert(n);
-                            continue 'fields;
+                        match attr::WithOrSkip::parse_attrs(&field.attrs, attr_name)? {
+                            Some(Spanning {
+                                item: attr::WithOrSkip::Skip,
+                                ..
+                            }) => {
+                                _ = skipped_fields.insert(n);
+                                continue 'fields;
+                            }
+                            Some(Spanning {
+                                item: attr::WithOrSkip::With(with),
+                                ..
+                            }) => {
+                                alternate_eq_functions.insert(n, with.func);
+                                continue 'fields;
+                            }
+                            None => {}
                         }
                     }
                 }
-                variants.push((Some(&variant.ident), &variant.fields, skipped_fields));
+                variants.push((
+                    Some(&variant.ident),
+                    &variant.fields,
+                    skipped_fields,
+                    alternate_eq_functions,
+                ));
             }
         }
         syn::Data::Union(data) => {
@@ -84,6 +124,10 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
 /// Indices of [`syn::Field`]s marked with an [`attr::Skip`].
 type SkippedFields = HashSet<usize>;
 
+/// Mapping from [`syn::Field`] marked with an [`attr::With`] to the [`syn::Path`] of the alternate
+/// eq function.
+type FieldsWithAlternateEqFunction = HashMap<usize, syn::Path>;
+
 /// Expansion of a macro for generating a structural [`PartialEq`] implementation of an enum or a
 /// struct.
 struct StructuralExpansion<'i> {
@@ -93,7 +137,12 @@ struct StructuralExpansion<'i> {
     self_ty: (&'i syn::Ident, &'i syn::Generics),
 
     /// [`syn::Fields`] of the enum/struct to be compared in this [`StructuralExpansion`].
-    variants: Vec<(Option<&'i syn::Ident>, &'i syn::Fields, SkippedFields)>,
+    variants: Vec<(
+        Option<&'i syn::Ident>,
+        &'i syn::Fields,
+        SkippedFields,
+        FieldsWithAlternateEqFunction,
+    )>,
 
     /// Indicator whether some original enum variants where skipped with an [`attr::Skip`].
     has_skipped_variants: bool,
@@ -144,7 +193,7 @@ impl StructuralExpansion<'_> {
         let match_arms = self
             .variants
             .iter()
-            .filter_map(|(variant, all_fields, skipped_fields)| {
+            .filter_map(|(variant, all_fields, skipped_fields, alternate_eq_functions)| {
                 if all_fields.is_empty() || skipped_fields.len() == all_fields.len() {
                     return None;
                 }
@@ -160,7 +209,16 @@ impl StructuralExpansion<'_> {
                     .map(|num| {
                         let self_val = format_ident!("__self_{num}");
                         let other_val = format_ident!("__other_{num}");
-                        punctuated::Pair::Punctuated(quote! { #self_val #cmp #other_val }, &chain)
+                        let equality = alternate_eq_functions
+                            .get(&num)
+                            .map(|eq_fn| {
+                                let maybe_not = (!eq).then(|| quote! {!});
+                                quote! { #maybe_not #eq_fn(#self_val, #other_val) }
+                            }
+                            ).unwrap_or_else(||
+                            quote! { #self_val #cmp #other_val }
+                        );
+                        punctuated::Pair::Punctuated(equality, &chain)
                     })
                     .collect::<Punctuated<TokenStream, _>>();
                 _ = val_eqs.pop_punct();
@@ -178,14 +236,14 @@ impl StructuralExpansion<'_> {
                 });
             let unreachable_arm = (self.variants.len() > 1
                 && no_fields_arm.is_none())
-            .then(|| {
-                quote! {
+                .then(|| {
+                    quote! {
                     // SAFETY: This arm is never reachable due to `mem::discriminant()` comparison
                     //         preceding the expanded `match (self, other)` expression, but is
                     //         required by it when there is more than one variant.
                     _ => unsafe { derive_more::core::hint::unreachable_unchecked() },
                 }
-            });
+                });
 
             quote! {
                 match (self, __other) {
@@ -221,7 +279,7 @@ impl ToTokens for StructuralExpansion<'_> {
         {
             let self_ty: syn::Type = parse_quote! { Self };
             let implementor_ty: syn::Type = parse_quote! { #ty #ty_generics };
-            for (_, all_fields, skipped_fields) in &self.variants {
+            for (_, all_fields, skipped_fields, _) in &self.variants {
                 for field_ty in
                     all_fields.iter().enumerate().filter_map(|(n, field)| {
                         (!skipped_fields.contains(&n)).then_some(&field.ty)

--- a/impl/src/cmp/partial_eq.rs
+++ b/impl/src/cmp/partial_eq.rs
@@ -33,8 +33,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
             }
             if !has_skipped_variants {
                 let mut skipped_fields = SkippedFields::default();
-                let mut alternate_eq_functions =
-                    FieldsWithAlternateEqFunction::default();
+                let mut custom_eq_functions = FieldsWithCustomEqFunction::default();
                 'fields: for (n, field) in data.fields.iter().enumerate() {
                     match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         Some(Spanning {
@@ -48,7 +47,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                             item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
-                            alternate_eq_functions.insert(n, with.func);
+                            custom_eq_functions.insert(n, with.func);
                             continue 'fields;
                         }
                         None => {}
@@ -64,7 +63,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     None,
                     &data.fields,
                     skipped_fields,
-                    alternate_eq_functions,
+                    custom_eq_functions,
                 ));
             }
         }
@@ -77,8 +76,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     }
                 }
                 let mut skipped_fields = SkippedFields::default();
-                let mut alternate_eq_functions =
-                    FieldsWithAlternateEqFunction::default();
+                let mut custom_eq_functions = FieldsWithCustomEqFunction::default();
                 'fields: for (n, field) in variant.fields.iter().enumerate() {
                     match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         Some(Spanning {
@@ -92,7 +90,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                             item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
-                            alternate_eq_functions.insert(n, with.func);
+                            custom_eq_functions.insert(n, with.func);
                             continue 'fields;
                         }
                         None => {}
@@ -108,7 +106,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     Some(&variant.ident),
                     &variant.fields,
                     skipped_fields,
-                    alternate_eq_functions,
+                    custom_eq_functions,
                 ));
             }
         }
@@ -132,9 +130,9 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
 /// Indices of [`syn::Field`]s marked with an [`attr::Skip`].
 type SkippedFields = HashSet<usize>;
 
-/// Mapping from [`syn::Field`] marked with an [`attr::With`] to the [`syn::Path`] of the alternate
+/// Mapping from [`syn::Field`] marked with an [`attr::With`] to the [`syn::Path`] of the custom
 /// eq function.
-type FieldsWithAlternateEqFunction = HashMap<usize, syn::Path>;
+type FieldsWithCustomEqFunction = HashMap<usize, syn::Path>;
 
 /// Expansion of a macro for generating a structural [`PartialEq`] implementation of an enum or a
 /// struct.
@@ -149,7 +147,7 @@ struct StructuralExpansion<'i> {
         Option<&'i syn::Ident>,
         &'i syn::Fields,
         SkippedFields,
-        FieldsWithAlternateEqFunction,
+        FieldsWithCustomEqFunction,
     )>,
 
     /// Indicator whether some original enum variants where skipped with an [`attr::Skip`].
@@ -201,7 +199,7 @@ impl StructuralExpansion<'_> {
         let match_arms = self
             .variants
             .iter()
-            .filter_map(|(variant, all_fields, skipped_fields, alternate_eq_functions)| {
+            .filter_map(|(variant, all_fields, skipped_fields, custom_eq_functions)| {
                 if all_fields.is_empty() || skipped_fields.len() == all_fields.len() {
                     return None;
                 }
@@ -217,7 +215,7 @@ impl StructuralExpansion<'_> {
                     .map(|num| {
                         let self_val = format_ident!("__self_{num}");
                         let other_val = format_ident!("__other_{num}");
-                        let equality = alternate_eq_functions
+                        let equality = custom_eq_functions
                             .get(&num)
                             .map(|eq_fn| {
                                 let maybe_not = (!eq).then(|| quote! {!});

--- a/impl/src/cmp/partial_eq.rs
+++ b/impl/src/cmp/partial_eq.rs
@@ -215,8 +215,7 @@ impl StructuralExpansion<'_> {
                                 let maybe_not = (!eq).then(|| quote! {!});
                                 quote! { #maybe_not #eq_fn(#self_val, #other_val) }
                             }
-                            ).unwrap_or_else(||
-                            quote! { #self_val #cmp #other_val }
+                            ).unwrap_or_else(|| quote! { #self_val #cmp #other_val }
                         );
                         punctuated::Pair::Punctuated(equality, &chain)
                     })

--- a/impl/src/hash.rs
+++ b/impl/src/hash.rs
@@ -8,7 +8,6 @@ use crate::utils::{
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
-use syn::parse::{Parse, ParseStream};
 use syn::{
     parse_quote,
     punctuated::{self, Punctuated},
@@ -39,7 +38,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 let mut alternate_hash_functions =
                     FieldsWithAlternateHashFunction::default();
                 'fields: for (n, field) in data.fields.iter().enumerate() {
-                    match FieldAttributes::parse_attrs(&field.attrs, &attr_name)? {
+                    match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         None => {
                             for attr_name in &secondary_attr_names {
                                 if attr::Skip::parse_attrs(&field.attrs, attr_name)?
@@ -51,14 +50,14 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                             }
                         }
                         Some(Spanning {
-                            item: FieldAttributes::Skip,
+                            item: attr::WithOrSkip::Skip,
                             ..
                         }) => {
                             skipped_fields.insert(n);
                         }
 
                         Some(Spanning {
-                            item: FieldAttributes::With(with),
+                            item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
                             alternate_hash_functions.insert(n, with.func.clone());
@@ -85,7 +84,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 let mut alternate_hash_functions =
                     FieldsWithAlternateHashFunction::default();
                 'fields: for (n, field) in variant.fields.iter().enumerate() {
-                    match FieldAttributes::parse_attrs(&field.attrs, &attr_name)? {
+                    match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         None => {
                             for attr_name in &secondary_attr_names {
                                 if attr::Skip::parse_attrs(&field.attrs, attr_name)?
@@ -97,14 +96,14 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                             }
                         }
                         Some(Spanning {
-                            item: FieldAttributes::Skip,
+                            item: attr::WithOrSkip::Skip,
                             ..
                         }) => {
                             skipped_fields.insert(n);
                         }
 
                         Some(Spanning {
-                            item: FieldAttributes::With(with),
+                            item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
                             alternate_hash_functions.insert(n, with.func.clone());
@@ -135,44 +134,6 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
     }
     .into_token_stream())
 }
-
-/// Custom combination of an [`attr::Skip`] and [`attr::With`] used for a better error message
-/// including all the possible variants.
-enum FieldAttributes {
-    /// Parsed [`attr::Skip`].
-    Skip,
-
-    /// Parsed [`attr::With`].
-    With(attr::With),
-}
-
-// TODO: Try generalize in `Either`.
-impl Parse for FieldAttributes {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        mod ident {
-            use syn::custom_keyword;
-
-            custom_keyword!(with);
-            custom_keyword!(skip);
-            custom_keyword!(ignore);
-        }
-
-        // `.lookahead1()` with all possible idents forms a nice error message including all the
-        // possible variants.
-        let ahead = input.lookahead1();
-
-        if ahead.peek(ident::with) {
-            Ok(Self::With(input.parse()?))
-        } else if ahead.peek(ident::skip) || ahead.peek(ident::ignore) {
-            _ = input.parse::<attr::Skip>()?;
-            Ok(Self::Skip)
-        } else {
-            Err(ahead.error())
-        }
-    }
-}
-
-impl ParseMultiple for FieldAttributes {}
 
 /// Indices of [`syn::Field`]s marked with an [`attr::Skip`].
 type SkippedFields = HashSet<usize>;

--- a/impl/src/hash.rs
+++ b/impl/src/hash.rs
@@ -14,20 +14,24 @@ use syn::{
     spanned::Spanned as _,
 };
 
+const PARTIAL_EQ_WITH_WITHOUT_HASH_ERROR: &str =
+    "field has `#[partial_eq(with(...))]` but no `#[hash(with(...))]` or `#[hash(skip)]`: a custom \
+     equality function requires a consistent `Hash` implementation to uphold the `Hash`/`Eq` \
+     invariant (`a == b` implies `hash(a) == hash(b)`)";
+
 /// Expands a [`Hash`] derive macro.
 pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStream> {
     let attr_name = format_ident!("hash");
-    let secondary_attr_name = format_ident!("eq");
-    let tertiary_attr_name = format_ident!("partial_eq");
-    let attr_names = [&attr_name, &secondary_attr_name, &tertiary_attr_name];
-    let secondary_attr_names = [&secondary_attr_name, &tertiary_attr_name];
+    let partial_eq_attr_name = format_ident!("partial_eq");
+    let eq_attr_name = format_ident!("eq");
+    let skip_attr_names = [&attr_name, &partial_eq_attr_name, &eq_attr_name];
 
     let mut has_skipped_variants = false;
     let mut variants = vec![];
 
     match &input.data {
         syn::Data::Struct(data) => {
-            for attr_name in &attr_names {
+            for attr_name in skip_attr_names {
                 if attr::Skip::parse_attrs(&input.attrs, attr_name)?.is_some() {
                     has_skipped_variants = true;
                     break;
@@ -37,30 +41,46 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 let mut skipped_fields = SkippedFields::default();
                 let mut alternate_hash_functions =
                     FieldsWithAlternateHashFunction::default();
-                'fields: for (n, field) in data.fields.iter().enumerate() {
+                for (n, field) in data.fields.iter().enumerate() {
                     match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         None => {
-                            for attr_name in &secondary_attr_names {
-                                if attr::Skip::parse_attrs(&field.attrs, attr_name)?
-                                    .is_some()
-                                {
-                                    _ = skipped_fields.insert(n);
-                                    continue 'fields;
+                            if let Some(Spanning { item, span, .. }) =
+                                attr::WithOrSkip::parse_attrs(
+                                    &field.attrs,
+                                    &partial_eq_attr_name,
+                                )?
+                            {
+                                match item {
+                                    attr::WithOrSkip::Skip => {
+                                        _ = skipped_fields.insert(n);
+                                    }
+                                    attr::WithOrSkip::With(_) => {
+                                        return Err(syn::Error::new(
+                                            span,
+                                            PARTIAL_EQ_WITH_WITHOUT_HASH_ERROR,
+                                        ));
+                                    }
                                 }
+                            } else if attr::Skip::parse_attrs(
+                                &field.attrs,
+                                &eq_attr_name,
+                            )?
+                            .is_some()
+                            {
+                                _ = skipped_fields.insert(n);
                             }
                         }
                         Some(Spanning {
                             item: attr::WithOrSkip::Skip,
                             ..
                         }) => {
-                            skipped_fields.insert(n);
+                            _ = skipped_fields.insert(n);
                         }
-
                         Some(Spanning {
                             item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
-                            alternate_hash_functions.insert(n, with.func.clone());
+                            alternate_hash_functions.insert(n, with.func);
                         }
                     }
                 }
@@ -74,7 +94,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
         }
         syn::Data::Enum(data) => {
             'variants: for variant in &data.variants {
-                for attr_name in &attr_names {
+                for attr_name in skip_attr_names {
                     if attr::Skip::parse_attrs(&variant.attrs, attr_name)?.is_some() {
                         has_skipped_variants = true;
                         continue 'variants;
@@ -83,30 +103,46 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                 let mut skipped_fields = SkippedFields::default();
                 let mut alternate_hash_functions =
                     FieldsWithAlternateHashFunction::default();
-                'fields: for (n, field) in variant.fields.iter().enumerate() {
+                for (n, field) in variant.fields.iter().enumerate() {
                     match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         None => {
-                            for attr_name in &secondary_attr_names {
-                                if attr::Skip::parse_attrs(&field.attrs, attr_name)?
-                                    .is_some()
-                                {
-                                    _ = skipped_fields.insert(n);
-                                    continue 'fields;
+                            if let Some(Spanning { item, span, .. }) =
+                                attr::WithOrSkip::parse_attrs(
+                                    &field.attrs,
+                                    &partial_eq_attr_name,
+                                )?
+                            {
+                                match item {
+                                    attr::WithOrSkip::Skip => {
+                                        _ = skipped_fields.insert(n);
+                                    }
+                                    attr::WithOrSkip::With(_) => {
+                                        return Err(syn::Error::new(
+                                            span,
+                                            PARTIAL_EQ_WITH_WITHOUT_HASH_ERROR,
+                                        ));
+                                    }
                                 }
+                            } else if attr::Skip::parse_attrs(
+                                &field.attrs,
+                                &eq_attr_name,
+                            )?
+                            .is_some()
+                            {
+                                _ = skipped_fields.insert(n);
                             }
                         }
                         Some(Spanning {
                             item: attr::WithOrSkip::Skip,
                             ..
                         }) => {
-                            skipped_fields.insert(n);
+                            _ = skipped_fields.insert(n);
                         }
-
                         Some(Spanning {
                             item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
-                            alternate_hash_functions.insert(n, with.func.clone());
+                            alternate_hash_functions.insert(n, with.func);
                         }
                     }
                 }

--- a/impl/src/hash.rs
+++ b/impl/src/hash.rs
@@ -39,8 +39,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
             }
             if !has_skipped_variants {
                 let mut skipped_fields = SkippedFields::default();
-                let mut alternate_hash_functions =
-                    FieldsWithAlternateHashFunction::default();
+                let mut custom_hash_functions = FieldsWithCustomHashFunction::default();
                 for (n, field) in data.fields.iter().enumerate() {
                     match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         None => {
@@ -80,7 +79,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                             item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
-                            alternate_hash_functions.insert(n, with.func);
+                            custom_hash_functions.insert(n, with.func);
                         }
                     }
                 }
@@ -88,7 +87,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     None,
                     &data.fields,
                     skipped_fields,
-                    alternate_hash_functions,
+                    custom_hash_functions,
                 ));
             }
         }
@@ -101,8 +100,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     }
                 }
                 let mut skipped_fields = SkippedFields::default();
-                let mut alternate_hash_functions =
-                    FieldsWithAlternateHashFunction::default();
+                let mut custom_hash_functions = FieldsWithCustomHashFunction::default();
                 for (n, field) in variant.fields.iter().enumerate() {
                     match attr::WithOrSkip::parse_attrs(&field.attrs, &attr_name)? {
                         None => {
@@ -142,7 +140,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                             item: attr::WithOrSkip::With(with),
                             ..
                         }) => {
-                            alternate_hash_functions.insert(n, with.func);
+                            custom_hash_functions.insert(n, with.func);
                         }
                     }
                 }
@@ -150,7 +148,7 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
                     Some(&variant.ident),
                     &variant.fields,
                     skipped_fields,
-                    alternate_hash_functions,
+                    custom_hash_functions,
                 ));
             }
         }
@@ -174,9 +172,9 @@ pub fn expand(input: &syn::DeriveInput, _: &'static str) -> syn::Result<TokenStr
 /// Indices of [`syn::Field`]s marked with an [`attr::Skip`].
 type SkippedFields = HashSet<usize>;
 
-/// Mapping from [`syn::Field`] marked with an [`attr::With`] to the [`syn::Path`] of the alternate
+/// Mapping from [`syn::Field`] marked with an [`attr::With`] to the [`syn::Path`] of the custom
 /// hash function.
-type FieldsWithAlternateHashFunction = HashMap<usize, syn::Path>;
+type FieldsWithCustomHashFunction = HashMap<usize, syn::Path>;
 
 /// Expansion of a macro for generating a structural [`Hash`] implementation of an enum or a struct.
 struct StructuralExpansion<'i> {
@@ -190,7 +188,7 @@ struct StructuralExpansion<'i> {
         Option<&'i syn::Ident>,
         &'i syn::Fields,
         SkippedFields,
-        FieldsWithAlternateHashFunction,
+        FieldsWithCustomHashFunction,
     )>,
 
     /// Indicator whether some original enum variants where skipped with an [`attr::Skip`].
@@ -230,7 +228,7 @@ impl StructuralExpansion<'_> {
             .variants
             .iter()
             .map(
-                |(variant, all_fields, skipped_fields, alternate_hash_functions)| {
+                |(variant, all_fields, skipped_fields, custom_hash_functions)| {
                     let variant = variant.map(|variant| quote! { :: #variant });
                     let self_pattern = all_fields
                         .non_exhaustive_arm_pattern("__self_", skipped_fields);
@@ -239,7 +237,7 @@ impl StructuralExpansion<'_> {
                         .filter(|num| !skipped_fields.contains(num))
                         .map(|num| {
                             let self_val = format_ident!("__self_{num}");
-                            let hash_function = alternate_hash_functions
+                            let hash_function = custom_hash_functions
                                 .get(&num)
                                 .map(|it| quote! {#it})
                                 .unwrap_or_else(

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -2442,12 +2442,11 @@ pub(crate) mod attr {
         impl ParseMultiple for With {}
     }
 
-
     #[cfg(any(feature = "hash", feature = "eq"))]
     mod with_or_skip {
-        use syn::parse::{Parse, ParseStream};
         use crate::utils::attr;
         use crate::utils::attr::ParseMultiple;
+        use syn::parse::{Parse, ParseStream};
 
         /// Custom combination of an [`attr::Skip`] and [`attr::With`] used for a better error message
         /// including all the possible variants.
@@ -2485,8 +2484,7 @@ pub(crate) mod attr {
         }
 
         impl ParseMultiple for WithOrSkip {}
-        }
-
+    }
 }
 
 #[cfg(any(feature = "from", feature = "into"))]

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1566,8 +1566,10 @@ pub(crate) mod attr {
     pub(crate) use self::skip::Skip;
     #[cfg(any(feature = "as_ref", feature = "from", feature = "try_from"))]
     pub(crate) use self::types::Types;
-    #[cfg(feature = "hash")]
+    #[cfg(any(feature = "hash", feature = "eq"))]
     pub(crate) use self::with::With;
+    #[cfg(any(feature = "hash", feature = "eq"))]
+    pub(crate) use self::with_or_skip::WithOrSkip;
     #[cfg(any(feature = "as_ref", feature = "from"))]
     pub(crate) use self::{conversion::Conversion, field_conversion::FieldConversion};
     #[cfg(feature = "try_from")]
@@ -2404,7 +2406,7 @@ pub(crate) mod attr {
         impl ParseMultiple for RenameAll {}
     }
 
-    #[cfg(feature = "hash")]
+    #[cfg(any(feature = "hash", feature = "eq"))]
     mod with {
         use syn::parenthesized;
         use syn::parse::{Parse, ParseStream};
@@ -2439,6 +2441,52 @@ pub(crate) mod attr {
 
         impl ParseMultiple for With {}
     }
+
+
+    #[cfg(any(feature = "hash", feature = "eq"))]
+    mod with_or_skip {
+        use syn::parse::{Parse, ParseStream};
+        use crate::utils::attr;
+        use crate::utils::attr::ParseMultiple;
+
+        /// Custom combination of an [`attr::Skip`] and [`attr::With`] used for a better error message
+        /// including all the possible variants.
+        pub enum WithOrSkip {
+            /// Parsed [`attr::Skip`].
+            Skip,
+            /// Parsed [`attr::With`].
+            With(attr::With),
+        }
+
+        // TODO: Try generalize in `Either`.
+        impl Parse for WithOrSkip {
+            fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+                mod ident {
+                    use syn::custom_keyword;
+
+                    custom_keyword!(with);
+                    custom_keyword!(skip);
+                    custom_keyword!(ignore);
+                }
+
+                // `.lookahead1()` with all possible idents forms a nice error message including all the
+                // possible variants.
+                let ahead = input.lookahead1();
+
+                if ahead.peek(ident::with) {
+                    Ok(Self::With(input.parse()?))
+                } else if ahead.peek(ident::skip) || ahead.peek(ident::ignore) {
+                    _ = input.parse::<attr::Skip>()?;
+                    Ok(Self::Skip)
+                } else {
+                    Err(ahead.error())
+                }
+            }
+        }
+
+        impl ParseMultiple for WithOrSkip {}
+        }
+
 }
 
 #[cfg(any(feature = "from", feature = "into"))]

--- a/tests/compile_fail/eq/unknown_field_attribute.stderr
+++ b/tests/compile_fail/eq/unknown_field_attribute.stderr
@@ -1,10 +1,10 @@
-error: only `skip`/`ignore` allowed here
+error: expected one of: `with`, `skip`, `ignore`
  --> tests/compile_fail/eq/unknown_field_attribute.rs:2:17
   |
 2 | struct Foo(#[eq(unknown)] i32);
   |                 ^^^^^^^
 
-error: only `skip`/`ignore` allowed here
+error: expected one of: `with`, `skip`, `ignore`
   --> tests/compile_fail/eq/unknown_field_attribute.rs:12:16
    |
 12 |     Bar { #[eq(unknown)] i: i32 },

--- a/tests/compile_fail/eq/unknown_field_attribute.stderr
+++ b/tests/compile_fail/eq/unknown_field_attribute.stderr
@@ -1,10 +1,10 @@
-error: expected one of: `with`, `skip`, `ignore`
+error: only `skip`/`ignore` allowed here
  --> tests/compile_fail/eq/unknown_field_attribute.rs:2:17
   |
 2 | struct Foo(#[eq(unknown)] i32);
   |                 ^^^^^^^
 
-error: expected one of: `with`, `skip`, `ignore`
+error: only `skip`/`ignore` allowed here
   --> tests/compile_fail/eq/unknown_field_attribute.rs:12:16
    |
 12 |     Bar { #[eq(unknown)] i: i32 },

--- a/tests/compile_fail/eq/with_attribute.rs
+++ b/tests/compile_fail/eq/with_attribute.rs
@@ -1,0 +1,28 @@
+fn always_eq<T>(_: &T, _: &T) -> bool {
+    true
+}
+
+#[derive(derive_more::Eq)]
+struct Foo(#[eq(with(always_eq))] i32);
+
+impl PartialEq for Foo {
+    fn eq(&self, _: &Self) -> bool {
+        unimplemented!()
+    }
+}
+
+#[derive(derive_more::Eq)]
+enum Enum {
+    Bar {
+        #[eq(with(always_eq))]
+        i: i32,
+    },
+}
+
+impl PartialEq for Enum {
+    fn eq(&self, _: &Self) -> bool {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/tests/compile_fail/eq/with_attribute.stderr
+++ b/tests/compile_fail/eq/with_attribute.stderr
@@ -1,0 +1,11 @@
+error: only `skip`/`ignore` allowed here
+ --> tests/compile_fail/eq/with_attribute.rs:6:17
+  |
+6 | struct Foo(#[eq(with(always_eq))] i32);
+  |                 ^^^^
+
+error: only `skip`/`ignore` allowed here
+  --> tests/compile_fail/eq/with_attribute.rs:17:14
+   |
+17 |         #[eq(with(always_eq))]
+   |              ^^^^

--- a/tests/compile_fail/hash/partial_eq_with_without_hash.rs
+++ b/tests/compile_fail/hash/partial_eq_with_without_hash.rs
@@ -1,0 +1,16 @@
+fn always_eq(_: &i32, _: &i32) -> bool {
+    true
+}
+
+#[derive(derive_more::Hash, derive_more::PartialEq, derive_more::Eq)]
+struct Foo(#[partial_eq(with(always_eq))] i32);
+
+#[derive(derive_more::Hash, derive_more::PartialEq, derive_more::Eq)]
+enum Enum {
+    Bar {
+        #[partial_eq(with(always_eq))]
+        i: i32,
+    },
+}
+
+fn main() {}

--- a/tests/compile_fail/hash/partial_eq_with_without_hash.stderr
+++ b/tests/compile_fail/hash/partial_eq_with_without_hash.stderr
@@ -1,0 +1,11 @@
+error: field has `#[partial_eq(with(...))]` but no `#[hash(with(...))]` or `#[hash(skip)]`: a custom equality function requires a consistent `Hash` implementation to uphold the `Hash`/`Eq` invariant (`a == b` implies `hash(a) == hash(b)`)
+ --> tests/compile_fail/hash/partial_eq_with_without_hash.rs:6:12
+  |
+6 | struct Foo(#[partial_eq(with(always_eq))] i32);
+  |            ^
+
+error: field has `#[partial_eq(with(...))]` but no `#[hash(with(...))]` or `#[hash(skip)]`: a custom equality function requires a consistent `Hash` implementation to uphold the `Hash`/`Eq` invariant (`a == b` implies `hash(a) == hash(b)`)
+  --> tests/compile_fail/hash/partial_eq_with_without_hash.rs:11:9
+   |
+11 |         #[partial_eq(with(always_eq))]
+   |         ^

--- a/tests/compile_fail/partial_eq/unknown_field_attribute.stderr
+++ b/tests/compile_fail/partial_eq/unknown_field_attribute.stderr
@@ -1,10 +1,10 @@
-error: only `skip`/`ignore` allowed here
+error: expected one of: `with`, `skip`, `ignore`
  --> tests/compile_fail/partial_eq/unknown_field_attribute.rs:2:25
   |
 2 | struct Foo(#[partial_eq(unknown)] i32);
   |                         ^^^^^^^
 
-error: only `skip`/`ignore` allowed here
+error: expected one of: `with`, `skip`, `ignore`
  --> tests/compile_fail/partial_eq/unknown_field_attribute.rs:6:24
   |
 6 |     Bar { #[partial_eq(unknown)] i: i32 },

--- a/tests/compile_fail/partial_eq/unknown_with_function.rs
+++ b/tests/compile_fail/partial_eq/unknown_with_function.rs
@@ -1,0 +1,18 @@
+#[derive(derive_more::PartialEq)]
+struct Foo(#[partial_eq(with(unknown))] i32);
+
+fn incompatible_types(a:& str) ->i32 {0}
+
+#[derive(derive_more::PartialEq)]
+struct Bar(#[partial_eq(with(incompatible_types))] i32);
+
+
+#[derive(derive_more::PartialEq)]
+enum Enum {
+    Bar { #[partial_eq(with(unknown))] i: i32 },
+    Baz { #[partial_eq(with(incompatible_types))] i: i32 },
+}
+
+
+
+fn main() {}

--- a/tests/compile_fail/partial_eq/unknown_with_function.rs
+++ b/tests/compile_fail/partial_eq/unknown_with_function.rs
@@ -1,18 +1,15 @@
 #[derive(derive_more::PartialEq)]
 struct Foo(#[partial_eq(with(unknown))] i32);
 
-fn incompatible_types(a:& str) ->i32 {0}
+fn incompatible_types(_a: &str) ->i32 {0}
 
 #[derive(derive_more::PartialEq)]
 struct Bar(#[partial_eq(with(incompatible_types))] i32);
-
 
 #[derive(derive_more::PartialEq)]
 enum Enum {
     Bar { #[partial_eq(with(unknown))] i: i32 },
     Baz { #[partial_eq(with(incompatible_types))] i: i32 },
 }
-
-
 
 fn main() {}

--- a/tests/compile_fail/partial_eq/unknown_with_function.stderr
+++ b/tests/compile_fail/partial_eq/unknown_with_function.stderr
@@ -1,0 +1,80 @@
+error[E0425]: cannot find function `unknown` in this scope
+ --> tests/compile_fail/partial_eq/unknown_with_function.rs:2:30
+  |
+2 | struct Foo(#[partial_eq(with(unknown))] i32);
+  |                              ^^^^^^^ not found in this scope
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+ --> tests/compile_fail/partial_eq/unknown_with_function.rs:7:30
+  |
+6 | #[derive(derive_more::PartialEq)]
+  |          ----------------------
+  |          |
+  |          expected `&str`, found `&i32`
+  |          unexpected argument #2 of type `&i32`
+7 | struct Bar(#[partial_eq(with(incompatible_types))] i32);
+  |                              ^^^^^^^^^^^^^^^^^^
+  |
+  = note: expected reference `&str`
+             found reference `&i32`
+note: function defined here
+ --> tests/compile_fail/partial_eq/unknown_with_function.rs:4:4
+  |
+4 | fn incompatible_types(a:& str) ->i32 {0}
+  |    ^^^^^^^^^^^^^^^^^^ -------
+
+error[E0308]: mismatched types
+ --> tests/compile_fail/partial_eq/unknown_with_function.rs:6:10
+  |
+6 | #[derive(derive_more::PartialEq)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^
+  |          |
+  |          expected `bool`, found `i32`
+  |          expected `bool` because of return type
+  |
+  = note: this error originates in the derive macro `derive_more::PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find function `unknown` in this scope
+  --> tests/compile_fail/partial_eq/unknown_with_function.rs:12:29
+   |
+12 |     Bar { #[partial_eq(with(unknown))] i: i32 },
+   |                             ^^^^^^^ not found in this scope
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> tests/compile_fail/partial_eq/unknown_with_function.rs:13:29
+   |
+10 | #[derive(derive_more::PartialEq)]
+   |          ----------------------
+   |          |
+   |          expected `&str`, found `&i32`
+   |          unexpected argument #2 of type `&i32`
+...
+13 |     Baz { #[partial_eq(with(incompatible_types))] i: i32 },
+   |                             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected reference `&str`
+              found reference `&i32`
+note: function defined here
+  --> tests/compile_fail/partial_eq/unknown_with_function.rs:4:4
+   |
+ 4 | fn incompatible_types(a:& str) ->i32 {0}
+   |    ^^^^^^^^^^^^^^^^^^ -------
+
+error[E0308]: mismatched types
+  --> tests/compile_fail/partial_eq/unknown_with_function.rs:10:10
+   |
+10 | #[derive(derive_more::PartialEq)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          expected `bool`, found `i32`
+   |          expected `bool` because of return type
+   |
+   = note: this error originates in the derive macro `derive_more::PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused variable: `a`
+ --> tests/compile_fail/partial_eq/unknown_with_function.rs:4:23
+  |
+4 | fn incompatible_types(a:& str) ->i32 {0}
+  |                       ^ help: if this is intentional, prefix it with an underscore: `_a`
+  |
+  = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

--- a/tests/compile_fail/partial_eq/unknown_with_function.stderr
+++ b/tests/compile_fail/partial_eq/unknown_with_function.stderr
@@ -20,8 +20,8 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
 note: function defined here
  --> tests/compile_fail/partial_eq/unknown_with_function.rs:4:4
   |
-4 | fn incompatible_types(a:& str) ->i32 {0}
-  |    ^^^^^^^^^^^^^^^^^^ -------
+4 | fn incompatible_types(_a: &str) ->i32 {0}
+  |    ^^^^^^^^^^^^^^^^^^ --------
 
 error[E0308]: mismatched types
  --> tests/compile_fail/partial_eq/unknown_with_function.rs:6:10
@@ -35,21 +35,21 @@ error[E0308]: mismatched types
   = note: this error originates in the derive macro `derive_more::PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `unknown` in this scope
-  --> tests/compile_fail/partial_eq/unknown_with_function.rs:12:29
+  --> tests/compile_fail/partial_eq/unknown_with_function.rs:11:29
    |
-12 |     Bar { #[partial_eq(with(unknown))] i: i32 },
+11 |     Bar { #[partial_eq(with(unknown))] i: i32 },
    |                             ^^^^^^^ not found in this scope
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> tests/compile_fail/partial_eq/unknown_with_function.rs:13:29
+  --> tests/compile_fail/partial_eq/unknown_with_function.rs:12:29
    |
-10 | #[derive(derive_more::PartialEq)]
+ 9 | #[derive(derive_more::PartialEq)]
    |          ----------------------
    |          |
    |          expected `&str`, found `&i32`
    |          unexpected argument #2 of type `&i32`
 ...
-13 |     Baz { #[partial_eq(with(incompatible_types))] i: i32 },
+12 |     Baz { #[partial_eq(with(incompatible_types))] i: i32 },
    |                             ^^^^^^^^^^^^^^^^^^
    |
    = note: expected reference `&str`
@@ -57,24 +57,16 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
 note: function defined here
   --> tests/compile_fail/partial_eq/unknown_with_function.rs:4:4
    |
- 4 | fn incompatible_types(a:& str) ->i32 {0}
-   |    ^^^^^^^^^^^^^^^^^^ -------
+ 4 | fn incompatible_types(_a: &str) ->i32 {0}
+   |    ^^^^^^^^^^^^^^^^^^ --------
 
 error[E0308]: mismatched types
-  --> tests/compile_fail/partial_eq/unknown_with_function.rs:10:10
-   |
-10 | #[derive(derive_more::PartialEq)]
-   |          ^^^^^^^^^^^^^^^^^^^^^^
-   |          |
-   |          expected `bool`, found `i32`
-   |          expected `bool` because of return type
-   |
-   = note: this error originates in the derive macro `derive_more::PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: unused variable: `a`
- --> tests/compile_fail/partial_eq/unknown_with_function.rs:4:23
+ --> tests/compile_fail/partial_eq/unknown_with_function.rs:9:10
   |
-4 | fn incompatible_types(a:& str) ->i32 {0}
-  |                       ^ help: if this is intentional, prefix it with an underscore: `_a`
+9 | #[derive(derive_more::PartialEq)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^
+  |          |
+  |          expected `bool`, found `i32`
+  |          expected `bool` because of return type
   |
-  = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+  = note: this error originates in the derive macro `derive_more::PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/eq.rs
+++ b/tests/eq.rs
@@ -162,6 +162,64 @@ mod structs {
             }
         }
 
+        mod with {
+            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+
+            fn eq_special(_: &NotPartialEq, _: &NotPartialEq) -> bool {
+                true
+            }
+
+            struct NotPartialEq(i32);
+
+            #[test]
+            fn single_field() {
+                #[derive(Eq, PartialEq)]
+                struct Foo(#[partial_eq(with(eq_special))] NotPartialEq);
+                #[derive(Eq, PartialEq)]
+                struct Bar(#[eq(with(eq_special))] NotPartialEq);
+
+                let _: AssertParamIsEq<Foo>;
+                let _: AssertParamIsEq<Bar>;
+            }
+
+            #[test]
+            fn multiple_fields() {
+                #[derive(Eq, PartialEq)]
+                struct Foo {
+                    #[partial_eq(with(eq_special))]
+                    a: NotPartialEq,
+                    b: i32,
+                }
+
+                #[derive(Eq, PartialEq)]
+                struct Bar {
+                    #[eq(with(eq_special))]
+                    a: NotPartialEq,
+                    b: i32,
+                }
+
+                let _: AssertParamIsEq<Foo>;
+                let _: AssertParamIsEq<Bar>;
+            }
+
+            #[test]
+            fn tuple_all() {
+                #[derive(Eq, PartialEq)]
+                struct Foo(
+                    #[partial_eq(with(eq_special))] NotPartialEq,
+                    #[partial_eq(with(eq_special))] NotPartialEq,
+                );
+
+                #[derive(Eq, PartialEq)]
+                struct Bar(
+                    #[eq(with(eq_special))] NotPartialEq,
+                    #[eq(with(eq_special))] NotPartialEq,
+                );
+
+                let _: AssertParamIsEq<Bar>;
+            }
+        }
+
         mod generic {
             #[cfg(not(feature = "std"))]
             use ::alloc::{boxed::Box, vec::Vec};
@@ -541,6 +599,94 @@ mod enums {
                         b: bool,
                     },
                     Baz,
+                }
+
+                let _: AssertParamIsEq<E>;
+            }
+        }
+
+        mod with {
+            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+
+            fn eq_special(_: &NotPartialEq, _: &NotPartialEq) -> bool {
+                true
+            }
+
+            struct NotPartialEq(i32);
+
+            #[test]
+            fn single_field() {
+                #[derive(Eq, PartialEq)]
+                enum E {
+                    Foo(#[partial_eq(with(eq_special))] NotPartialEq),
+                    Bar(#[eq(with(eq_special))] NotPartialEq),
+                    Baz,
+                }
+
+                let _: AssertParamIsEq<E>;
+            }
+
+            #[test]
+            fn multiple_fields() {
+                #[derive(Eq, PartialEq)]
+                enum E {
+                    Foo {
+                        #[partial_eq(with(eq_special))]
+                        a: NotPartialEq,
+                        b: i32,
+                    },
+                    Bar {
+                        #[eq(with(eq_special))]
+                        a: NotPartialEq,
+                        b: i32,
+                    },
+                    Baz,
+                }
+
+                let _: AssertParamIsEq<E>;
+            }
+
+            #[test]
+            fn tuple_all() {
+                #[derive(Eq, PartialEq)]
+                enum E {
+                    Foo(
+                        #[partial_eq(with(eq_special))] NotPartialEq,
+                        #[partial_eq(with(eq_special))] NotPartialEq,
+                    ),
+                    Bar(
+                        #[eq(with(eq_special))] NotPartialEq,
+                        #[eq(with(eq_special))] NotPartialEq,
+                    ),
+                    Baz,
+                }
+
+                let _: AssertParamIsEq<E>;
+            }
+
+            #[test]
+            fn multi_variant() {
+                #[derive(Eq, PartialEq)]
+                enum E {
+                    Foo(#[partial_eq(with(eq_special))] NotPartialEq),
+                    Bar {
+                        #[partial_eq(with(eq_special))]
+                        val: NotPartialEq,
+                    },
+                    Baz,
+                }
+
+                let _: AssertParamIsEq<E>;
+            }
+
+            #[test]
+            fn with_skip_combined() {
+                #[derive(Eq, PartialEq)]
+                enum E {
+                    Foo(
+                        #[partial_eq(with(eq_special))] NotPartialEq,
+                        #[partial_eq(skip)] NotPartialEq,
+                    ),
                 }
 
                 let _: AssertParamIsEq<E>;

--- a/tests/eq.rs
+++ b/tests/eq.rs
@@ -175,11 +175,8 @@ mod structs {
             fn single_field() {
                 #[derive(Eq, PartialEq)]
                 struct Foo(#[partial_eq(with(eq_special))] NotPartialEq);
-                #[derive(Eq, PartialEq)]
-                struct Bar(#[eq(with(eq_special))] NotPartialEq);
 
                 let _: AssertParamIsEq<Foo>;
-                let _: AssertParamIsEq<Bar>;
             }
 
             #[test]
@@ -191,15 +188,7 @@ mod structs {
                     b: i32,
                 }
 
-                #[derive(Eq, PartialEq)]
-                struct Bar {
-                    #[eq(with(eq_special))]
-                    a: NotPartialEq,
-                    b: i32,
-                }
-
                 let _: AssertParamIsEq<Foo>;
-                let _: AssertParamIsEq<Bar>;
             }
 
             #[test]
@@ -210,13 +199,7 @@ mod structs {
                     #[partial_eq(with(eq_special))] NotPartialEq,
                 );
 
-                #[derive(Eq, PartialEq)]
-                struct Bar(
-                    #[eq(with(eq_special))] NotPartialEq,
-                    #[eq(with(eq_special))] NotPartialEq,
-                );
-
-                let _: AssertParamIsEq<Bar>;
+                let _: AssertParamIsEq<Foo>;
             }
         }
 
@@ -619,8 +602,7 @@ mod enums {
                 #[derive(Eq, PartialEq)]
                 enum E {
                     Foo(#[partial_eq(with(eq_special))] NotPartialEq),
-                    Bar(#[eq(with(eq_special))] NotPartialEq),
-                    Baz,
+                    Bar,
                 }
 
                 let _: AssertParamIsEq<E>;
@@ -635,12 +617,7 @@ mod enums {
                         a: NotPartialEq,
                         b: i32,
                     },
-                    Bar {
-                        #[eq(with(eq_special))]
-                        a: NotPartialEq,
-                        b: i32,
-                    },
-                    Baz,
+                    Bar,
                 }
 
                 let _: AssertParamIsEq<E>;
@@ -654,11 +631,7 @@ mod enums {
                         #[partial_eq(with(eq_special))] NotPartialEq,
                         #[partial_eq(with(eq_special))] NotPartialEq,
                     ),
-                    Bar(
-                        #[eq(with(eq_special))] NotPartialEq,
-                        #[eq(with(eq_special))] NotPartialEq,
-                    ),
-                    Baz,
+                    Bar,
                 }
 
                 let _: AssertParamIsEq<E>;

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -298,6 +298,44 @@ mod enums {
 }
 
 #[cfg(feature = "eq")]
+mod partial_eq_with_requires_hash_attr {
+    use derive_more::{Eq, Hash, PartialEq};
+
+    use super::{do_hash, utils};
+
+    fn eq_mod_10(a: &u32, b: &u32) -> bool {
+        a % 10 == b % 10
+    }
+
+    // Field uses a custom equality, so a matching custom hash function is provided.
+    #[derive(Hash, Eq, PartialEq)]
+    struct WithBoth {
+        #[partial_eq(with(eq_mod_10))]
+        #[hash(with(utils::alternate_u32_hash_function))]
+        a: u32,
+        b: i32,
+    }
+
+    // Field uses a custom equality and is skipped from hashing — also consistent.
+    #[derive(Hash, Eq, PartialEq)]
+    struct WithSkip {
+        #[partial_eq(with(eq_mod_10))]
+        #[hash(skip)]
+        a: u32,
+        b: i32,
+    }
+
+    #[test]
+    fn assert() {
+        assert_eq!(
+            do_hash(&WithBoth { a: 42, b: 7 }),
+            do_hash(&(42u32, 42u32, 7i32)),
+        );
+        assert_eq!(do_hash(&WithSkip { a: 42, b: 7 }), do_hash(&7i32));
+    }
+}
+
+#[cfg(feature = "eq")]
 mod hash_respects_eq_skip {
     use derive_more::{Eq, Hash, PartialEq};
 

--- a/tests/partial_eq.rs
+++ b/tests/partial_eq.rs
@@ -248,6 +248,69 @@ mod structs {
             }
         }
 
+        mod with {
+            use derive_more::PartialEq;
+
+            #[test]
+            fn single_field() {
+                #[derive(Debug)]
+                struct NotPartialEq(i32);
+                fn eq_special(a: &NotPartialEq, b: &NotPartialEq) -> bool {
+                    a.0 == b.0
+                }
+
+                #[derive(Debug, PartialEq)]
+                struct Foo(#[partial_eq(with(eq_special))] NotPartialEq);
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(Foo(NotPartialEq(42)), Foo(NotPartialEq(42)));
+                assert!(!(Foo(NotPartialEq(42)) != Foo(NotPartialEq(42))));
+
+                assert!(!(Foo(NotPartialEq(42)) == Foo(NotPartialEq(73))));
+                assert_ne!(Foo(NotPartialEq(42)), Foo(NotPartialEq(73)));
+            }
+
+            fn eq_special_always_equal(_: &u32, _: &u32) -> bool {
+                true
+            }
+
+            #[test]
+            fn multiple_fields() {
+                #[derive(Debug, PartialEq)]
+                struct Foo {
+                    #[partial_eq(with(eq_special_always_equal))]
+                    a: u32,
+                    b: u32,
+                }
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(Foo { a: 73, b: 1 }, Foo { a: 42, b: 1 });
+                assert!(!(Foo { a: 73, b: 1 } != Foo { a: 42, b: 1 }));
+
+                assert!(!(Foo { a: 73, b: 1 } == Foo { a: 42, b: 2 }));
+                assert_ne!(Foo { a: 73, b: 1 }, Foo { a: 42, b: 2 });
+            }
+
+            #[test]
+            fn tuple_all() {
+                mod eq {
+                    pub fn always_eq(_: &i32, _: &i32) -> bool {
+                        true
+                    }
+                }
+
+                #[derive(Debug, PartialEq)]
+                struct Foo(
+                    #[partial_eq(with(eq::always_eq))] i32,
+                    #[partial_eq(with(eq::always_eq))] i32,
+                );
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(Foo(12, 13), Foo(14, 15));
+                assert!(!(Foo(12, 13) != Foo(14, 15)));
+            }
+        }
+
         mod generic {
             #[cfg(not(feature = "std"))]
             use ::alloc::{boxed::Box, vec, vec::Vec};
@@ -924,6 +987,145 @@ mod enums {
                 assert_ne!(E::Foo(true, 0), E::Bar { a: NoEq, b: true });
                 assert_ne!(E::Foo(true, 0), E::Baz);
                 assert_ne!(E::Bar { a: NoEq, b: true }, E::Baz);
+            }
+        }
+
+        mod with {
+            use derive_more::PartialEq;
+
+            #[test]
+            fn single_field() {
+                #[derive(Debug)]
+                struct NotPartialEq(i32);
+                fn eq_special(a: &NotPartialEq, b: &NotPartialEq) -> bool {
+                    a.0 == b.0
+                }
+
+                #[derive(Debug, PartialEq)]
+                enum E {
+                    Foo(#[partial_eq(with(eq_special))] NotPartialEq),
+                    Bar,
+                }
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(E::Foo(NotPartialEq(42)), E::Foo(NotPartialEq(42)));
+                assert!(!(E::Foo(NotPartialEq(42)) != E::Foo(NotPartialEq(42))));
+
+                assert!(!(E::Foo(NotPartialEq(42)) == E::Foo(NotPartialEq(73))));
+                assert_ne!(E::Foo(NotPartialEq(42)), E::Foo(NotPartialEq(73)));
+
+                assert!(!(E::Foo(NotPartialEq(42)) == E::Bar));
+                assert_ne!(E::Foo(NotPartialEq(42)), E::Bar);
+            }
+
+            fn eq_special_always_equal(_: &u32, _: &u32) -> bool {
+                true
+            }
+
+            #[test]
+            fn multiple_fields() {
+                #[derive(Debug, PartialEq)]
+                enum E {
+                    Foo {
+                        #[partial_eq(with(eq_special_always_equal))]
+                        a: u32,
+                        b: u32,
+                    },
+                    Bar,
+                }
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(E::Foo { a: 73, b: 1 }, E::Foo { a: 42, b: 1 });
+                assert!(!(E::Foo { a: 73, b: 1 } != E::Foo { a: 42, b: 1 }));
+
+                assert!(!(E::Foo { a: 73, b: 1 } == E::Foo { a: 42, b: 2 }));
+                assert_ne!(E::Foo { a: 73, b: 1 }, E::Foo { a: 42, b: 2 });
+
+                assert!(!(E::Foo { a: 73, b: 1 } == E::Bar));
+                assert_ne!(E::Foo { a: 73, b: 1 }, E::Bar);
+            }
+
+            #[test]
+            fn tuple_all() {
+                mod eq {
+                    pub fn always_eq(_: &i32, _: &i32) -> bool {
+                        true
+                    }
+                }
+
+                #[derive(Debug, PartialEq)]
+                enum E {
+                    Foo(
+                        #[partial_eq(with(eq::always_eq))] i32,
+                        #[partial_eq(with(eq::always_eq))] i32,
+                    ),
+                    Bar,
+                }
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(E::Foo(12, 13), E::Foo(14, 15));
+                assert!(!(E::Foo(12, 13) != E::Foo(14, 15)));
+
+                assert!(!(E::Foo(73, 1) == E::Bar));
+                assert_ne!(E::Foo(73, 1), E::Bar);
+            }
+
+            #[test]
+            fn multi_variant() {
+                fn eq_mod_10(a: &i32, b: &i32) -> bool {
+                    a % 10 == b % 10
+                }
+
+                #[derive(Debug, PartialEq)]
+                enum E {
+                    Foo(#[partial_eq(with(eq_mod_10))] i32),
+                    Bar {
+                        #[partial_eq(with(eq_mod_10))]
+                        val: i32,
+                    },
+                    Baz,
+                }
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(E::Foo(13), E::Foo(23));
+                assert!(!(E::Foo(13) != E::Foo(23)));
+
+                assert_ne!(E::Foo(13), E::Foo(24));
+                assert!(!(E::Foo(13) == E::Foo(24)));
+
+                assert_eq!(E::Bar { val: 15 }, E::Bar { val: 25 });
+                assert!(!(E::Bar { val: 15 } != E::Bar { val: 25 }));
+
+                assert_ne!(E::Bar { val: 15 }, E::Bar { val: 26 });
+                assert!(!(E::Bar { val: 15 } == E::Bar { val: 26 }));
+
+                assert_eq!(E::Baz, E::Baz);
+                assert!(!(E::Baz != E::Baz));
+
+                assert_ne!(E::Foo(13), E::Bar { val: 13 });
+                assert!(!(E::Foo(13) == E::Bar { val: 13 }));
+
+                assert_ne!(E::Foo(13), E::Baz);
+                assert!(!(E::Foo(13) == E::Baz));
+
+                assert_ne!(E::Bar { val: 13 }, E::Baz);
+                assert!(!(E::Bar { val: 13 } == E::Baz));
+            }
+
+            #[test]
+            fn with_skip_combined() {
+                fn eq_always(_: &i32, _: &i32) -> bool {
+                    true
+                }
+
+                #[derive(Debug, PartialEq)]
+                enum E {
+                    Foo(#[partial_eq(with(eq_always))] i32, #[partial_eq(skip)] i32),
+                }
+
+                // assert both using == and != as both are overloaded
+                assert_eq!(E::Foo(1, 2), E::Foo(3, 4));
+                assert!(!(E::Foo(1, 2) != E::Foo(3, 4)));
             }
         }
 


### PR DESCRIPTION
## Synopsis

This adds the possibility to use custom functions to perform the equality check in `PartialEq`/`Eq` derives. This is quite useful when wrapping types without a `PartialEq`/`Eq` impl

## Solution

This builds on #532 and reuse the `FieldAttributes` for `Hash`, I moved the struct to `utils::attr` and renamed it `WithOrSkip`.

I removed fields types that have a `with` attribute from the automatically added `where Type: Eq` bound automatically generated by the `Eq` derive. This seems like the thing to do as if you're using a custom function it most probably means the field doesn't implement `Eq`.  

While this is not part of the roadmap for PartialEq, defined in #163 this is something that will be quite useful for people migrating form `derivative` as this was something supported by this crate

## Checklist

- [x] Documentation is updated (if required)
- [x] Tests are added/updated (if required)
- [x] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
