### PR TITLE
feat: Move `rename_all` behind a new `display_rename_all` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## master
 
+### Breaking changes
+
+- `#[display(rename_all = "...")]` now requires the `display_rename_all` feature,
+  which is included in `full`. This keeps the `display` feature free of the
+  `convert_case` dependency.
+
 ### Added
 - Add `Hash` derive similar to `std`'s one, but considering generics correctly,
   and supporting custom hash functions per field or skipping fields.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ debug = ["derive_more-impl/debug"]
 deref = ["derive_more-impl/deref"]
 deref_mut = ["derive_more-impl/deref_mut"]
 display = ["derive_more-impl/display"]
+display_rename_all = ["display", "derive_more-impl/display_rename_all"]
 eq = ["derive_more-impl/eq"]
 error = ["derive_more-impl/error"]
 from = ["derive_more-impl/from"]
@@ -90,6 +91,7 @@ full = [
     "deref",
     "deref_mut",
     "display",
+    "display_rename_all",
     "eq",
     "error",
     "from",

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -56,7 +56,8 @@ constructor = []
 debug = ["syn/extra-traits", "dep:unicode-ident"]
 deref = []
 deref_mut = []
-display = ["syn/extra-traits", "dep:unicode-ident", "dep:convert_case"]
+display = ["syn/extra-traits", "dep:unicode-ident"]
+display_rename_all = ["display", "dep:convert_case"]
 eq = ["syn/extra-traits", "syn/visit"]
 error = ["syn/extra-traits"]
 from = ["syn/extra-traits"]
@@ -85,6 +86,7 @@ full = [
     "deref",
     "deref_mut",
     "display",
+    "display_rename_all",
     "eq",
     "error",
     "from",

--- a/impl/doc/display.md
+++ b/impl/doc/display.md
@@ -233,6 +233,9 @@ assert_eq!(Enum::C.to_string(), "c");
 When no format is specified, deriving `Display` uses the variant name verbatim as its format.
 To control this the `#[display(rename_all = "...")]` attribute can be placed on structs, enums and variants.
 
+This attribute requires the `display_rename_all` feature, which is part of `full`. It is separate
+from `display` because the case conversion pulls in the `convert_case` dependency.
+
 The available casings are:
 - `lowercase`
 - `UPPERCASE`

--- a/impl/src/fmt/display.rs
+++ b/impl/src/fmt/display.rs
@@ -103,6 +103,17 @@ struct ContainerAttributes {
     common: super::ContainerAttributes,
 }
 
+impl ContainerAttributes {
+    /// Applies the [`attr::RenameAll`] of these attributes to the provided `name`, if any.
+    fn rename(&self, name: String) -> String {
+        #[cfg(feature = "display_rename_all")]
+        if let Some(rename_all) = &self.rename_all {
+            return rename_all.convert_case(&name);
+        }
+        name
+    }
+}
+
 impl Parse for ContainerAttributes {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         mod ident {
@@ -130,6 +141,12 @@ impl Parse for ContainerAttributes {
                 ..Default::default()
             })
         } else if ahead.peek(ident::rename_all) {
+            if !cfg!(feature = "display_rename_all") {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "`rename_all` requires the `display_rename_all` feature of `derive_more`",
+                ));
+            }
             Ok(Self {
                 rename_all: Some(input.parse()?),
                 ..Self::default()
@@ -427,10 +444,7 @@ impl Expansion<'_> {
             None => {
                 if shared_attr_is_wrapping || !has_shared_attr {
                     body = if self.fields.is_empty() {
-                        let mut ident_str = self.ident.unraw().to_string();
-                        if let Some(rename_all) = &self.attrs.rename_all {
-                            ident_str = rename_all.convert_case(&ident_str);
-                        }
+                        let ident_str = self.attrs.rename(self.ident.unraw().to_string());
 
                         if shared_attr_is_wrapping {
                             quote! { #ident_str }

--- a/impl/src/utils.rs
+++ b/impl/src/utils.rs
@@ -2344,6 +2344,7 @@ pub(crate) mod attr {
 
         impl RenameAll {
             /// Converts the provided `name` into the case of this [`RenameAll`].
+            #[cfg(any(feature = "display_rename_all", feature = "from_str"))]
             pub(crate) fn convert_case(&self, name: &str) -> String {
                 use convert_case::Casing as _;
 


### PR DESCRIPTION
Related to https://github.com/JelteF/derive_more/pull/538

## Synopsis

`display` pulls `convert_case`, hence `unicode-segmentation`, which some consumers
cannot vendor. It is only needed for the optional `#[display(rename_all = "...")]`
attribute.

## Solution

Move `rename_all` behind a new `display_rename_all` feature, enabled by `full`.

## Checklist

- [x] Documentation is updated (if required)
- [ ] Tests are added/updated (if required)
- [x] [CHANGELOG entry](/CHANGELOG.md) is added (if required)