### PR TITLE
Implement Borrow and BorrowMut derive macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Hash` derive similar to `std`'s one, but considering generics correctly,
   and supporting custom hash functions per field or skipping fields.
   ([#532](https://github.com/JelteF/derive_more/pull/532))
+- Add `Borrow` derive for single-field structs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   and supporting custom hash functions per field or skipping fields.
   ([#532](https://github.com/JelteF/derive_more/pull/532))
 - Add `Borrow` derive for single-field structs.
+- Add `BorrowMut` derive for single-field structs.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ default = ["std"]
 add = ["derive_more-impl/add"]
 add_assign = ["derive_more-impl/add_assign"]
 as_ref = ["derive_more-impl/as_ref"]
+borrow = ["derive_more-impl/borrow"]
 constructor = ["derive_more-impl/constructor"]
 debug = ["derive_more-impl/debug"]
 deref = ["derive_more-impl/deref"]
@@ -85,6 +86,7 @@ full = [
     "add",
     "add_assign",
     "as_ref",
+    "borrow",
     "constructor",
     "debug",
     "deref",
@@ -131,6 +133,11 @@ required-features = ["as_ref"]
 name = "as_ref"
 path = "tests/as_ref.rs"
 required-features = ["as_ref"]
+
+[[test]]
+name = "borrow"
+path = "tests/borrow.rs"
+required-features = ["borrow"]
 
 [[test]]
 name = "boats_display_derive"
@@ -260,7 +267,24 @@ required-features = ["unwrap"]
 [[test]]
 name = "compile_fail"
 path = "tests/compile_fail/mod.rs"
-required-features = ["as_ref", "debug", "display", "from", "into", "is_variant", "try_from", "try_into"]
+required-features = [
+    "add",
+    "add_assign",
+    "as_ref",
+    "borrow",
+    "debug",
+    "display",
+    "eq",
+    "from",
+    "from_str",
+    "hash",
+    "into",
+    "is_variant",
+    "mul",
+    "mul_assign",
+    "try_from",
+    "try_into",
+]
 
 [[test]]
 name = "no_std"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,11 @@ path = "tests/borrow.rs"
 required-features = ["borrow"]
 
 [[test]]
+name = "borrow_mut"
+path = "tests/borrow_mut.rs"
+required-features = ["borrow"]
+
+[[test]]
 name = "boats_display_derive"
 path = "tests/boats_display_derive.rs"
 required-features = ["display"]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ These are traits that are used to convert automatically between types.
 5. [`TryInto`]
 6. [`IntoIterator`]
 7. [`AsRef`], [`AsMut`]
-8. [`Borrow`]
+8. [`Borrow`], [`BorrowMut`]
 
 
 ### Formatting traits
@@ -252,6 +252,7 @@ Changing [MSRV] (minimum supported Rust version) of this crate is treated as a *
 [`AsRef`]: https://docs.rs/derive_more/latest/derive_more/derive.AsRef.html
 [`AsMut`]: https://docs.rs/derive_more/latest/derive_more/derive.AsMut.html
 [`Borrow`]: https://docs.rs/derive_more/latest/derive_more/derive.Borrow.html
+[`BorrowMut`]: https://docs.rs/derive_more/latest/derive_more/derive.BorrowMut.html
 
 [`Debug`]: https://docs.rs/derive_more/latest/derive_more/derive.Debug.html
 [`Display`-like]: https://docs.rs/derive_more/latest/derive_more/derive.Display.html

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These are traits that are used to convert automatically between types.
 5. [`TryInto`]
 6. [`IntoIterator`]
 7. [`AsRef`], [`AsMut`]
+8. [`Borrow`]
 
 
 ### Formatting traits
@@ -250,6 +251,7 @@ Changing [MSRV] (minimum supported Rust version) of this crate is treated as a *
 [`IntoIterator`]: https://docs.rs/derive_more/latest/derive_more/derive.IntoIterator.html
 [`AsRef`]: https://docs.rs/derive_more/latest/derive_more/derive.AsRef.html
 [`AsMut`]: https://docs.rs/derive_more/latest/derive_more/derive.AsMut.html
+[`Borrow`]: https://docs.rs/derive_more/latest/derive_more/derive.Borrow.html
 
 [`Debug`]: https://docs.rs/derive_more/latest/derive_more/derive.Debug.html
 [`Display`-like]: https://docs.rs/derive_more/latest/derive_more/derive.Display.html

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -52,6 +52,7 @@ default = []
 add = ["syn/extra-traits", "syn/visit"]
 add_assign = ["syn/extra-traits", "syn/visit"]
 as_ref = ["syn/extra-traits", "syn/visit"]
+borrow = ["syn/visit"]
 constructor = []
 debug = ["syn/extra-traits", "dep:unicode-ident"]
 deref = []
@@ -80,6 +81,7 @@ full = [
     "add",
     "add_assign",
     "as_ref",
+    "borrow",
     "constructor",
     "debug",
     "deref",

--- a/impl/doc/as_mut.md
+++ b/impl/doc/as_mut.md
@@ -69,13 +69,12 @@ of the field itself, and types for which the field type implements `AsMut`.
 # use derive_more::AsMut;
 #
 #[derive(AsMut)]
-#[as_mut(str, [u8], String)]
+#[as_mut(str, String)]
 struct Types(String);
 
 let mut item = Types("test".to_owned());
 let _: &mut str = item.as_mut();
-let _: &mut [u8] = item.as_mut();
-let _: &mut String = item.as_mut();_
+let _: &mut String = item.as_mut();
 ```
 
 > **WARNING**: When either the field type, or the specified conversion type,
@@ -148,7 +147,7 @@ Generates:
 #     valid: bool,
 # }
 impl AsMut<str> for MyWrapper {
-    fn as_mut(&mut self) -> &mut String {
+    fn as_mut(&mut self) -> &mut str {
         self.name.as_mut()
     }
 }

--- a/impl/doc/borrow.md
+++ b/impl/doc/borrow.md
@@ -1,0 +1,90 @@
+# What `#[derive(Borrow)]` generates
+
+Deriving `Borrow` generates an implementation of `core::borrow::Borrow` that
+borrows a single-field struct as its field.
+
+`Borrow` has stronger semantic requirements than `AsRef`: equality, ordering and
+hashing of the borrowed value are expected to match those of the owning value.
+For that reason, this derive only supports structs with exactly one field.
+
+
+
+
+## Newtypes and Structs with One Field
+
+When `Borrow` is derived for a newtype or a struct with one field, a single
+implementation is generated for the field type.
+
+```rust
+# use derive_more::Borrow;
+#
+#[derive(Borrow)]
+struct MyWrapper(String);
+```
+
+Generates code equivalent to:
+
+```rust
+# struct MyWrapper(String);
+impl core::borrow::Borrow<String> for MyWrapper {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}
+```
+
+It's also possible to use the `#[borrow(forward)]` attribute to forward to the
+field's `Borrow` implementation.
+
+```rust
+# use derive_more::Borrow;
+# use derive_more::core::borrow::Borrow as _;
+#
+#[derive(Borrow)]
+#[borrow(forward)]
+struct MyWrapper(String);
+
+let item = MyWrapper("test".to_owned());
+let _: &str = item.borrow();
+```
+
+This generates code equivalent to:
+
+```rust
+# struct MyWrapper(String);
+impl<T: ?Sized> core::borrow::Borrow<T> for MyWrapper
+where
+    String: core::borrow::Borrow<T>,
+{
+    #[inline]
+    fn borrow(&self) -> &T {
+        self.0.borrow()
+    }
+}
+```
+
+Forwarding cannot be derived through a generic parameter, an associated type of
+a generic parameter, or a forwarding pointer to either. Directly borrowing an
+associated type of a generic parameter is not supported either. These shapes can
+overlap with `core`'s blanket `impl<T> Borrow<T> for T`.
+
+
+
+
+## Structs with Multiple Fields
+
+Deriving `Borrow` for structs with more than one field is not supported.
+
+```rust,compile_fail
+# use derive_more::Borrow;
+#
+#[derive(Borrow)]
+struct User(String, bool);
+```
+
+
+
+
+## Enums
+
+Deriving `Borrow` for enums is not supported.

--- a/impl/doc/borrow_mut.md
+++ b/impl/doc/borrow_mut.md
@@ -1,0 +1,108 @@
+# What `#[derive(BorrowMut)]` generates
+
+Deriving `BorrowMut` generates an implementation of
+`core::borrow::BorrowMut` that mutably borrows a single-field struct as its
+field.
+
+`BorrowMut<T>` requires `Borrow<T>`, so the type must also implement the
+matching `Borrow` implementation. Usually this means deriving both `Borrow` and
+`BorrowMut`.
+
+
+
+
+## Newtypes and Structs with One Field
+
+When `BorrowMut` is derived for a newtype or a struct with one field, a single
+implementation is generated for the field type.
+
+```rust
+# use derive_more::{Borrow, BorrowMut};
+#
+#[derive(Borrow, BorrowMut)]
+struct MyWrapper(String);
+```
+
+Generates code equivalent to:
+
+```rust
+# struct MyWrapper(String);
+# impl core::borrow::Borrow<String> for MyWrapper {
+#     fn borrow(&self) -> &String {
+#         &self.0
+#     }
+# }
+impl core::borrow::BorrowMut<String> for MyWrapper {
+    fn borrow_mut(&mut self) -> &mut String {
+        &mut self.0
+    }
+}
+```
+
+It's also possible to use the `#[borrow_mut(forward)]` attribute to forward to
+the field's `BorrowMut` implementation. The matching `Borrow` implementation
+must borrow the same type, so forwarded `BorrowMut` usually goes together with
+`#[borrow(forward)]`.
+
+```rust
+# use derive_more::{Borrow, BorrowMut};
+# use derive_more::core::borrow::BorrowMut as _;
+#
+#[derive(Borrow, BorrowMut)]
+#[borrow(forward)]
+#[borrow_mut(forward)]
+struct MyWrapper(String);
+
+let mut item = MyWrapper("test".to_owned());
+let _: &mut str = item.borrow_mut();
+```
+
+This generates code equivalent to:
+
+```rust
+# struct MyWrapper(String);
+# impl<T: ?Sized> core::borrow::Borrow<T> for MyWrapper
+# where
+#     String: core::borrow::Borrow<T>,
+# {
+#     #[inline]
+#     fn borrow(&self) -> &T {
+#         self.0.borrow()
+#     }
+# }
+impl<T: ?Sized> core::borrow::BorrowMut<T> for MyWrapper
+where
+    String: core::borrow::BorrowMut<T>,
+{
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut T {
+        self.0.borrow_mut()
+    }
+}
+```
+
+Forwarding cannot be derived through a generic parameter, an associated type of
+a generic parameter, or a forwarding pointer to either. Directly borrowing an
+associated type of a generic parameter is not supported either. These shapes can
+overlap with `core`'s blanket `impl<T> BorrowMut<T> for T`.
+
+
+
+
+## Structs with Multiple Fields
+
+Deriving `BorrowMut` for structs with more than one field is not supported.
+
+```rust,compile_fail
+# use derive_more::{Borrow, BorrowMut};
+#
+#[derive(Borrow, BorrowMut)]
+struct User(String, bool);
+```
+
+
+
+
+## Enums
+
+Deriving `BorrowMut` for enums is not supported.

--- a/impl/src/borrow.rs
+++ b/impl/src/borrow.rs
@@ -1,7 +1,7 @@
-//! Implementation of a [`Borrow`] derive macro.
+//! Implementation of `Borrow`/`BorrowMut` derive macros.
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, ToTokens as _};
+use quote::{format_ident, quote};
 use syn::{
     parse::{Parse, ParseStream},
     parse_quote,
@@ -14,13 +14,20 @@ use crate::utils::{
     Either, GenericsSearch, Spanning,
 };
 
-/// Expands a [`Borrow`] derive macro.
+/// Expands a `Borrow`/`BorrowMut` derive macro.
 pub(crate) fn expand(
     input: &syn::DeriveInput,
     trait_name: &'static str,
 ) -> syn::Result<TokenStream> {
     let trait_ident = format_ident!("{trait_name}");
-    let attr_name = format_ident!("borrow");
+    let is_mutable = trait_name == "BorrowMut";
+    let attr_name =
+        format_ident!("{}", if is_mutable { "borrow_mut" } else { "borrow" });
+    let trait_info = ExpansionCtx {
+        trait_ident: &trait_ident,
+        attr_name: &attr_name,
+        is_mutable,
+    };
 
     let data = match &input.data {
         syn::Data::Struct(data) => Ok(data),
@@ -46,14 +53,15 @@ pub(crate) fn expand(
     }
 
     let field = data.fields.iter().next().unwrap();
-    let struct_attr = StructAttribute::parse_attrs(&input.attrs, &attr_name)?;
-    let field_attr = FieldAttribute::parse_attrs(&field.attrs, &attr_name)?;
+    let struct_attr = StructAttribute::parse_attrs(&input.attrs, trait_info.attr_name)?;
+    let field_attr = FieldAttribute::parse_attrs(&field.attrs, trait_info.attr_name)?;
 
     if struct_attr.is_some() && field_attr.is_some() {
         return Err(syn::Error::new(
             field.span(),
             format!(
-                "`#[{attr_name}(...)]` cannot be placed on both struct and its field"
+                "`#[{}(...)]` cannot be placed on both struct and its field",
+                trait_info.attr_name,
             ),
         ));
     }
@@ -68,9 +76,11 @@ pub(crate) fn expand(
                 return Err(syn::Error::new(
                     attr.span,
                     format!(
-                        "`#[{attr_name}({})]` cannot be used when deriving `{trait_ident}` \
+                        "`#[{}({})]` cannot be used when deriving `{}` \
                          because exactly one field must be borrowed",
+                        trait_info.attr_name,
                         skip.name(),
+                        trait_info.trait_ident,
                     ),
                 ));
             }
@@ -79,23 +89,22 @@ pub(crate) fn expand(
         false
     };
 
-    validate_field_type(field, &input.generics, is_forwarded, &trait_ident)?;
+    validate_field_type(field, &input.generics, is_forwarded, trait_info)?;
 
-    Ok(Expansion {
-        ident: &input.ident,
-        generics: &input.generics,
+    Ok(expand_impl(
+        &input.ident,
+        &input.generics,
         field,
-        field_index: 0,
         is_forwarded,
-    }
-    .into_token_stream())
+        trait_info,
+    ))
 }
 
 fn validate_field_type(
     field: &syn::Field,
     generics: &syn::Generics,
     is_forwarded: bool,
-    trait_ident: &syn::Ident,
+    trait_info: ExpansionCtx<'_>,
 ) -> syn::Result<()> {
     let field_ty = &field.ty;
 
@@ -103,9 +112,11 @@ fn validate_field_type(
         return Err(syn::Error::new(
             field_ty.span(),
             format!(
-                "`{trait_ident}` cannot be derived for an associated type projection involving \
-                 generic parameters because the impl can overlap with `core`'s blanket `Borrow` \
+                "`{}` cannot be derived for an associated type projection involving generic \
+                 parameters because the impl can overlap with `core`'s blanket `{}` \
                  implementation",
+                trait_info.trait_ident,
+                trait_info.trait_ident,
             ),
         ));
     }
@@ -113,9 +124,13 @@ fn validate_field_type(
     if is_forwarded && is_forwarded_overlap(field_ty, generics) {
         return Err(syn::Error::new(
             field_ty.span(),
-            "`#[borrow(forward)]` cannot be used on a generic parameter field, an associated \
-             type projection involving generic parameters, or a forwarding pointer to one \
-             because the impl can overlap with `core`'s blanket `Borrow` implementation",
+            format!(
+                "`#[{}(forward)]` cannot be used on a generic parameter field, an associated \
+                 type projection involving generic parameters, or a forwarding pointer to one \
+                 because the impl can overlap with `core`'s blanket `{}` implementation",
+                trait_info.attr_name,
+                trait_info.trait_ident,
+            ),
         ));
     }
 
@@ -133,11 +148,8 @@ fn is_assoc_type_involving_generic_param(
         syn::Type::Paren(ty) => {
             return is_assoc_type_involving_generic_param(&ty.elem, generics)
         }
-        ty => ty,
-    };
-
-    let syn::Type::Path(ty) = ty else {
-        return false;
+        syn::Type::Path(ty) => ty,
+        _ => return false,
     };
 
     if ty.qself.is_some() {
@@ -230,90 +242,92 @@ fn fundamental_path_segment(ty: &syn::TypePath) -> Option<&syn::PathSegment> {
     }
 }
 
-/// Expansion of a macro for generating a [`Borrow`] implementation for a single field of a struct.
-struct Expansion<'a> {
-    /// [`syn::Ident`] of the struct.
-    ident: &'a syn::Ident,
-
-    /// [`syn::Generics`] of the struct.
-    generics: &'a syn::Generics,
-
-    /// [`syn::Field`] of the struct.
-    field: &'a syn::Field,
-
-    /// Index of the [`syn::Field`].
-    field_index: usize,
-
-    /// Whether `Borrow::borrow()` should be forwarded to the field's `Borrow` implementation.
-    is_forwarded: bool,
+#[derive(Clone, Copy)]
+struct ExpansionCtx<'a> {
+    trait_ident: &'a syn::Ident,
+    attr_name: &'a syn::Ident,
+    is_mutable: bool,
 }
 
-impl quote::ToTokens for Expansion<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let field_ty = &self.field.ty;
-        let field_ident = self.field.ident.as_ref().map_or_else(
-            || syn::Index::from(self.field_index).to_token_stream(),
-            quote::ToTokens::to_token_stream,
+fn expand_impl(
+    ty_ident: &syn::Ident,
+    generics: &syn::Generics,
+    field: &syn::Field,
+    is_forwarded: bool,
+    trait_info: ExpansionCtx<'_>,
+) -> TokenStream {
+    let field_ty = &field.ty;
+    let field_ident = field
+        .ident
+        .as_ref()
+        .map_or_else(|| quote! { 0 }, |ident| quote! { #ident });
+    let (_, ty_gens, _) = generics.split_for_impl();
+    let borrow_ty = extra_borrow_type_param(generics, trait_info);
+    let trait_ident = trait_info.trait_ident;
+    let method_ident = trait_info.attr_name;
+    let mutability = trait_info.is_mutable.then(|| quote! { mut });
+
+    let trait_ty = if is_forwarded {
+        quote! { #borrow_ty }
+    } else {
+        quote! { #field_ty }
+    };
+    let return_ty = if is_forwarded {
+        quote! { #trait_ty }
+    } else {
+        borrowed_type_for_return(field_ty)
+    };
+    let trait_path = quote! {
+        derive_more::core::borrow::#trait_ident<#trait_ty>
+    };
+
+    let generics = if is_forwarded {
+        let mut generics = add_extra_generic_type_param(
+            generics,
+            quote! { #borrow_ty: ?derive_more::core::marker::Sized },
         );
-        let ty_ident = &self.ident;
-        let (_, ty_gens, _) = self.generics.split_for_impl();
-        let borrow_ty = extra_borrow_type_param(self.generics);
+        generics.make_where_clause().predicates.push(parse_quote! {
+            #field_ty: #trait_path
+        });
+        generics
+    } else {
+        generics.clone()
+    };
+    let (impl_gens, _, where_clause) = generics.split_for_impl();
 
-        let trait_ty = if self.is_forwarded {
-            quote! { #borrow_ty }
-        } else {
-            quote! { #field_ty }
-        };
-        let return_ty = if self.is_forwarded {
-            quote! { #trait_ty }
-        } else {
-            borrowed_type_for_return(field_ty)
-        };
-        let trait_path = quote! {
-            derive_more::core::borrow::Borrow<#trait_ty>
-        };
-
-        let generics = if self.is_forwarded {
-            let mut generics = add_extra_generic_type_param(
-                self.generics,
-                quote! { #borrow_ty: ?derive_more::core::marker::Sized },
-            );
-            generics.make_where_clause().predicates.push(parse_quote! {
-                #field_ty: #trait_path
-            });
-            generics
-        } else {
-            self.generics.clone()
-        };
-        let (impl_gens, _, where_clause) = generics.split_for_impl();
-
-        let body = if self.is_forwarded {
-            quote! {
-                <#field_ty as #trait_path>::borrow(&self.#field_ident)
-            }
-        } else {
-            quote! {
-                &self.#field_ident
-            }
-        };
-
+    let body = if is_forwarded {
         quote! {
-            #[allow(deprecated)] // omit warnings on deprecated fields/variants
-            #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
-            #[automatically_derived]
-            impl #impl_gens #trait_path for #ty_ident #ty_gens #where_clause {
-                #[inline]
-                fn borrow(&self) -> &#return_ty {
-                    #body
-                }
+            <#field_ty as #trait_path>::#method_ident(& #mutability self.#field_ident)
+        }
+    } else {
+        quote! {
+            & #mutability self.#field_ident
+        }
+    };
+
+    quote! {
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+        #[automatically_derived]
+        impl #impl_gens #trait_path for #ty_ident #ty_gens #where_clause {
+            #[inline]
+            fn #method_ident(& #mutability self) -> & #mutability #return_ty {
+                #body
             }
         }
-        .to_tokens(tokens);
     }
 }
 
-fn extra_borrow_type_param(generics: &syn::Generics) -> syn::Ident {
-    let mut ident = format_ident!("__BorrowT");
+fn extra_borrow_type_param(
+    generics: &syn::Generics,
+    trait_info: ExpansionCtx<'_>,
+) -> syn::Ident {
+    let prefix = if trait_info.is_mutable {
+        "__BorrowMutT"
+    } else {
+        "__BorrowT"
+    };
+    let mut ident = format_ident!("{prefix}");
     let mut index = 0;
 
     while generics.params.iter().any(|param| match param {
@@ -322,7 +336,7 @@ fn extra_borrow_type_param(generics: &syn::Generics) -> syn::Ident {
         syn::GenericParam::Lifetime(_) => false,
     }) {
         index += 1;
-        ident = format_ident!("__BorrowT{index}");
+        ident = format_ident!("{prefix}{index}");
     }
 
     ident

--- a/impl/src/borrow.rs
+++ b/impl/src/borrow.rs
@@ -1,0 +1,430 @@
+//! Implementation of a [`Borrow`] derive macro.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens as _};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_quote,
+    spanned::Spanned as _,
+};
+
+use crate::utils::{
+    add_extra_generic_type_param,
+    attr::{self, ParseMultiple as _},
+    Either, GenericsSearch, Spanning,
+};
+
+/// Expands a [`Borrow`] derive macro.
+pub(crate) fn expand(
+    input: &syn::DeriveInput,
+    trait_name: &'static str,
+) -> syn::Result<TokenStream> {
+    let trait_ident = format_ident!("{trait_name}");
+    let attr_name = format_ident!("borrow");
+
+    let data = match &input.data {
+        syn::Data::Struct(data) => Ok(data),
+        syn::Data::Enum(e) => Err(syn::Error::new(
+            e.enum_token.span(),
+            format!("`{trait_ident}` cannot be derived for enums"),
+        )),
+        syn::Data::Union(u) => Err(syn::Error::new(
+            u.union_token.span(),
+            format!("`{trait_ident}` cannot be derived for unions"),
+        )),
+    }?;
+
+    if data.fields.len() != 1 {
+        return Err(syn::Error::new(
+            if data.fields.is_empty() {
+                data.struct_token.span
+            } else {
+                data.fields.span()
+            },
+            format!("`{trait_ident}` can only be derived for structs with exactly one field"),
+        ));
+    }
+
+    let field = data.fields.iter().next().unwrap();
+    let struct_attr = StructAttribute::parse_attrs(&input.attrs, &attr_name)?;
+    let field_attr = FieldAttribute::parse_attrs(&field.attrs, &attr_name)?;
+
+    if struct_attr.is_some() && field_attr.is_some() {
+        return Err(syn::Error::new(
+            field.span(),
+            format!(
+                "`#[{attr_name}(...)]` cannot be placed on both struct and its field"
+            ),
+        ));
+    }
+
+    let is_forwarded = if struct_attr.is_some() {
+        true
+    } else if let Some(attr) = field_attr {
+        match attr.item {
+            FieldAttribute::Direct(_) => false,
+            FieldAttribute::Forward(_) => true,
+            FieldAttribute::Skip(skip) => {
+                return Err(syn::Error::new(
+                    attr.span,
+                    format!(
+                        "`#[{attr_name}({})]` cannot be used when deriving `{trait_ident}` \
+                         because exactly one field must be borrowed",
+                        skip.name(),
+                    ),
+                ));
+            }
+        }
+    } else {
+        false
+    };
+
+    validate_field_type(field, &input.generics, is_forwarded, &trait_ident)?;
+
+    Ok(Expansion {
+        ident: &input.ident,
+        generics: &input.generics,
+        field,
+        field_index: 0,
+        is_forwarded,
+    }
+    .into_token_stream())
+}
+
+fn validate_field_type(
+    field: &syn::Field,
+    generics: &syn::Generics,
+    is_forwarded: bool,
+    trait_ident: &syn::Ident,
+) -> syn::Result<()> {
+    let field_ty = &field.ty;
+
+    if is_assoc_type_involving_generic_param(field_ty, generics) {
+        return Err(syn::Error::new(
+            field_ty.span(),
+            format!(
+                "`{trait_ident}` cannot be derived for an associated type projection involving \
+                 generic parameters because the impl can overlap with `core`'s blanket `Borrow` \
+                 implementation",
+            ),
+        ));
+    }
+
+    if is_forwarded && is_forwarded_overlap(field_ty, generics) {
+        return Err(syn::Error::new(
+            field_ty.span(),
+            "`#[borrow(forward)]` cannot be used on a generic parameter field, an associated \
+             type projection involving generic parameters, or a forwarding pointer to one \
+             because the impl can overlap with `core`'s blanket `Borrow` implementation",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_assoc_type_involving_generic_param(
+    ty: &syn::Type,
+    generics: &syn::Generics,
+) -> bool {
+    let ty = match ty {
+        syn::Type::Group(ty) => {
+            return is_assoc_type_involving_generic_param(&ty.elem, generics)
+        }
+        syn::Type::Paren(ty) => {
+            return is_assoc_type_involving_generic_param(&ty.elem, generics)
+        }
+        ty => ty,
+    };
+
+    let syn::Type::Path(ty) = ty else {
+        return false;
+    };
+
+    if ty.qself.is_some() {
+        return GenericsSearch::from(generics).any_in(&syn::Type::Path(ty.clone()));
+    }
+
+    ty.path.segments.len() > 1
+        && generics
+            .type_params()
+            .any(|param| ty.path.segments[0].ident == param.ident)
+}
+
+fn is_bare_generic_param(ty: &syn::Type, generics: &syn::Generics) -> bool {
+    let syn::Type::Path(ty) = ty else {
+        return false;
+    };
+
+    ty.qself.is_none()
+        && ty.path.segments.len() == 1
+        && generics
+            .type_params()
+            .any(|param| ty.path.segments[0].ident == param.ident)
+}
+
+fn is_forwarded_overlap(ty: &syn::Type, generics: &syn::Generics) -> bool {
+    let ty = peel_forwarding_pointer(ty);
+    is_bare_generic_param(ty, generics)
+        || is_assoc_type_involving_generic_param(ty, generics)
+}
+
+fn peel_forwarding_pointer(ty: &syn::Type) -> &syn::Type {
+    match ty {
+        syn::Type::Group(ty) => peel_forwarding_pointer(&ty.elem),
+        syn::Type::Paren(ty) => peel_forwarding_pointer(&ty.elem),
+        syn::Type::Reference(ty) => peel_forwarding_pointer(&ty.elem),
+        syn::Type::Path(type_path) => {
+            fundamental_path_inner_type(type_path).map_or(ty, peel_forwarding_pointer)
+        }
+        _ => ty,
+    }
+}
+
+fn fundamental_path_inner_type(ty: &syn::TypePath) -> Option<&syn::Type> {
+    let segment = fundamental_path_segment(ty)?;
+
+    let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return None;
+    };
+
+    arguments.args.iter().find_map(|arg| {
+        if let syn::GenericArgument::Type(ty) = arg {
+            Some(ty)
+        } else {
+            None
+        }
+    })
+}
+
+fn fundamental_path_segment(ty: &syn::TypePath) -> Option<&syn::PathSegment> {
+    if ty.qself.is_some() {
+        return None;
+    }
+
+    let segments = ty.path.segments.iter().collect::<Vec<_>>();
+    match segments.as_slice() {
+        [segment] if segment.ident == "Box" || segment.ident == "Pin" => Some(segment),
+        [std_or_alloc, boxed, segment]
+            if (std_or_alloc.ident == "std" || std_or_alloc.ident == "alloc")
+                && boxed.ident == "boxed"
+                && segment.ident == "Box" =>
+        {
+            Some(segment)
+        }
+        [std_or_core, pin, segment]
+            if (std_or_core.ident == "std" || std_or_core.ident == "core")
+                && pin.ident == "pin"
+                && segment.ident == "Pin" =>
+        {
+            Some(segment)
+        }
+        [derive_more, core, pin, segment]
+            if derive_more.ident == "derive_more"
+                && core.ident == "core"
+                && pin.ident == "pin"
+                && segment.ident == "Pin" =>
+        {
+            Some(segment)
+        }
+        _ => None,
+    }
+}
+
+/// Expansion of a macro for generating a [`Borrow`] implementation for a single field of a struct.
+struct Expansion<'a> {
+    /// [`syn::Ident`] of the struct.
+    ident: &'a syn::Ident,
+
+    /// [`syn::Generics`] of the struct.
+    generics: &'a syn::Generics,
+
+    /// [`syn::Field`] of the struct.
+    field: &'a syn::Field,
+
+    /// Index of the [`syn::Field`].
+    field_index: usize,
+
+    /// Whether `Borrow::borrow()` should be forwarded to the field's `Borrow` implementation.
+    is_forwarded: bool,
+}
+
+impl quote::ToTokens for Expansion<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let field_ty = &self.field.ty;
+        let field_ident = self.field.ident.as_ref().map_or_else(
+            || syn::Index::from(self.field_index).to_token_stream(),
+            quote::ToTokens::to_token_stream,
+        );
+        let ty_ident = &self.ident;
+        let (_, ty_gens, _) = self.generics.split_for_impl();
+        let borrow_ty = extra_borrow_type_param(self.generics);
+
+        let trait_ty = if self.is_forwarded {
+            quote! { #borrow_ty }
+        } else {
+            quote! { #field_ty }
+        };
+        let return_ty = if self.is_forwarded {
+            quote! { #trait_ty }
+        } else {
+            borrowed_type_for_return(field_ty)
+        };
+        let trait_path = quote! {
+            derive_more::core::borrow::Borrow<#trait_ty>
+        };
+
+        let generics = if self.is_forwarded {
+            let mut generics = add_extra_generic_type_param(
+                self.generics,
+                quote! { #borrow_ty: ?derive_more::core::marker::Sized },
+            );
+            generics.make_where_clause().predicates.push(parse_quote! {
+                #field_ty: #trait_path
+            });
+            generics
+        } else {
+            self.generics.clone()
+        };
+        let (impl_gens, _, where_clause) = generics.split_for_impl();
+
+        let body = if self.is_forwarded {
+            quote! {
+                <#field_ty as #trait_path>::borrow(&self.#field_ident)
+            }
+        } else {
+            quote! {
+                &self.#field_ident
+            }
+        };
+
+        quote! {
+            #[allow(deprecated)] // omit warnings on deprecated fields/variants
+            #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
+            #[automatically_derived]
+            impl #impl_gens #trait_path for #ty_ident #ty_gens #where_clause {
+                #[inline]
+                fn borrow(&self) -> &#return_ty {
+                    #body
+                }
+            }
+        }
+        .to_tokens(tokens);
+    }
+}
+
+fn extra_borrow_type_param(generics: &syn::Generics) -> syn::Ident {
+    let mut ident = format_ident!("__BorrowT");
+    let mut index = 0;
+
+    while generics.params.iter().any(|param| match param {
+        syn::GenericParam::Type(param) => param.ident == ident,
+        syn::GenericParam::Const(param) => param.ident == ident,
+        syn::GenericParam::Lifetime(_) => false,
+    }) {
+        index += 1;
+        ident = format_ident!("__BorrowT{index}");
+    }
+
+    ident
+}
+
+fn borrowed_type_for_return(ty: &syn::Type) -> TokenStream {
+    match ty {
+        syn::Type::Group(ty) => borrowed_type_for_return(&ty.elem),
+        syn::Type::Paren(ty) => borrowed_type_for_return(&ty.elem),
+        syn::Type::TraitObject(ty) => {
+            let mut ty = ty.clone();
+            if !ty
+                .bounds
+                .iter()
+                .any(|bound| matches!(bound, syn::TypeParamBound::Lifetime(_)))
+            {
+                ty.bounds.push(parse_quote! { 'static });
+            }
+
+            quote! { (#ty) }
+        }
+        _ => quote! { #ty },
+    }
+}
+
+type StructAttribute = attr::Forward;
+
+#[derive(Clone, Copy)]
+enum FieldAttribute {
+    Direct(attr::Empty),
+    Forward(attr::Forward),
+    Skip(attr::Skip),
+}
+
+type UntypedFieldAttribute = Either<attr::Empty, Either<attr::Forward, attr::Skip>>;
+
+impl From<UntypedFieldAttribute> for FieldAttribute {
+    fn from(value: UntypedFieldAttribute) -> Self {
+        match value {
+            UntypedFieldAttribute::Left(empty) => Self::Direct(empty),
+            UntypedFieldAttribute::Right(Either::Left(forward)) => {
+                Self::Forward(forward)
+            }
+            UntypedFieldAttribute::Right(Either::Right(skip)) => Self::Skip(skip),
+        }
+    }
+}
+
+impl From<FieldAttribute> for UntypedFieldAttribute {
+    fn from(value: FieldAttribute) -> Self {
+        match value {
+            FieldAttribute::Direct(empty) => Self::Left(empty),
+            FieldAttribute::Forward(forward) => Self::Right(Either::Left(forward)),
+            FieldAttribute::Skip(skip) => Self::Right(Either::Right(skip)),
+        }
+    }
+}
+
+impl Parse for FieldAttribute {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        mod ident {
+            use syn::custom_keyword;
+
+            custom_keyword!(forward);
+            custom_keyword!(skip);
+            custom_keyword!(ignore);
+        }
+
+        let ahead = input.lookahead1();
+
+        if ahead.peek(ident::forward) {
+            input.parse::<attr::Forward>().map(Self::Forward)
+        } else if ahead.peek(ident::skip) || ahead.peek(ident::ignore) {
+            input.parse::<attr::Skip>().map(Self::Skip)
+        } else {
+            Err(ahead.error())
+        }
+    }
+}
+
+impl attr::ParseMultiple for FieldAttribute {
+    fn parse_attr_with<P: attr::Parser>(
+        attr: &syn::Attribute,
+        parser: &P,
+    ) -> syn::Result<Self> {
+        if matches!(attr.meta, syn::Meta::Path(_)) {
+            Ok(Self::Direct(attr::Empty))
+        } else {
+            attr.parse_args_with(|ps: ParseStream<'_>| parser.parse(ps))
+        }
+    }
+
+    fn merge_attrs(
+        prev: Spanning<Self>,
+        new: Spanning<Self>,
+        name: &syn::Ident,
+    ) -> syn::Result<Spanning<Self>> {
+        UntypedFieldAttribute::merge_attrs(
+            prev.map(Into::into),
+            new.map(Into::into),
+            name,
+        )
+        .map(|attr| attr.map(Self::from))
+    }
+}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -12,6 +12,8 @@ mod utils;
 
 #[cfg(feature = "as_ref")]
 mod r#as;
+#[cfg(feature = "borrow")]
+mod borrow;
 #[cfg(feature = "eq")]
 mod cmp;
 #[cfg(feature = "constructor")]
@@ -145,6 +147,8 @@ create_derive!(
 
 create_derive!("as_ref", r#as::r#mut, AsMut, as_mut_derive, as_mut);
 create_derive!("as_ref", r#as::r#ref, AsRef, as_ref_derive, as_ref);
+
+create_derive!("borrow", borrow, Borrow, borrow_derive, borrow);
 
 create_derive!("constructor", constructor, Constructor, constructor_derive);
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -92,14 +92,20 @@ impl Output for Result<proc_macro2::TokenStream, ParseError> {
 }
 
 macro_rules! create_derive(
-    ($feature:literal, $mod_:ident $(:: $mod_rest:ident)*, $trait_:ident, $fn_name: ident $(,$attribute:ident)* $(,)?) => {
+    (@impl $feature:literal, $doc:literal, $mod_:ident $(:: $mod_rest:ident)*, $trait_:ident, $fn_name: ident $(,$attribute:ident)* $(,)?) => {
         #[cfg(feature = $feature)]
         #[proc_macro_derive($trait_, attributes($($attribute),*))]
-        #[doc = include_str!(concat!("../doc/", $feature, ".md"))]
+        #[doc = include_str!(concat!("../doc/", $doc, ".md"))]
         pub fn $fn_name(input: TokenStream) -> TokenStream {
             let ast = syn::parse(input).unwrap();
             Output::process($mod_$(:: $mod_rest)*::expand(&ast, stringify!($trait_)))
         }
+    };
+    ($feature:literal, doc = $doc:literal, $mod_:ident $(:: $mod_rest:ident)*, $trait_:ident, $fn_name: ident $(,$attribute:ident)* $(,)?) => {
+        create_derive!(@impl $feature, $doc, $mod_$(:: $mod_rest)*, $trait_, $fn_name $(,$attribute)*);
+    };
+    ($feature:literal, $mod_:ident $(:: $mod_rest:ident)*, $trait_:ident, $fn_name: ident $(,$attribute:ident)* $(,)?) => {
+        create_derive!(@impl $feature, $feature, $mod_$(:: $mod_rest)*, $trait_, $fn_name $(,$attribute)*);
     }
 );
 
@@ -145,10 +151,25 @@ create_derive!(
     bitxor_assign,
 );
 
-create_derive!("as_ref", r#as::r#mut, AsMut, as_mut_derive, as_mut);
+create_derive!(
+    "as_ref",
+    doc = "as_mut",
+    r#as::r#mut,
+    AsMut,
+    as_mut_derive,
+    as_mut
+);
 create_derive!("as_ref", r#as::r#ref, AsRef, as_ref_derive, as_ref);
 
 create_derive!("borrow", borrow, Borrow, borrow_derive, borrow);
+create_derive!(
+    "borrow",
+    doc = "borrow_mut",
+    borrow,
+    BorrowMut,
+    borrow_mut_derive,
+    borrow_mut,
+);
 
 create_derive!("constructor", constructor, Constructor, constructor_derive);
 

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -16,6 +16,7 @@ use syn::{
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "debug",
     feature = "display",
     feature = "eq",
@@ -35,6 +36,7 @@ pub(crate) use self::fields_ext::FieldsExt;
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "eq",
     feature = "from_str",
     feature = "hash",
@@ -46,6 +48,7 @@ pub(crate) use self::generics_search::GenericsSearch;
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "debug",
     feature = "display",
     feature = "eq",
@@ -1329,6 +1332,7 @@ pub fn is_type_parameter_used_in_type(
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "debug",
     feature = "display",
     feature = "eq",
@@ -1408,6 +1412,7 @@ mod either {
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "debug",
     feature = "display",
     feature = "eq",
@@ -1511,6 +1516,7 @@ mod spanning {
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "debug",
     feature = "display",
     feature = "eq",
@@ -1535,6 +1541,7 @@ pub(crate) mod attr {
 
     #[cfg(any(
         feature = "as_ref",
+        feature = "borrow",
         feature = "from",
         feature = "into",
         feature = "try_from"
@@ -1544,6 +1551,7 @@ pub(crate) mod attr {
     pub(crate) use self::error::Error;
     #[cfg(any(
         feature = "as_ref",
+        feature = "borrow",
         feature = "from",
         feature = "mul",
         feature = "mul_assign",
@@ -1555,6 +1563,7 @@ pub(crate) mod attr {
         feature = "add",
         feature = "add_assign",
         feature = "as_ref",
+        feature = "borrow",
         feature = "debug",
         feature = "eq",
         feature = "from",
@@ -1704,6 +1713,7 @@ pub(crate) mod attr {
 
     #[cfg(any(
         feature = "as_ref",
+        feature = "borrow",
         feature = "from",
         feature = "into",
         feature = "try_from"
@@ -1767,6 +1777,7 @@ pub(crate) mod attr {
 
     #[cfg(any(
         feature = "as_ref",
+        feature = "borrow",
         feature = "from",
         feature = "mul",
         feature = "mul_assign",
@@ -1897,6 +1908,7 @@ pub(crate) mod attr {
         feature = "add",
         feature = "add_assign",
         feature = "as_ref",
+        feature = "borrow",
         feature = "debug",
         feature = "display",
         feature = "eq",
@@ -2563,6 +2575,7 @@ mod fields_ext {
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "eq",
     feature = "from_str",
     feature = "hash",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! [`TryInto`]: macro@crate::TryInto
 //! [`IntoIterator`]: macro@crate::IntoIterator
 //! [`AsRef`]: macro@crate::AsRef
+//! [`Borrow`]: macro@crate::Borrow
 //!
 //! [`Debug`]: macro@crate::Debug
 //! [`Display`-like]: macro@crate::Display
@@ -184,6 +185,7 @@ pub mod with_trait {
             SubAssign,
         );
         re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
+        re_export_traits!("borrow", borrow_traits, core::borrow, Borrow);
         re_export_traits!("debug", debug_traits, core::fmt, Debug);
         re_export_traits!("deref", deref_traits, core::ops, Deref);
         re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
@@ -258,6 +260,9 @@ pub mod with_trait {
 
         #[cfg(feature = "as_ref")]
         pub use derive_more_impl::{AsMut, AsRef};
+
+        #[cfg(feature = "borrow")]
+        pub use derive_more_impl::Borrow;
 
         #[cfg(feature = "constructor")]
         pub use derive_more_impl::Constructor;
@@ -351,6 +356,10 @@ pub mod with_trait {
     #[cfg(feature = "as_ref")]
     #[doc(hidden)]
     pub use all_traits_and_derives::{AsMut, AsRef};
+
+    #[cfg(feature = "borrow")]
+    #[doc(hidden)]
+    pub use all_traits_and_derives::Borrow;
 
     #[cfg(feature = "constructor")]
     #[doc(hidden)]
@@ -460,6 +469,7 @@ pub mod with_trait {
     feature = "add",
     feature = "add_assign",
     feature = "as_ref",
+    feature = "borrow",
     feature = "constructor",
     feature = "debug",
     feature = "deref",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`IntoIterator`]: macro@crate::IntoIterator
 //! [`AsRef`]: macro@crate::AsRef
 //! [`Borrow`]: macro@crate::Borrow
+//! [`BorrowMut`]: macro@crate::BorrowMut
 //!
 //! [`Debug`]: macro@crate::Debug
 //! [`Display`-like]: macro@crate::Display
@@ -185,7 +186,7 @@ pub mod with_trait {
             SubAssign,
         );
         re_export_traits!("as_ref", as_ref_traits, core::convert, AsMut, AsRef);
-        re_export_traits!("borrow", borrow_traits, core::borrow, Borrow);
+        re_export_traits!("borrow", borrow_traits, core::borrow, Borrow, BorrowMut);
         re_export_traits!("debug", debug_traits, core::fmt, Debug);
         re_export_traits!("deref", deref_traits, core::ops, Deref);
         re_export_traits!("deref_mut", deref_mut_traits, core::ops, DerefMut);
@@ -262,7 +263,7 @@ pub mod with_trait {
         pub use derive_more_impl::{AsMut, AsRef};
 
         #[cfg(feature = "borrow")]
-        pub use derive_more_impl::Borrow;
+        pub use derive_more_impl::{Borrow, BorrowMut};
 
         #[cfg(feature = "constructor")]
         pub use derive_more_impl::Constructor;
@@ -359,7 +360,7 @@ pub mod with_trait {
 
     #[cfg(feature = "borrow")]
     #[doc(hidden)]
-    pub use all_traits_and_derives::Borrow;
+    pub use all_traits_and_derives::{Borrow, BorrowMut};
 
     #[cfg(feature = "constructor")]
     #[doc(hidden)]

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -1,0 +1,319 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
+#![allow(dead_code)] // some code is tested for type checking only
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
+
+#[cfg(feature = "std")]
+use std::borrow::ToOwned;
+
+use core::{borrow::Borrow as _, ptr};
+
+use derive_more::Borrow;
+
+mod single_field {
+    use super::*;
+
+    #[test]
+    fn tuple() {
+        #[derive(Borrow)]
+        struct Tuple(String);
+
+        let item = Tuple("test".to_owned());
+        let borrowed: &String = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.0));
+    }
+
+    #[test]
+    fn named() {
+        #[derive(Borrow)]
+        struct Named {
+            value: String,
+        }
+
+        let item = Named {
+            value: "test".to_owned(),
+        };
+        let borrowed: &String = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.value));
+    }
+
+    #[test]
+    fn generic() {
+        #[derive(Borrow)]
+        struct Generic<T>(T);
+
+        let item = Generic("test".to_owned());
+        let borrowed: &String = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.0));
+    }
+
+    #[test]
+    fn field() {
+        #[derive(Borrow)]
+        struct Field(#[borrow] String);
+
+        let item = Field("test".to_owned());
+        let borrowed: &String = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.0));
+    }
+
+    #[test]
+    fn named_field() {
+        #[derive(Borrow)]
+        struct NamedField {
+            #[borrow]
+            value: String,
+        }
+
+        let item = NamedField {
+            value: "test".to_owned(),
+        };
+        let borrowed: &String = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.value));
+    }
+
+    #[test]
+    fn lifetime() {
+        #[derive(Borrow)]
+        struct Lifetime<'a>(&'a i32);
+
+        let value = 1;
+        let item = Lifetime(&value);
+        let borrowed: &&i32 = item.borrow();
+
+        assert!(ptr::eq::<i32>(*borrowed, item.0));
+    }
+
+    #[test]
+    fn field_lifetime() {
+        #[derive(Borrow)]
+        struct FieldLifetime<'a>(#[borrow] &'a i32);
+
+        let value = 1;
+        let item = FieldLifetime(&value);
+        let borrowed: &&i32 = item.borrow();
+
+        assert!(ptr::eq::<i32>(*borrowed, item.0));
+    }
+
+    #[test]
+    fn named_lifetime() {
+        #[derive(Borrow)]
+        struct NamedLifetime<'a> {
+            value: &'a i32,
+        }
+
+        let value = 1;
+        let item = NamedLifetime { value: &value };
+        let borrowed: &&i32 = item.borrow();
+
+        assert!(ptr::eq::<i32>(*borrowed, item.value));
+    }
+
+    #[test]
+    fn named_field_lifetime() {
+        #[derive(Borrow)]
+        struct NamedFieldLifetime<'a> {
+            #[borrow]
+            value: &'a i32,
+        }
+
+        let value = 1;
+        let item = NamedFieldLifetime { value: &value };
+        let borrowed: &&i32 = item.borrow();
+
+        assert!(ptr::eq::<i32>(*borrowed, item.value));
+    }
+
+    #[test]
+    fn const_param() {
+        #[derive(Borrow)]
+        struct ConstParam<const N: usize>([i32; N]);
+
+        let item = ConstParam([1, 2]);
+        let borrowed: &[i32; 2] = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.0));
+    }
+
+    #[test]
+    fn named_const_param() {
+        #[derive(Borrow)]
+        struct NamedConstParam<const N: usize> {
+            value: [i32; N],
+        }
+
+        let item = NamedConstParam { value: [1, 2] };
+        let borrowed: &[i32; 2] = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.value));
+    }
+
+    #[test]
+    fn field_const_param() {
+        #[derive(Borrow)]
+        struct FieldConstParam<const N: usize>(#[borrow] [i32; N]);
+
+        let item = FieldConstParam([1, 2]);
+        let borrowed: &[i32; 2] = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.0));
+    }
+
+    #[test]
+    fn named_field_const_param() {
+        #[derive(Borrow)]
+        struct NamedFieldConstParam<const N: usize> {
+            #[borrow]
+            value: [i32; N],
+        }
+
+        let item = NamedFieldConstParam { value: [1, 2] };
+        let borrowed: &[i32; 2] = item.borrow();
+
+        assert!(ptr::eq(borrowed, &item.value));
+    }
+
+    #[test]
+    fn forward() {
+        #[derive(Borrow)]
+        #[borrow(forward)]
+        struct Forward(String);
+
+        let item = Forward("test".to_owned());
+        let borrowed: &str = item.borrow();
+
+        assert!(ptr::eq::<str>(borrowed, item.0.borrow()));
+    }
+
+    #[test]
+    fn named_forward() {
+        #[derive(Borrow)]
+        #[borrow(forward)]
+        struct NamedForward {
+            value: String,
+        }
+
+        let item = NamedForward {
+            value: "test".to_owned(),
+        };
+        let borrowed: &str = item.borrow();
+
+        assert!(ptr::eq::<str>(borrowed, item.value.borrow()));
+    }
+
+    #[test]
+    fn field_forward() {
+        #[derive(Borrow)]
+        struct FieldForward(#[borrow(forward)] String);
+
+        let item = FieldForward("test".to_owned());
+        let borrowed: &str = item.borrow();
+
+        assert!(ptr::eq::<str>(borrowed, item.0.borrow()));
+    }
+
+    #[test]
+    fn named_field_forward() {
+        #[derive(Borrow)]
+        struct NamedFieldForward {
+            #[borrow(forward)]
+            value: String,
+        }
+
+        let item = NamedFieldForward {
+            value: "test".to_owned(),
+        };
+        let borrowed: &str = item.borrow();
+
+        assert!(ptr::eq::<str>(borrowed, item.value.borrow()));
+    }
+
+    #[test]
+    fn forward_generic_container() {
+        #[derive(Borrow)]
+        #[borrow(forward)]
+        struct Forward<T>(Vec<T>);
+
+        let item = Forward(vec![1, 2, 3]);
+        let borrowed: &[i32] = item.borrow();
+
+        assert!(ptr::eq::<[i32]>(borrowed, item.0.as_slice()));
+    }
+
+    #[test]
+    fn forward_with_internal_generic_name_collision() {
+        #[derive(Borrow)]
+        #[borrow(forward)]
+        struct Forward<__BorrowT>(Vec<__BorrowT>);
+
+        let item = Forward(vec![1, 2, 3]);
+        let borrowed: &[i32] = item.borrow();
+
+        assert!(ptr::eq::<[i32]>(borrowed, item.0.as_slice()));
+    }
+
+    #[cfg(nightly)]
+    mod never {
+        use super::*;
+
+        #[derive(Borrow)]
+        struct Nothing(!);
+    }
+
+    mod deprecated {
+        use super::*;
+
+        #[derive(Borrow)]
+        #[deprecated(note = "struct")]
+        struct Deprecated(#[deprecated(note = "field")] i32);
+
+        #[derive(Borrow)]
+        #[deprecated(note = "struct")]
+        struct DeprecatedNamed {
+            #[deprecated(note = "field")]
+            field: i32,
+        }
+    }
+
+    mod trait_object {
+        use super::*;
+
+        use core::fmt::Debug;
+
+        #[derive(Borrow)]
+        struct DynDebug(dyn Debug);
+
+        #[derive(Borrow)]
+        struct DynDebugSend(dyn Debug + Send);
+
+        #[derive(Borrow)]
+        struct DynDebugLifetime<'a>(dyn Debug + 'a);
+
+        #[test]
+        fn direct() {
+            fn assert_debug<T: ?Sized + core::borrow::Borrow<dyn Debug>>() {}
+            fn assert_debug_send<T: ?Sized + core::borrow::Borrow<dyn Debug + Send>>() {
+            }
+            fn assert_debug_lifetime<
+                'a,
+                T: ?Sized + core::borrow::Borrow<dyn Debug + 'a>,
+            >() {
+            }
+
+            assert_debug::<DynDebug>();
+            assert_debug_send::<DynDebugSend>();
+            assert_debug_lifetime::<DynDebugLifetime<'static>>();
+        }
+    }
+}

--- a/tests/borrow_mut.rs
+++ b/tests/borrow_mut.rs
@@ -1,0 +1,307 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(never_type))]
+#![allow(dead_code)] // some code is tested for type checking only
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
+
+#[cfg(feature = "std")]
+use std::borrow::ToOwned;
+
+use core::{borrow::BorrowMut as _, ptr};
+
+use derive_more::{Borrow, BorrowMut};
+
+mod single_field {
+    use super::*;
+
+    #[test]
+    fn tuple() {
+        #[derive(Borrow, BorrowMut)]
+        struct Tuple(String);
+
+        let mut item = Tuple("test".to_owned());
+        let field = ptr::addr_of_mut!(item.0);
+        let borrowed: &mut String = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        borrowed.push('!');
+        assert_eq!(item.0, "test!");
+    }
+
+    #[test]
+    fn named() {
+        #[derive(Borrow, BorrowMut)]
+        struct Named {
+            value: String,
+        }
+
+        let mut item = Named {
+            value: "test".to_owned(),
+        };
+        let field = ptr::addr_of_mut!(item.value);
+        let borrowed: &mut String = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        borrowed.push('!');
+        assert_eq!(item.value, "test!");
+    }
+
+    #[test]
+    fn generic() {
+        #[derive(Borrow, BorrowMut)]
+        struct Generic<T>(T);
+
+        let mut item = Generic("test".to_owned());
+        let field = ptr::addr_of_mut!(item.0);
+        let borrowed: &mut String = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        borrowed.push('!');
+        assert_eq!(item.0, "test!");
+    }
+
+    #[test]
+    fn field() {
+        #[derive(Borrow, BorrowMut)]
+        struct Field(#[borrow_mut] String);
+
+        let mut item = Field("test".to_owned());
+        let field = ptr::addr_of_mut!(item.0);
+        let borrowed: &mut String = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        borrowed.push('!');
+        assert_eq!(item.0, "test!");
+    }
+
+    #[test]
+    fn named_field() {
+        #[derive(Borrow, BorrowMut)]
+        struct NamedField {
+            #[borrow_mut]
+            value: String,
+        }
+
+        let mut item = NamedField {
+            value: "test".to_owned(),
+        };
+        let field = ptr::addr_of_mut!(item.value);
+        let borrowed: &mut String = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        borrowed.push('!');
+        assert_eq!(item.value, "test!");
+    }
+
+    #[test]
+    fn lifetime() {
+        #[derive(Borrow, BorrowMut)]
+        struct Lifetime<'a>(&'a mut i32);
+
+        let mut value = 1;
+        let mut item = Lifetime(&mut value);
+        let field = ptr::addr_of_mut!(item.0);
+        let borrowed: &mut &mut i32 = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        **borrowed = 2;
+        assert_eq!(value, 2);
+    }
+
+    #[test]
+    fn const_param() {
+        #[derive(Borrow, BorrowMut)]
+        struct ConstParam<const N: usize>([i32; N]);
+
+        let mut item = ConstParam([1, 2]);
+        let field = ptr::addr_of_mut!(item.0);
+        let borrowed: &mut [i32; 2] = item.borrow_mut();
+
+        assert!(ptr::eq(borrowed, field));
+        borrowed[0] = 3;
+        assert_eq!(item.0, [3, 2]);
+    }
+
+    #[test]
+    fn forward() {
+        #[derive(Borrow, BorrowMut)]
+        #[borrow(forward)]
+        #[borrow_mut(forward)]
+        struct Forward(String);
+
+        let mut item = Forward("test".to_owned());
+        let field = item.0.as_mut_str() as *mut str;
+        let borrowed: &mut str = item.borrow_mut();
+
+        assert!(ptr::eq::<str>(borrowed, field));
+        borrowed.make_ascii_uppercase();
+        assert_eq!(item.0, "TEST");
+    }
+
+    #[test]
+    fn named_forward() {
+        #[derive(Borrow, BorrowMut)]
+        #[borrow(forward)]
+        #[borrow_mut(forward)]
+        struct NamedForward {
+            value: String,
+        }
+
+        let mut item = NamedForward {
+            value: "test".to_owned(),
+        };
+        let field = item.value.as_mut_str() as *mut str;
+        let borrowed: &mut str = item.borrow_mut();
+
+        assert!(ptr::eq::<str>(borrowed, field));
+        borrowed.make_ascii_uppercase();
+        assert_eq!(item.value, "TEST");
+    }
+
+    #[test]
+    fn field_forward() {
+        #[derive(Borrow, BorrowMut)]
+        struct FieldForward(
+            #[borrow(forward)]
+            #[borrow_mut(forward)]
+            String,
+        );
+
+        let mut item = FieldForward("test".to_owned());
+        let field = item.0.as_mut_str() as *mut str;
+        let borrowed: &mut str = item.borrow_mut();
+
+        assert!(ptr::eq::<str>(borrowed, field));
+        borrowed.make_ascii_uppercase();
+        assert_eq!(item.0, "TEST");
+    }
+
+    #[test]
+    fn named_field_forward() {
+        #[derive(Borrow, BorrowMut)]
+        struct NamedFieldForward {
+            #[borrow(forward)]
+            #[borrow_mut(forward)]
+            value: String,
+        }
+
+        let mut item = NamedFieldForward {
+            value: "test".to_owned(),
+        };
+        let field = item.value.as_mut_str() as *mut str;
+        let borrowed: &mut str = item.borrow_mut();
+
+        assert!(ptr::eq::<str>(borrowed, field));
+        borrowed.make_ascii_uppercase();
+        assert_eq!(item.value, "TEST");
+    }
+
+    #[test]
+    fn forward_generic_container() {
+        #[derive(Borrow, BorrowMut)]
+        #[borrow(forward)]
+        #[borrow_mut(forward)]
+        struct Forward<T>(Vec<T>);
+
+        let mut item = Forward(vec![1, 2, 3]);
+        let field = item.0.as_mut_slice() as *mut [i32];
+        let borrowed: &mut [i32] = item.borrow_mut();
+
+        assert!(ptr::eq::<[i32]>(borrowed, field));
+        borrowed[0] = 4;
+        assert_eq!(item.0.as_slice(), &[4, 2, 3]);
+    }
+
+    #[test]
+    fn forward_with_internal_generic_name_collision() {
+        #[derive(Borrow, BorrowMut)]
+        #[borrow(forward)]
+        #[borrow_mut(forward)]
+        struct Forward<__BorrowMutT>(Vec<__BorrowMutT>);
+
+        let mut item = Forward(vec![1, 2, 3]);
+        let field = item.0.as_mut_slice() as *mut [i32];
+        let borrowed: &mut [i32] = item.borrow_mut();
+
+        assert!(ptr::eq::<[i32]>(borrowed, field));
+        borrowed[0] = 4;
+        assert_eq!(item.0.as_slice(), &[4, 2, 3]);
+    }
+
+    #[cfg(nightly)]
+    mod never {
+        use super::*;
+
+        #[derive(Borrow, BorrowMut)]
+        struct Nothing(!);
+    }
+
+    mod deprecated {
+        use super::*;
+
+        #[derive(Borrow, BorrowMut)]
+        #[deprecated(note = "struct")]
+        struct Deprecated(#[deprecated(note = "field")] i32);
+
+        #[derive(Borrow, BorrowMut)]
+        #[deprecated(note = "struct")]
+        struct DeprecatedNamed {
+            #[deprecated(note = "field")]
+            field: i32,
+        }
+    }
+
+    mod trait_object {
+        use super::*;
+
+        use core::fmt::Debug;
+
+        #[derive(Borrow, BorrowMut)]
+        struct DynDebug(dyn Debug);
+
+        #[derive(Borrow, BorrowMut)]
+        struct DynDebugSend(dyn Debug + Send);
+
+        #[derive(Borrow, BorrowMut)]
+        struct DynDebugLifetime<'a>(dyn Debug + 'a);
+
+        #[test]
+        fn direct() {
+            fn assert_debug<T: ?Sized + core::borrow::BorrowMut<dyn Debug>>() {}
+            fn assert_debug_send<
+                T: ?Sized + core::borrow::BorrowMut<dyn Debug + Send>,
+            >() {
+            }
+            fn assert_debug_lifetime<
+                'a,
+                T: ?Sized + core::borrow::BorrowMut<dyn Debug + 'a>,
+            >() {
+            }
+
+            assert_debug::<DynDebug>();
+            assert_debug_send::<DynDebugSend>();
+            assert_debug_lifetime::<DynDebugLifetime<'static>>();
+        }
+    }
+}
+
+mod with_trait {
+    use super::*;
+    use derive_more::with_trait::{Borrow, BorrowMut};
+
+    #[derive(Borrow, BorrowMut)]
+    struct Tuple(String);
+
+    #[test]
+    fn reexports_trait_and_derive() {
+        let mut item = Tuple("test".to_owned());
+        let borrowed: &mut String = BorrowMut::borrow_mut(&mut item);
+
+        borrowed.push('!');
+        assert_eq!(item.0, "test!");
+    }
+}

--- a/tests/compile_fail/borrow/associated_type.rs
+++ b/tests/compile_fail/borrow/associated_type.rs
@@ -1,0 +1,8 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+struct Foo<T: Trait>(T::Assoc);
+
+fn main() {}

--- a/tests/compile_fail/borrow/associated_type.stderr
+++ b/tests/compile_fail/borrow/associated_type.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/associated_type.rs:6:22
+  |
+6 | struct Foo<T: Trait>(T::Assoc);
+  |                      ^

--- a/tests/compile_fail/borrow/const_projection.rs
+++ b/tests/compile_fail/borrow/const_projection.rs
@@ -1,0 +1,10 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+struct Foo<const N: usize>(<[i32; N] as Trait>::Assoc)
+where
+    [i32; N]: Trait;
+
+fn main() {}

--- a/tests/compile_fail/borrow/const_projection.stderr
+++ b/tests/compile_fail/borrow/const_projection.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/const_projection.rs:6:28
+  |
+6 | struct Foo<const N: usize>(<[i32; N] as Trait>::Assoc)
+  |                            ^

--- a/tests/compile_fail/borrow/enum.rs
+++ b/tests/compile_fail/borrow/enum.rs
@@ -1,0 +1,6 @@
+#[derive(derive_more::Borrow)]
+enum Foo {
+    Bar(String),
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/enum.stderr
+++ b/tests/compile_fail/borrow/enum.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for enums
+ --> tests/compile_fail/borrow/enum.rs:2:1
+  |
+2 | enum Foo {
+  | ^^^^

--- a/tests/compile_fail/borrow/forward_box_associated_type.rs
+++ b/tests/compile_fail/borrow/forward_box_associated_type.rs
@@ -1,0 +1,9 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo<T: Trait>(Box<T::Assoc>);
+
+fn main() {}

--- a/tests/compile_fail/borrow/forward_box_associated_type.stderr
+++ b/tests/compile_fail/borrow/forward_box_associated_type.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(forward)]` cannot be used on a generic parameter field, an associated type projection involving generic parameters, or a forwarding pointer to one because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/forward_box_associated_type.rs:7:22
+  |
+7 | struct Foo<T: Trait>(Box<T::Assoc>);
+  |                      ^^^

--- a/tests/compile_fail/borrow/forward_box_generic.rs
+++ b/tests/compile_fail/borrow/forward_box_generic.rs
@@ -1,0 +1,5 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo<T>(Box<T>);
+
+fn main() {}

--- a/tests/compile_fail/borrow/forward_box_generic.stderr
+++ b/tests/compile_fail/borrow/forward_box_generic.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(forward)]` cannot be used on a generic parameter field, an associated type projection involving generic parameters, or a forwarding pointer to one because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/forward_box_generic.rs:3:15
+  |
+3 | struct Foo<T>(Box<T>);
+  |               ^^^

--- a/tests/compile_fail/borrow/forward_generic.rs
+++ b/tests/compile_fail/borrow/forward_generic.rs
@@ -1,0 +1,5 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo<T>(T);
+
+fn main() {}

--- a/tests/compile_fail/borrow/forward_generic.stderr
+++ b/tests/compile_fail/borrow/forward_generic.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(forward)]` cannot be used on a generic parameter field, an associated type projection involving generic parameters, or a forwarding pointer to one because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/forward_generic.rs:3:15
+  |
+3 | struct Foo<T>(T);
+  |               ^

--- a/tests/compile_fail/borrow/forward_ref_associated_type.rs
+++ b/tests/compile_fail/borrow/forward_ref_associated_type.rs
@@ -1,0 +1,9 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo<'a, T: Trait>(&'a T::Assoc);
+
+fn main() {}

--- a/tests/compile_fail/borrow/forward_ref_associated_type.stderr
+++ b/tests/compile_fail/borrow/forward_ref_associated_type.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(forward)]` cannot be used on a generic parameter field, an associated type projection involving generic parameters, or a forwarding pointer to one because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/forward_ref_associated_type.rs:7:26
+  |
+7 | struct Foo<'a, T: Trait>(&'a T::Assoc);
+  |                          ^

--- a/tests/compile_fail/borrow/forward_ref_generic.rs
+++ b/tests/compile_fail/borrow/forward_ref_generic.rs
@@ -1,0 +1,5 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo<'a, T>(&'a T);
+
+fn main() {}

--- a/tests/compile_fail/borrow/forward_ref_generic.stderr
+++ b/tests/compile_fail/borrow/forward_ref_generic.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(forward)]` cannot be used on a generic parameter field, an associated type projection involving generic parameters, or a forwarding pointer to one because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/forward_ref_generic.rs:3:19
+  |
+3 | struct Foo<'a, T>(&'a T);
+  |                   ^

--- a/tests/compile_fail/borrow/generic_projection.rs
+++ b/tests/compile_fail/borrow/generic_projection.rs
@@ -1,0 +1,10 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+struct Foo<T>(<Vec<T> as Trait>::Assoc)
+where
+    Vec<T>: Trait;
+
+fn main() {}

--- a/tests/compile_fail/borrow/generic_projection.stderr
+++ b/tests/compile_fail/borrow/generic_projection.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/generic_projection.rs:6:15
+  |
+6 | struct Foo<T>(<Vec<T> as Trait>::Assoc)
+  |               ^

--- a/tests/compile_fail/borrow/lifetime_projection.rs
+++ b/tests/compile_fail/borrow/lifetime_projection.rs
@@ -1,0 +1,10 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+struct Foo<'a>(<&'a i32 as Trait>::Assoc)
+where
+    &'a i32: Trait;
+
+fn main() {}

--- a/tests/compile_fail/borrow/lifetime_projection.stderr
+++ b/tests/compile_fail/borrow/lifetime_projection.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/lifetime_projection.rs:6:16
+  |
+6 | struct Foo<'a>(<&'a i32 as Trait>::Assoc)
+  |                ^

--- a/tests/compile_fail/borrow/multi_field.rs
+++ b/tests/compile_fail/borrow/multi_field.rs
@@ -1,0 +1,7 @@
+#[derive(derive_more::Borrow)]
+struct Foo {
+    bar: i32,
+    baz: f32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/multi_field.stderr
+++ b/tests/compile_fail/borrow/multi_field.stderr
@@ -1,0 +1,9 @@
+error: `Borrow` can only be derived for structs with exactly one field
+ --> tests/compile_fail/borrow/multi_field.rs:2:12
+  |
+2 |   struct Foo {
+  |  ____________^
+3 | |     bar: i32,
+4 | |     baz: f32,
+5 | | }
+  | |_^

--- a/tests/compile_fail/borrow/multiple_field_attrs.rs
+++ b/tests/compile_fail/borrow/multiple_field_attrs.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::Borrow)]
+struct Foo(
+    #[borrow]
+    #[borrow(forward)]
+    String,
+);
+
+fn main() {}

--- a/tests/compile_fail/borrow/multiple_field_attrs.stderr
+++ b/tests/compile_fail/borrow/multiple_field_attrs.stderr
@@ -1,0 +1,5 @@
+error: only single kind of `#[borrow(...)]` attribute is allowed here
+ --> tests/compile_fail/borrow/multiple_field_attrs.rs:4:5
+  |
+4 |     #[borrow(forward)]
+  |     ^

--- a/tests/compile_fail/borrow/multiple_struct_attrs.rs
+++ b/tests/compile_fail/borrow/multiple_struct_attrs.rs
@@ -1,0 +1,6 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+#[borrow(forward)]
+struct Foo(String);
+
+fn main() {}

--- a/tests/compile_fail/borrow/multiple_struct_attrs.stderr
+++ b/tests/compile_fail/borrow/multiple_struct_attrs.stderr
@@ -1,0 +1,5 @@
+error: only single `#[borrow(...)]` attribute is allowed here
+ --> tests/compile_fail/borrow/multiple_struct_attrs.rs:3:1
+  |
+3 | #[borrow(forward)]
+  | ^

--- a/tests/compile_fail/borrow/non_borrowable_forward.rs
+++ b/tests/compile_fail/borrow/non_borrowable_forward.rs
@@ -1,0 +1,10 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo(i32);
+
+fn main() {
+    use core::borrow::Borrow as _;
+
+    let item = Foo(1);
+    let _: &str = item.borrow();
+}

--- a/tests/compile_fail/borrow/non_borrowable_forward.stderr
+++ b/tests/compile_fail/borrow/non_borrowable_forward.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `i32: Borrow<str>` is not satisfied
+ --> tests/compile_fail/borrow/non_borrowable_forward.rs:9:24
+  |
+9 |     let _: &str = item.borrow();
+  |                        ^^^^^^ the trait `Borrow<str>` is not implemented for `i32`
+  |
+help: the trait `Borrow<str>` is not implemented for `Foo`
+      but trait `Borrow<i32>` is implemented for it
+ --> tests/compile_fail/borrow/non_borrowable_forward.rs:1:10
+  |
+1 | #[derive(derive_more::Borrow)]
+  |          ^^^^^^^^^^^^^^^^^^^
+  = help: for that trait implementation, expected `i32`, found `str`
+note: required for `Foo` to implement `Borrow<str>`
+ --> tests/compile_fail/borrow/non_borrowable_forward.rs:3:8
+  |
+1 | #[derive(derive_more::Borrow)]
+  |          ------------------- type parameter would need to implement `Borrow<str>`
+2 | #[borrow(forward)]
+3 | struct Foo(i32);
+  |        ^^^
+  = help: consider manually implementing `Borrow<str>` to avoid undesired bounds
+  = note: this error originates in the derive macro `derive_more::Borrow` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail/borrow/parenthesized_associated_type.rs
+++ b/tests/compile_fail/borrow/parenthesized_associated_type.rs
@@ -1,0 +1,10 @@
+#![allow(unused_parens)]
+
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+struct Foo<T: Trait>((T::Assoc));
+
+fn main() {}

--- a/tests/compile_fail/borrow/parenthesized_associated_type.stderr
+++ b/tests/compile_fail/borrow/parenthesized_associated_type.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/parenthesized_associated_type.rs:8:22
+  |
+8 | struct Foo<T: Trait>((T::Assoc));
+  |                      ^^^^^^^^^^

--- a/tests/compile_fail/borrow/qualified_associated_type.rs
+++ b/tests/compile_fail/borrow/qualified_associated_type.rs
@@ -1,0 +1,8 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::Borrow)]
+struct Foo<T: Trait>(<T as Trait>::Assoc);
+
+fn main() {}

--- a/tests/compile_fail/borrow/qualified_associated_type.stderr
+++ b/tests/compile_fail/borrow/qualified_associated_type.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `Borrow` implementation
+ --> tests/compile_fail/borrow/qualified_associated_type.rs:6:22
+  |
+6 | struct Foo<T: Trait>(<T as Trait>::Assoc);
+  |                      ^

--- a/tests/compile_fail/borrow/skip.rs
+++ b/tests/compile_fail/borrow/skip.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::Borrow)]
+struct Foo(#[borrow(skip)] i32);
+
+fn main() {}

--- a/tests/compile_fail/borrow/skip.stderr
+++ b/tests/compile_fail/borrow/skip.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(skip)]` cannot be used when deriving `Borrow` because exactly one field must be borrowed
+ --> tests/compile_fail/borrow/skip.rs:2:12
+  |
+2 | struct Foo(#[borrow(skip)] i32);
+  |            ^

--- a/tests/compile_fail/borrow/skip_and_others.rs
+++ b/tests/compile_fail/borrow/skip_and_others.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::Borrow)]
+struct Foo(
+    #[borrow]
+    #[borrow(skip)]
+    i32,
+);
+
+fn main() {}

--- a/tests/compile_fail/borrow/skip_and_others.stderr
+++ b/tests/compile_fail/borrow/skip_and_others.stderr
@@ -1,0 +1,5 @@
+error: only single kind of `#[borrow(...)]` attribute is allowed here
+ --> tests/compile_fail/borrow/skip_and_others.rs:4:5
+  |
+4 |     #[borrow(skip)]
+  |     ^

--- a/tests/compile_fail/borrow/struct_and_field.rs
+++ b/tests/compile_fail/borrow/struct_and_field.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo {
+    #[borrow]
+    bar: i32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/struct_and_field.stderr
+++ b/tests/compile_fail/borrow/struct_and_field.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow(...)]` cannot be placed on both struct and its field
+ --> tests/compile_fail/borrow/struct_and_field.rs:4:5
+  |
+4 |     #[borrow]
+  |     ^

--- a/tests/compile_fail/borrow/struct_attr_empty.rs
+++ b/tests/compile_fail/borrow/struct_attr_empty.rs
@@ -1,0 +1,5 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo;
+
+fn main() {}

--- a/tests/compile_fail/borrow/struct_attr_empty.stderr
+++ b/tests/compile_fail/borrow/struct_attr_empty.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` can only be derived for structs with exactly one field
+ --> tests/compile_fail/borrow/struct_attr_empty.rs:3:1
+  |
+3 | struct Foo;
+  | ^^^^^^

--- a/tests/compile_fail/borrow/struct_attr_multiple_fields.rs
+++ b/tests/compile_fail/borrow/struct_attr_multiple_fields.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::Borrow)]
+#[borrow(forward)]
+struct Foo {
+    bar: i32,
+    baz: f32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/struct_attr_multiple_fields.stderr
+++ b/tests/compile_fail/borrow/struct_attr_multiple_fields.stderr
@@ -1,0 +1,9 @@
+error: `Borrow` can only be derived for structs with exactly one field
+ --> tests/compile_fail/borrow/struct_attr_multiple_fields.rs:3:12
+  |
+3 |   struct Foo {
+  |  ____________^
+4 | |     bar: i32,
+5 | |     baz: f32,
+6 | | }
+  | |_^

--- a/tests/compile_fail/borrow/union.rs
+++ b/tests/compile_fail/borrow/union.rs
@@ -1,0 +1,7 @@
+#[derive(derive_more::Borrow)]
+union Foo {
+    bar: i32,
+    baz: f32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/union.stderr
+++ b/tests/compile_fail/borrow/union.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` cannot be derived for unions
+ --> tests/compile_fail/borrow/union.rs:2:1
+  |
+2 | union Foo {
+  | ^^^^^

--- a/tests/compile_fail/borrow/unit.rs
+++ b/tests/compile_fail/borrow/unit.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::Borrow)]
+struct Foo;
+
+fn main() {}

--- a/tests/compile_fail/borrow/unit.stderr
+++ b/tests/compile_fail/borrow/unit.stderr
@@ -1,0 +1,5 @@
+error: `Borrow` can only be derived for structs with exactly one field
+ --> tests/compile_fail/borrow/unit.rs:2:1
+  |
+2 | struct Foo;
+  | ^^^^^^

--- a/tests/compile_fail/borrow/unknown_field_attr_arg.rs
+++ b/tests/compile_fail/borrow/unknown_field_attr_arg.rs
@@ -1,0 +1,7 @@
+#[derive(derive_more::Borrow)]
+struct Foo {
+    #[borrow(baz)]
+    bar: i32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/unknown_field_attr_arg.stderr
+++ b/tests/compile_fail/borrow/unknown_field_attr_arg.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `forward`, `skip`, `ignore`
+ --> tests/compile_fail/borrow/unknown_field_attr_arg.rs:3:14
+  |
+3 |     #[borrow(baz)]
+  |              ^^^

--- a/tests/compile_fail/borrow/unknown_struct_attr_arg.rs
+++ b/tests/compile_fail/borrow/unknown_struct_attr_arg.rs
@@ -1,0 +1,7 @@
+#[derive(derive_more::Borrow)]
+#[borrow(baz)]
+struct Foo {
+    bar: i32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow/unknown_struct_attr_arg.stderr
+++ b/tests/compile_fail/borrow/unknown_struct_attr_arg.stderr
@@ -1,0 +1,5 @@
+error: only `forward` allowed here
+ --> tests/compile_fail/borrow/unknown_struct_attr_arg.rs:2:10
+  |
+2 | #[borrow(baz)]
+  |          ^^^

--- a/tests/compile_fail/borrow_mut/associated_type.rs
+++ b/tests/compile_fail/borrow_mut/associated_type.rs
@@ -1,0 +1,8 @@
+trait Trait {
+    type Assoc;
+}
+
+#[derive(derive_more::BorrowMut)]
+struct Foo<T: Trait>(T::Assoc);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/associated_type.stderr
+++ b/tests/compile_fail/borrow_mut/associated_type.stderr
@@ -1,0 +1,5 @@
+error: `BorrowMut` cannot be derived for an associated type projection involving generic parameters because the impl can overlap with `core`'s blanket `BorrowMut` implementation
+ --> tests/compile_fail/borrow_mut/associated_type.rs:6:22
+  |
+6 | struct Foo<T: Trait>(T::Assoc);
+  |                      ^

--- a/tests/compile_fail/borrow_mut/enum.rs
+++ b/tests/compile_fail/borrow_mut/enum.rs
@@ -1,0 +1,6 @@
+#[derive(derive_more::BorrowMut)]
+enum Foo {
+    Bar(i32),
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/enum.stderr
+++ b/tests/compile_fail/borrow_mut/enum.stderr
@@ -1,0 +1,5 @@
+error: `BorrowMut` cannot be derived for enums
+ --> tests/compile_fail/borrow_mut/enum.rs:2:1
+  |
+2 | enum Foo {
+  | ^^^^

--- a/tests/compile_fail/borrow_mut/forward_generic.rs
+++ b/tests/compile_fail/borrow_mut/forward_generic.rs
@@ -1,0 +1,5 @@
+#[derive(derive_more::BorrowMut)]
+#[borrow_mut(forward)]
+struct Foo<T>(T);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/forward_generic.stderr
+++ b/tests/compile_fail/borrow_mut/forward_generic.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow_mut(forward)]` cannot be used on a generic parameter field, an associated type projection involving generic parameters, or a forwarding pointer to one because the impl can overlap with `core`'s blanket `BorrowMut` implementation
+ --> tests/compile_fail/borrow_mut/forward_generic.rs:3:15
+  |
+3 | struct Foo<T>(T);
+  |               ^

--- a/tests/compile_fail/borrow_mut/multi_field.rs
+++ b/tests/compile_fail/borrow_mut/multi_field.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::BorrowMut)]
+struct Foo(i32, i32);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/multi_field.stderr
+++ b/tests/compile_fail/borrow_mut/multi_field.stderr
@@ -1,0 +1,5 @@
+error: `BorrowMut` can only be derived for structs with exactly one field
+ --> tests/compile_fail/borrow_mut/multi_field.rs:2:11
+  |
+2 | struct Foo(i32, i32);
+  |           ^^^^^^^^^^

--- a/tests/compile_fail/borrow_mut/non_borrowable_forward.rs
+++ b/tests/compile_fail/borrow_mut/non_borrowable_forward.rs
@@ -1,0 +1,11 @@
+#[derive(derive_more::Borrow, derive_more::BorrowMut)]
+#[borrow(forward)]
+#[borrow_mut(forward)]
+struct Foo(i32);
+
+fn main() {
+    use core::borrow::BorrowMut as _;
+
+    let mut item = Foo(1);
+    let _: &mut str = item.borrow_mut();
+}

--- a/tests/compile_fail/borrow_mut/non_borrowable_forward.stderr
+++ b/tests/compile_fail/borrow_mut/non_borrowable_forward.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `i32: BorrowMut<str>` is not satisfied
+  --> tests/compile_fail/borrow_mut/non_borrowable_forward.rs:10:28
+   |
+10 |     let _: &mut str = item.borrow_mut();
+   |                            ^^^^^^^^^^ the trait `BorrowMut<str>` is not implemented for `i32`
+   |
+help: the trait `BorrowMut<str>` is not implemented for `Foo`
+      but trait `BorrowMut<i32>` is implemented for it
+  --> tests/compile_fail/borrow_mut/non_borrowable_forward.rs:1:31
+   |
+ 1 | #[derive(derive_more::Borrow, derive_more::BorrowMut)]
+   |                               ^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `i32`, found `str`
+note: required for `Foo` to implement `BorrowMut<str>`
+  --> tests/compile_fail/borrow_mut/non_borrowable_forward.rs:4:8
+   |
+ 1 | #[derive(derive_more::Borrow, derive_more::BorrowMut)]
+   |                               ---------------------- type parameter would need to implement `BorrowMut<str>`
+...
+ 4 | struct Foo(i32);
+   |        ^^^
+   = help: consider manually implementing `BorrowMut<str>` to avoid undesired bounds
+   = note: this error originates in the derive macro `derive_more::BorrowMut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile_fail/borrow_mut/skip.rs
+++ b/tests/compile_fail/borrow_mut/skip.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::BorrowMut)]
+struct Foo(#[borrow_mut(skip)] i32);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/skip.stderr
+++ b/tests/compile_fail/borrow_mut/skip.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow_mut(skip)]` cannot be used when deriving `BorrowMut` because exactly one field must be borrowed
+ --> tests/compile_fail/borrow_mut/skip.rs:2:12
+  |
+2 | struct Foo(#[borrow_mut(skip)] i32);
+  |            ^

--- a/tests/compile_fail/borrow_mut/struct_and_field.rs
+++ b/tests/compile_fail/borrow_mut/struct_and_field.rs
@@ -1,0 +1,8 @@
+#[derive(derive_more::BorrowMut)]
+#[borrow_mut(forward)]
+struct Foo(
+    #[borrow_mut]
+    i32,
+);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/struct_and_field.stderr
+++ b/tests/compile_fail/borrow_mut/struct_and_field.stderr
@@ -1,0 +1,5 @@
+error: `#[borrow_mut(...)]` cannot be placed on both struct and its field
+ --> tests/compile_fail/borrow_mut/struct_and_field.rs:4:5
+  |
+4 |     #[borrow_mut]
+  |     ^

--- a/tests/compile_fail/borrow_mut/union.rs
+++ b/tests/compile_fail/borrow_mut/union.rs
@@ -1,0 +1,6 @@
+#[derive(derive_more::BorrowMut)]
+union Foo {
+    bar: i32,
+}
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/union.stderr
+++ b/tests/compile_fail/borrow_mut/union.stderr
@@ -1,0 +1,5 @@
+error: `BorrowMut` cannot be derived for unions
+ --> tests/compile_fail/borrow_mut/union.rs:2:1
+  |
+2 | union Foo {
+  | ^^^^^

--- a/tests/compile_fail/borrow_mut/unit.rs
+++ b/tests/compile_fail/borrow_mut/unit.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::BorrowMut)]
+struct Foo;
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/unit.stderr
+++ b/tests/compile_fail/borrow_mut/unit.stderr
@@ -1,0 +1,5 @@
+error: `BorrowMut` can only be derived for structs with exactly one field
+ --> tests/compile_fail/borrow_mut/unit.rs:2:1
+  |
+2 | struct Foo;
+  | ^^^^^^

--- a/tests/compile_fail/borrow_mut/unknown_field_attr_arg.rs
+++ b/tests/compile_fail/borrow_mut/unknown_field_attr_arg.rs
@@ -1,0 +1,4 @@
+#[derive(derive_more::BorrowMut)]
+struct Foo(#[borrow_mut(baz)] i32);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/unknown_field_attr_arg.stderr
+++ b/tests/compile_fail/borrow_mut/unknown_field_attr_arg.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `forward`, `skip`, `ignore`
+ --> tests/compile_fail/borrow_mut/unknown_field_attr_arg.rs:2:25
+  |
+2 | struct Foo(#[borrow_mut(baz)] i32);
+  |                         ^^^

--- a/tests/compile_fail/borrow_mut/unknown_struct_attr_arg.rs
+++ b/tests/compile_fail/borrow_mut/unknown_struct_attr_arg.rs
@@ -1,0 +1,5 @@
+#[derive(derive_more::BorrowMut)]
+#[borrow_mut(baz)]
+struct Foo(i32);
+
+fn main() {}

--- a/tests/compile_fail/borrow_mut/unknown_struct_attr_arg.stderr
+++ b/tests/compile_fail/borrow_mut/unknown_struct_attr_arg.stderr
@@ -1,0 +1,5 @@
+error: only `forward` allowed here
+ --> tests/compile_fail/borrow_mut/unknown_struct_attr_arg.rs:2:14
+  |
+2 | #[borrow_mut(baz)]
+  |              ^^^

--- a/tests/compile_fail/eq/non_eq_field.stderr
+++ b/tests/compile_fail/eq/non_eq_field.stderr
@@ -14,5 +14,4 @@ error[E0277]: the trait bound `f32: Eq` is not satisfied
             u128
             u16
           and $N others
-  = help: see issue #48214
   = note: this error originates in the derive macro `derive_more::Eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/eq.rs
+++ b/tests/eq.rs
@@ -8,7 +8,7 @@ mod structs {
     mod structural {
         #[cfg(not(feature = "std"))]
         use ::alloc::{boxed::Box, vec::Vec};
-        use derive_more::{Eq, __private::AssertParamIsEq};
+        use derive_more::{__private::AssertParamIsEq, Eq};
 
         #[test]
         fn unit() {
@@ -73,7 +73,7 @@ mod structs {
         }
 
         mod skip {
-            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
+            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
 
             struct NoEq;
 
@@ -165,7 +165,7 @@ mod structs {
         mod generic {
             #[cfg(not(feature = "std"))]
             use ::alloc::{boxed::Box, vec::Vec};
-            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
+            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
 
             trait Some {
                 type Assoc;
@@ -245,7 +245,7 @@ mod structs {
             }
 
             mod skip {
-                use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
+                use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
 
                 struct NoEq;
 
@@ -327,7 +327,7 @@ mod enums {
     mod structural {
         #[cfg(not(feature = "std"))]
         use ::alloc::{boxed::Box, vec::Vec};
-        use derive_more::{Eq, __private::AssertParamIsEq};
+        use derive_more::{__private::AssertParamIsEq, Eq};
 
         #[test]
         fn empty() {
@@ -434,7 +434,7 @@ mod enums {
         }
 
         mod skip {
-            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
+            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
 
             struct NoEq;
 
@@ -550,7 +550,7 @@ mod enums {
         mod generic {
             #[cfg(not(feature = "std"))]
             use ::alloc::{boxed::Box, vec::Vec};
-            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
+            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
 
             trait Some {
                 type Assoc;
@@ -654,7 +654,7 @@ mod enums {
             }
 
             mod skip {
-                use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
+                use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
 
                 struct NoEq;
 

--- a/tests/eq.rs
+++ b/tests/eq.rs
@@ -8,7 +8,7 @@ mod structs {
     mod structural {
         #[cfg(not(feature = "std"))]
         use ::alloc::{boxed::Box, vec::Vec};
-        use derive_more::{__private::AssertParamIsEq, Eq};
+        use derive_more::{Eq, __private::AssertParamIsEq};
 
         #[test]
         fn unit() {
@@ -73,7 +73,7 @@ mod structs {
         }
 
         mod skip {
-            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
 
             struct NoEq;
 
@@ -165,7 +165,7 @@ mod structs {
         mod generic {
             #[cfg(not(feature = "std"))]
             use ::alloc::{boxed::Box, vec::Vec};
-            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
 
             trait Some {
                 type Assoc;
@@ -245,7 +245,7 @@ mod structs {
             }
 
             mod skip {
-                use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+                use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
 
                 struct NoEq;
 
@@ -327,7 +327,7 @@ mod enums {
     mod structural {
         #[cfg(not(feature = "std"))]
         use ::alloc::{boxed::Box, vec::Vec};
-        use derive_more::{__private::AssertParamIsEq, Eq};
+        use derive_more::{Eq, __private::AssertParamIsEq};
 
         #[test]
         fn empty() {
@@ -434,7 +434,7 @@ mod enums {
         }
 
         mod skip {
-            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
 
             struct NoEq;
 
@@ -550,7 +550,7 @@ mod enums {
         mod generic {
             #[cfg(not(feature = "std"))]
             use ::alloc::{boxed::Box, vec::Vec};
-            use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+            use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
 
             trait Some {
                 type Assoc;
@@ -654,7 +654,7 @@ mod enums {
             }
 
             mod skip {
-                use derive_more::{__private::AssertParamIsEq, Eq, PartialEq};
+                use derive_more::{Eq, PartialEq, __private::AssertParamIsEq};
 
                 struct NoEq;
 

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -2,8 +2,8 @@
 #![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::{
-    Add, AddAssign, Borrow, Constructor, Deref, DerefMut, Display, Error, From,
-    FromStr, Index, IndexMut, IntoIterator, Mul, MulAssign, Not, Sum, TryInto,
+    Add, AddAssign, Borrow, BorrowMut, Constructor, Deref, DerefMut, Display, Error,
+    From, FromStr, Index, IndexMut, IntoIterator, Mul, MulAssign, Not, Sum, TryInto,
 };
 
 #[derive(
@@ -22,6 +22,7 @@ use derive_more::{
     DerefMut,
     IntoIterator,
     Borrow,
+    BorrowMut,
     Constructor
 )]
 #[deref(forward)]
@@ -56,6 +57,7 @@ struct WrappedDouble2<T: Clone, U: Clone>(T, U);
     DerefMut,
     IntoIterator,
     Borrow,
+    BorrowMut,
     Constructor
 )]
 struct WrappedWithConst<T, const C: u32>(T);
@@ -75,6 +77,7 @@ struct WrappedWithConst<T, const C: u32>(T);
     DerefMut,
     IntoIterator,
     Borrow,
+    BorrowMut,
     Constructor,
     Sum
 )]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -2,8 +2,8 @@
 #![allow(dead_code)] // some code is tested for type checking only
 
 use derive_more::{
-    Add, AddAssign, Constructor, Deref, DerefMut, Display, Error, From, FromStr, Index,
-    IndexMut, IntoIterator, Mul, MulAssign, Not, Sum, TryInto,
+    Add, AddAssign, Borrow, Constructor, Deref, DerefMut, Display, Error, From,
+    FromStr, Index, IndexMut, IntoIterator, Mul, MulAssign, Not, Sum, TryInto,
 };
 
 #[derive(
@@ -21,6 +21,7 @@ use derive_more::{
     Deref,
     DerefMut,
     IntoIterator,
+    Borrow,
     Constructor
 )]
 #[deref(forward)]
@@ -54,6 +55,7 @@ struct WrappedDouble2<T: Clone, U: Clone>(T, U);
     Deref,
     DerefMut,
     IntoIterator,
+    Borrow,
     Constructor
 )]
 struct WrappedWithConst<T, const C: u32>(T);
@@ -72,6 +74,7 @@ struct WrappedWithConst<T, const C: u32>(T);
     Deref,
     DerefMut,
     IntoIterator,
+    Borrow,
     Constructor,
     Sum
 )]


### PR DESCRIPTION
Hey, thanks for the crate, very helpful!

I needed `Borrow` and `BorrowMut` derives. [The old PR](https://github.com/JelteF/derive_more/pull/145) was abandoned, so I went ahead and implemented them starting from the fresh master.

Resolves [#260](https://github.com/JelteF/derive_more/issues/260)

---

- [x] Documentation is updated
- [x] Tests are added
- [x] CHANGELOG entry is added

---

I used `codex` with GPT-5.5 xhigh. Multiple rounds of code review + manual edits. However, I'm not familiar with derive macros, so may have missed something.

Let me know if any changes are needed 🙏