### PR TITLE
chore: replace `unicode-xid` with `unicode-ident`

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -27,7 +27,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0.45"
 convert_case = { version = "0.10", optional = true }
-unicode-xid = { version = "0.2.2", optional = true }
+unicode-ident = { version = "1.0", optional = true }
 
 [build-dependencies]
 rustc_version = "0.4"
@@ -53,10 +53,10 @@ add = ["syn/extra-traits", "syn/visit"]
 add_assign = ["syn/extra-traits", "syn/visit"]
 as_ref = ["syn/extra-traits", "syn/visit"]
 constructor = []
-debug = ["syn/extra-traits", "dep:unicode-xid"]
+debug = ["syn/extra-traits", "dep:unicode-ident"]
 deref = []
 deref_mut = []
-display = ["syn/extra-traits", "dep:unicode-xid", "dep:convert_case"]
+display = ["syn/extra-traits", "dep:unicode-ident", "dep:convert_case"]
 eq = ["syn/extra-traits", "syn/visit"]
 error = ["syn/extra-traits"]
 from = ["syn/extra-traits"]

--- a/impl/src/fmt/parsing.rs
+++ b/impl/src/fmt/parsing.rs
@@ -4,7 +4,7 @@
 
 use std::iter;
 
-use unicode_xid::UnicodeXID as XID;
+use unicode_ident::{is_xid_continue, is_xid_start};
 
 /// Output of the [`format_string`] parser.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -517,10 +517,10 @@ fn identifier(input: &str) -> Option<(LeftToParse<'_>, Identifier<'_>)> {
     map(
         alt(&mut [
             &mut map(
-                check_char(XID::is_xid_start),
-                take_while0(check_char(XID::is_xid_continue)),
+                check_char(is_xid_start),
+                take_while0(check_char(is_xid_continue)),
             ),
-            &mut and_then(char('_'), take_while1(check_char(XID::is_xid_continue))),
+            &mut and_then(char('_'), take_while1(check_char(is_xid_continue))),
         ]),
         |(i, _)| (i, &input[..(input.len() - i.len())]),
     )(input)


### PR DESCRIPTION
## Synopsis

The `unicode-ident` crate is the same dependency already used by `proc-macro2` and `syn`, reducing the total number of dependencies. It's also supposedly more optimized.
