### PR TITLE
Fix Constructor derive emitting redundant_field_names lint

### DIFF
--- a/impl/src/constructor.rs
+++ b/impl/src/constructor.rs
@@ -52,9 +52,7 @@ fn tuple_body(return_type: &Ident, fields: &[&Field]) -> (TokenStream, Vec<Ident
 }
 
 fn struct_body(return_type: &Ident, fields: &[&Field]) -> (TokenStream, Vec<Ident>) {
-    let field_names: &Vec<Ident> =
-        &field_idents(fields).iter().map(|f| (**f).clone()).collect();
-    let vars = field_names;
-    let ret_vars = field_names.clone();
-    (quote! { #return_type{#(#field_names: #vars),*} }, ret_vars)
+    let field_names: Vec<Ident> =
+        field_idents(fields).iter().map(|f| (**f).clone()).collect();
+    (quote! { #return_type{#(#field_names),*} }, field_names)
 }


### PR DESCRIPTION
The `Constructor` derive for named-field structs was generating:

```rust
Self { field: field }
```

instead of the field init shorthand:

```rust
Self { field }
```

This triggers `clippy::redundant_field_names` on nightly Clippy when `-D warnings` is set, breaking crates that use `#[deny(clippy::all)]` or similar.

**Fix:** use `#(#field_names),*` in the struct literal rather than `#(#field_names: #vars),*`. Since the parameter names already match the field names, the shorthand is always valid here. This also removes a redundant variable alias and clone in `struct_body`.