### PR TITLE
feat(from_str): support rename attribute

### DIFF
--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -136,6 +136,7 @@ struct FlatExpansion<'i> {
     matches: Vec<(
         &'i syn::Ident,
         Either<&'i syn::DataStruct, &'i syn::Variant>,
+        Option<attr::Rename>,
         Option<attr::RenameAll>,
     )>,
 
@@ -165,7 +166,7 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
                         "only structs with no fields can derive `FromStr`",
                     ));
                 }
-                vec![(&input.ident, Either::Left(data), None)]
+                vec![(&input.ident, Either::Left(data), None, None)]
             }
             syn::Data::Enum(data) => data
                 .variants
@@ -177,10 +178,16 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
                             "only enums with no fields can derive `FromStr`",
                         ));
                     }
-                    let attr =
-                        attr::RenameAll::parse_attrs(&variant.attrs, attr_ident)?
-                            .map(Spanning::into_inner);
-                    Ok((&variant.ident, Either::Right(variant), attr))
+                    let attrs =
+                        FlatVariantAttributes::parse_attrs(&variant.attrs, attr_ident)?
+                            .map(Spanning::into_inner)
+                            .unwrap_or_default();
+                    Ok((
+                        &variant.ident,
+                        Either::Right(variant),
+                        attrs.rename,
+                        attrs.rename_all,
+                    ))
                 })
                 .collect::<syn::Result<_>>()?,
             syn::Data::Union(_) => {
@@ -200,10 +207,18 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
 
         let mut similar_matches = <HashMap<_, Vec<_>>>::new();
         if rename_all.is_none() {
-            for (ident, _, renaming) in &matches {
+            for (ident, _, rename, renaming) in &matches {
                 let name = ident.to_string();
                 let lowercased = name.to_lowercase();
-                if let Some(rename) = renaming {
+                if let Some(rename) = rename {
+                    let renamed_lowercased = rename.as_str().to_lowercase();
+                    if renamed_lowercased != lowercased {
+                        similar_matches
+                            .entry(renamed_lowercased)
+                            .or_default()
+                            .push(*ident);
+                    }
+                } else if let Some(rename) = renaming {
                     let renamed_lowercased = rename.convert_case(&name);
                     if renamed_lowercased != lowercased {
                         similar_matches
@@ -217,9 +232,11 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
         }
 
         let mut exact_matches = <HashMap<String, Vec<String>>>::new();
-        for (ident, _, renaming) in &matches {
+        for (ident, _, rename, renaming) in &matches {
             let name = ident.to_string();
-            let exact = if let Some(default_renaming) = &rename_all {
+            let exact = if let Some(rename) = rename {
+                rename.as_str().to_owned()
+            } else if let Some(default_renaming) = &rename_all {
                 renaming
                     .as_ref()
                     .unwrap_or(default_renaming)
@@ -273,10 +290,14 @@ impl ToTokens for FlatExpansion<'_> {
         let match_arms = if let Some(default_renaming) = self.rename_all {
             self.matches
                 .iter()
-                .map(|(ident, value, renaming)| {
-                    let converted = renaming
-                        .unwrap_or(default_renaming)
-                        .convert_case(&ident.to_string());
+                .map(|(ident, value, rename, renaming)| {
+                    let converted = if let Some(rename) = rename {
+                        rename.as_str().to_owned()
+                    } else {
+                        renaming
+                            .unwrap_or(default_renaming)
+                            .convert_case(&ident.to_string())
+                    };
                     let constructor = value.self_constructor_empty();
 
                     quote! { #converted => #constructor, }
@@ -285,10 +306,14 @@ impl ToTokens for FlatExpansion<'_> {
         } else {
             self.matches
                 .iter()
-                .map(|(ident, value, renaming)| {
+                .map(|(ident, value, rename, renaming)| {
                     let name = ident.to_string();
                     let constructor = value.self_constructor_empty();
-                    if let Some(rename) = renaming {
+                    if let Some(rename) = rename {
+                        let exact_name = rename.as_str();
+
+                        quote! { _ if s == #exact_name => #constructor, }
+                    } else if let Some(rename) = renaming {
                         let exact_name = rename.convert_case(&name);
 
                         quote! { _ if s == #exact_name => #constructor, }
@@ -462,6 +487,87 @@ impl<L: FieldsExt, R: FieldsExt> FieldsExt for Either<&L, &R> {
             Self::Left(l) => l.self_ty(),
             Self::Right(r) => r.self_ty(),
         }
+    }
+}
+
+/// Representation of possible [`FromStr`] derive macro attributes placed on a variant.
+///
+/// ```rust,ignore
+/// #[<attribute>(rename = "...")]
+/// #[<attribute>(rename_all = "<casing>")]
+/// ```
+#[derive(Default)]
+struct FlatVariantAttributes {
+    /// [`attr::Rename`] for custom renaming.
+    rename: Option<attr::Rename>,
+
+    /// [`attr::RenameAll`] for case conversion.
+    rename_all: Option<attr::RenameAll>,
+}
+
+impl Parse for FlatVariantAttributes {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        mod ident {
+            use syn::custom_keyword;
+
+            custom_keyword!(rename);
+            custom_keyword!(rename_all);
+        }
+
+        let ahead = input.lookahead1();
+        if ahead.peek(ident::rename) {
+            Ok(Self {
+                rename: Some(input.parse()?),
+                ..Default::default()
+            })
+        } else if ahead.peek(ident::rename_all) {
+            Ok(Self {
+                rename_all: Some(input.parse()?),
+                ..Default::default()
+            })
+        } else {
+            Err(ahead.error())
+        }
+    }
+}
+
+impl attr::ParseMultiple for FlatVariantAttributes {
+    fn merge_attrs(
+        prev: Spanning<Self>,
+        new: Spanning<Self>,
+        name: &syn::Ident,
+    ) -> syn::Result<Spanning<Self>> {
+        let Spanning {
+            span: prev_span,
+            item: mut prev,
+        } = prev;
+        let Spanning {
+            span: new_span,
+            item: new,
+        } = new;
+
+        if new.rename.and_then(|n| prev.rename.replace(n)).is_some() {
+            return Err(syn::Error::new(
+                new_span,
+                format!("multiple `#[{name}(rename=\"...\")]` attributes aren't allowed"),
+            ));
+        }
+
+        if new
+            .rename_all
+            .and_then(|n| prev.rename_all.replace(n))
+            .is_some()
+        {
+            return Err(syn::Error::new(
+                new_span,
+                format!("multiple `#[{name}(rename_all=\"...\")]` attributes aren't allowed"),
+            ));
+        }
+
+        Ok(Spanning::new(
+            prev,
+            prev_span.join(new_span).unwrap_or(prev_span),
+        ))
     }
 }
 

--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -133,6 +133,7 @@ struct FlatExpansion<'i> {
     /// a value-specific [`attr::RenameAll`] overriding [`FlatExpansion::rename_all`], if any.
     ///
     /// [`syn::Ident`]: struct@syn::Ident
+    #[allow(clippy::type_complexity)]
     matches: Vec<(
         &'i syn::Ident,
         Either<&'i syn::DataStruct, &'i syn::Variant>,
@@ -174,12 +175,7 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
                         "only structs with no fields can derive `FromStr`",
                     ));
                 }
-                vec![(
-                    &input.ident,
-                    Either::Left(data),
-                    rename.clone(),
-                    rename_all.clone(),
-                )]
+                vec![(&input.ident, Either::Left(data), rename, rename_all)]
             }
             syn::Data::Enum(data) => data
                 .variants
@@ -555,7 +551,9 @@ impl attr::ParseMultiple for FlatVariantAttributes {
         if new.rename.and_then(|n| prev.rename.replace(n)).is_some() {
             return Err(syn::Error::new(
                 new_span,
-                format!("multiple `#[{name}(rename=\"...\")]` attributes aren't allowed"),
+                format!(
+                    "multiple `#[{name}(rename=\"...\")]` attributes aren't allowed"
+                ),
             ));
         }
 
@@ -650,7 +648,9 @@ impl attr::ParseMultiple for FlatContainerAttributes {
         if new.rename.and_then(|n| prev.rename.replace(n)).is_some() {
             return Err(syn::Error::new(
                 new_span,
-                format!("multiple `#[{name}(rename=\"...\")]` attributes aren't allowed"),
+                format!(
+                    "multiple `#[{name}(rename=\"...\")]` attributes aren't allowed"
+                ),
             ));
         }
 

--- a/impl/src/from_str.rs
+++ b/impl/src/from_str.rs
@@ -158,6 +158,14 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
     fn try_from(input: &'i syn::DeriveInput) -> syn::Result<Self> {
         let attr_ident = &format_ident!("from_str");
 
+        let FlatContainerAttributes {
+            rename,
+            rename_all,
+            error: custom_error,
+        } = FlatContainerAttributes::parse_attrs(&input.attrs, attr_ident)?
+            .map(Spanning::into_inner)
+            .unwrap_or_default();
+
         let matches = match &input.data {
             syn::Data::Struct(data) => {
                 if !data.fields.is_empty() {
@@ -166,7 +174,12 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
                         "only structs with no fields can derive `FromStr`",
                     ));
                 }
-                vec![(&input.ident, Either::Left(data), None, None)]
+                vec![(
+                    &input.ident,
+                    Either::Left(data),
+                    rename.clone(),
+                    rename_all.clone(),
+                )]
             }
             syn::Data::Enum(data) => data
                 .variants
@@ -197,13 +210,6 @@ impl<'i> TryFrom<&'i syn::DeriveInput> for FlatExpansion<'i> {
                 ))
             }
         };
-
-        let FlatContainerAttributes {
-            rename_all,
-            error: custom_error,
-        } = FlatContainerAttributes::parse_attrs(&input.attrs, attr_ident)?
-            .map(Spanning::into_inner)
-            .unwrap_or_default();
 
         let mut similar_matches = <HashMap<_, Vec<_>>>::new();
         if rename_all.is_none() {
@@ -584,6 +590,9 @@ impl attr::ParseMultiple for FlatVariantAttributes {
 /// be specified only once.
 #[derive(Default)]
 struct FlatContainerAttributes {
+    /// [`attr::Rename`] for custom renaming.
+    rename: Option<attr::Rename>,
+
     /// [`attr::RenameAll`] for case conversion.
     rename_all: Option<attr::RenameAll>,
 
@@ -597,6 +606,7 @@ impl Parse for FlatContainerAttributes {
             use syn::custom_keyword;
 
             custom_keyword!(error);
+            custom_keyword!(rename);
             custom_keyword!(rename_all);
         }
 
@@ -604,6 +614,11 @@ impl Parse for FlatContainerAttributes {
         if ahead.peek(ident::error) {
             Ok(Self {
                 error: Some(input.parse()?),
+                ..Default::default()
+            })
+        } else if ahead.peek(ident::rename) {
+            Ok(Self {
+                rename: Some(input.parse()?),
                 ..Default::default()
             })
         } else if ahead.peek(ident::rename_all) {
@@ -631,6 +646,13 @@ impl attr::ParseMultiple for FlatContainerAttributes {
             span: new_span,
             item: new,
         } = new;
+
+        if new.rename.and_then(|n| prev.rename.replace(n)).is_some() {
+            return Err(syn::Error::new(
+                new_span,
+                format!("multiple `#[{name}(rename=\"...\")]` attributes aren't allowed"),
+            ));
+        }
 
         if new
             .rename_all

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1539,10 +1539,10 @@ pub(crate) mod attr {
         feature = "mul_assign",
     ))]
     pub(crate) use self::forward::Forward;
+    #[cfg(feature = "from_str")]
+    pub(crate) use self::rename::Rename;
     #[cfg(any(feature = "display", feature = "from_str"))]
     pub(crate) use self::rename_all::RenameAll;
-    #[cfg(any(feature = "display", feature = "from_str"))]
-    pub(crate) use self::rename::Rename;
     #[cfg(any(
         feature = "add",
         feature = "add_assign",

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -1541,6 +1541,8 @@ pub(crate) mod attr {
     pub(crate) use self::forward::Forward;
     #[cfg(any(feature = "display", feature = "from_str"))]
     pub(crate) use self::rename_all::RenameAll;
+    #[cfg(any(feature = "display", feature = "from_str"))]
+    pub(crate) use self::rename::Rename;
     #[cfg(any(
         feature = "add",
         feature = "add_assign",
@@ -2388,6 +2390,53 @@ pub(crate) mod attr {
         }
 
         impl ParseMultiple for RenameAll {}
+    }
+
+    #[cfg(any(feature = "display", feature = "from_str"))]
+    mod rename {
+        use syn::{
+            parse::{Parse, ParseStream},
+            spanned::Spanned as _,
+            token,
+        };
+
+        use super::ParseMultiple;
+
+        /// Representation of a `rename` macro attribute.
+        ///
+        /// ```rust,ignore
+        /// #[<attribute>(rename = "...")]
+        /// ```
+        #[derive(Clone, Debug)]
+        pub(crate) struct Rename(String);
+
+        impl Rename {
+            pub(crate) fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Parse for Rename {
+            fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+                let _ = input.parse::<syn::Path>().and_then(|p| {
+                    if p.is_ident("rename") {
+                        Ok(p)
+                    } else {
+                        Err(syn::Error::new(
+                            p.span(),
+                            "unknown attribute argument, expected `rename = \"...\"`",
+                        ))
+                    }
+                })?;
+
+                input.parse::<token::Eq>()?;
+
+                let lit: syn::LitStr = input.parse()?;
+                Ok(Self(lit.value()))
+            }
+        }
+
+        impl ParseMultiple for Rename {}
     }
 }
 

--- a/tests/compile_fail/as_mut/renamed_generic.stderr
+++ b/tests/compile_fail/as_mut/renamed_generic.stderr
@@ -13,6 +13,9 @@ error[E0599]: the method `as_mut` exists for struct `Baz<i32>`, but its trait bo
    = note: trait bound `Foo<i32>: AsMut<Foo<i32>>` was not satisfied
 note: the trait `AsMut` must be implemented
   --> $RUST/core/src/convert/mod.rs
+   |
+   | pub const trait AsMut<T: PointeeSized>: PointeeSized {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `as_mut`, perhaps you need to implement it:
            candidate #1: `AsMut`

--- a/tests/compile_fail/as_ref/renamed_generic.stderr
+++ b/tests/compile_fail/as_ref/renamed_generic.stderr
@@ -13,6 +13,9 @@ error[E0599]: the method `as_ref` exists for struct `Baz<i32>`, but its trait bo
    = note: trait bound `Foo<i32>: AsRef<Foo<i32>>` was not satisfied
 note: the trait `AsRef` must be implemented
   --> $RUST/core/src/convert/mod.rs
+   |
+   | pub const trait AsRef<T: PointeeSized>: PointeeSized {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `as_ref`, perhaps you need to implement it:
            candidate #1: `AsRef`

--- a/tests/compile_fail/from_str/enum_unknown_attribute.stderr
+++ b/tests/compile_fail/from_str/enum_unknown_attribute.stderr
@@ -1,4 +1,4 @@
-error: expected `error` or `rename_all`
+error: expected one of: `error`, `rename`, `rename_all`
  --> tests/compile_fail/from_str/enum_unknown_attribute.rs:2:12
   |
 2 | #[from_str(unknown = "unknown")]

--- a/tests/compile_fail/from_str/rename_collision.rs
+++ b/tests/compile_fail/from_str/rename_collision.rs
@@ -1,0 +1,11 @@
+use derive_more::FromStr;
+
+#[derive(FromStr)]
+#[from_str(rename_all = "lowercase")]
+enum E {
+    #[from_str(rename = "b")]
+    A,
+    B,
+}
+
+fn main() {}

--- a/tests/compile_fail/from_str/rename_collision.stderr
+++ b/tests/compile_fail/from_str/rename_collision.stderr
@@ -1,0 +1,5 @@
+error: `A`, `B` variants cannot have the same "b" string representation
+ --> tests/compile_fail/from_str/rename_collision.rs:5:6
+  |
+5 | enum E {
+  |      ^

--- a/tests/compile_fail/from_str/rename_duplicate.rs
+++ b/tests/compile_fail/from_str/rename_duplicate.rs
@@ -1,0 +1,11 @@
+use derive_more::FromStr;
+
+#[derive(FromStr)]
+enum E {
+    #[from_str(rename = "a")]
+    A,
+    #[from_str(rename = "a")]
+    B,
+}
+
+fn main() {}

--- a/tests/compile_fail/from_str/rename_duplicate.stderr
+++ b/tests/compile_fail/from_str/rename_duplicate.stderr
@@ -1,0 +1,5 @@
+error: `A`, `B` variants cannot have the same "a" string representation
+ --> tests/compile_fail/from_str/rename_duplicate.rs:4:6
+  |
+4 | enum E {
+  |      ^

--- a/tests/compile_fail/from_str/rename_multiple.rs
+++ b/tests/compile_fail/from_str/rename_multiple.rs
@@ -1,0 +1,10 @@
+use derive_more::FromStr;
+
+#[derive(FromStr)]
+enum E {
+    #[from_str(rename = "a")]
+    #[from_str(rename = "b")]
+    A,
+}
+
+fn main() {}

--- a/tests/compile_fail/from_str/rename_multiple.stderr
+++ b/tests/compile_fail/from_str/rename_multiple.stderr
@@ -1,0 +1,5 @@
+error: multiple `#[from_str(rename="...")]` attributes aren't allowed
+ --> tests/compile_fail/from_str/rename_multiple.rs:6:5
+  |
+6 |     #[from_str(rename = "b")]
+  |     ^

--- a/tests/compile_fail/from_str/struct_flat_unknown_attribute.stderr
+++ b/tests/compile_fail/from_str/struct_flat_unknown_attribute.stderr
@@ -1,4 +1,4 @@
-error: expected `error` or `rename_all`
+error: expected one of: `error`, `rename`, `rename_all`
  --> tests/compile_fail/from_str/struct_flat_unknown_attribute.rs:2:12
   |
 2 | #[from_str(unknown = "unknown")]

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -442,6 +442,19 @@ mod structs {
             );
         }
 
+        #[test]
+        fn rename() {
+            #[derive(Debug, Eq, FromStr, PartialEq)]
+            #[from_str(rename = "Bar")]
+            struct Foo;
+
+            assert_eq!("Bar".parse::<Foo>().unwrap(), Foo);
+            assert_eq!(
+                "Foo".parse::<Foo>().unwrap_err().to_string(),
+                "Invalid `Foo` string representation",
+            );
+        }
+
         mod rename_all {
             use super::*;
 
@@ -724,6 +737,79 @@ mod enums {
                 "other".parse::<Enum>().unwrap_err().to_string(),
                 "Invalid `Enum` string representation",
             );
+        }
+
+        mod rename {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                #[derive(Debug, Eq, FromStr, PartialEq)]
+                enum Enum {
+                    #[from_str(rename = "foo")]
+                    Foo,
+                    #[from_str(rename = "bar")]
+                    Bar,
+                }
+
+                assert_eq!("foo".parse::<Enum>().unwrap(), Enum::Foo);
+                assert_eq!("bar".parse::<Enum>().unwrap(), Enum::Bar);
+
+                assert_eq!(
+                    "Foo".parse::<Enum>().unwrap_err().to_string(),
+                    "Invalid `Enum` string representation",
+                );
+            }
+
+            #[test]
+            fn override_rename_all() {
+                #[derive(Debug, Eq, FromStr, PartialEq)]
+                #[from_str(rename_all = "UPPERCASE")]
+                enum Enum {
+                    #[from_str(rename = "foo")]
+                    Foo,
+                    Bar,
+                }
+
+                assert_eq!("foo".parse::<Enum>().unwrap(), Enum::Foo);
+                assert_eq!("BAR".parse::<Enum>().unwrap(), Enum::Bar);
+
+                assert_eq!(
+                    "FOO".parse::<Enum>().unwrap_err().to_string(),
+                    "Invalid `Enum` string representation",
+                );
+            }
+
+            #[test]
+            fn mixed() {
+                #[derive(Debug, Eq, FromStr, PartialEq)]
+                enum Enum {
+                    #[from_str(rename = "foo")]
+                    Foo,
+                    Bar,
+                }
+
+                assert_eq!("foo".parse::<Enum>().unwrap(), Enum::Foo);
+                // Default is case-insensitive
+                assert_eq!("Bar".parse::<Enum>().unwrap(), Enum::Bar);
+                assert_eq!("bar".parse::<Enum>().unwrap(), Enum::Bar);
+            }
+
+            #[test]
+            fn case_sensitivity() {
+                #[derive(Debug, Eq, FromStr, PartialEq)]
+                enum Enum {
+                    #[from_str(rename = "Foo")]
+                    Foo,
+                }
+
+                assert_eq!("Foo".parse::<Enum>().unwrap(), Enum::Foo);
+                // rename attribute is strict
+                assert_eq!(
+                    "foo".parse::<Enum>().unwrap_err().to_string(),
+                    "Invalid `Enum` string representation",
+                );
+            }
         }
 
         mod rename_all {


### PR DESCRIPTION
This refers to https://github.com/JelteF/derive_more/issues/216 and https://github.com/JelteF/derive_more/issues/480

<!-- Remove the lines above if there are no related issues/PRs -->

## Synopsis

This supports:

```rust
#[derive(Debug, Eq, FromStr, PartialEq)]
enum Enum {
    #[from_str(rename = "foo")]
    Foo,
    #[from_str(rename = "bar")]
    Bar,
}
```

## Solution

<!-- Describe how exactly the problem is (or will be) resolved -->

## Checklist

- [ ] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [ ] [CHANGELOG entry](/CHANGELOG.md) is added (if required)
